### PR TITLE
Fix `TypeError: AceStepConditionGenerationModel does not support len()`

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -722,7 +722,7 @@ class AceStepHandler:
         """
         Convert serialized audio code string into 25Hz latents using model quantizer/detokenizer.
         """
-        if not self.model or not hasattr(self.model, 'tokenizer') or not hasattr(self.model, 'detokenizer'):
+        if self.model is None or not hasattr(self.model, 'tokenizer') or not hasattr(self.model, 'detokenizer'):
             return None
         
         code_ids = self._parse_audio_code_string(code_str)


### PR DESCRIPTION
https://github.com/ace-step/ACE-Step-1.5/issues/52

Explicitly checking is None bypasses Python's attempt to call __len__ or __bool__ on the compiled model wrapper, preventing the TypeError