### PR TITLE
Fix AttributeError when llm_handler is None

### DIFF
--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -378,7 +378,7 @@ def generate_music(
         # 3. use_cot_language=True: detect vocal language via CoT
         # 4. use_cot_metas=True: fill missing metadata via CoT
         need_lm_for_cot = params.use_cot_caption or params.use_cot_language or params.use_cot_metas
-        use_lm = (params.thinking or need_lm_for_cot) and llm_handler.llm_initialized and params.task_type not in skip_lm_tasks
+        use_lm = (params.thinking or need_lm_for_cot) and llm_handler is not None and llm_handler.llm_initialized and params.task_type not in skip_lm_tasks
         lm_status = []
         
         if params.task_type in skip_lm_tasks:


### PR DESCRIPTION
Fixes a crash that occurs on systems with <12GB GPU memory where LLM initialization is skipped.

## Problem
The code attempted to access `llm_handler.llm_initialized` without checking if `llm_handler` was `None` first, causing:
```
AttributeError: 'NoneType' object has no attribute 'llm_initialized'
File "acestep/inference.py", line 371
```

## Solution
Added a null check `llm_handler is not None and` before accessing the attribute.

## Testing
- Tested on 4GB GPU (CUDA 12.8) with REST API integration
- LLM features correctly disabled when GPU memory is insufficient  
- No crashes during music generation
- Successfully generated audio without LLM support