### PR TITLE
Add tensorboard to training dependencies for LoRA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ modelscope
 # Training dependencies (required for LoRA training)
 peft>=0.7.0
 lightning>=2.0.0
+tensorboard>=2.0.0
 
 # nano-vllm dependencies
 triton-windows>=3.0.0,<3.4; sys_platform == 'win32'


### PR DESCRIPTION
**Why**

-   LoRA training via Lightning Fabric uses  `TensorBoardLogger`.
-   `tensorboard`  is missing from  `requirements.txt`, causing an immediate  `ModuleNotFoundError`  on Windows 11 (and likely other platforms).

**What changed**

-   Add  `tensorboard==2.0.0`  to training dependencies in  `requirements.txt`.

**How to test**

1.  Fresh install (Windows 11) with  `uv`
2.  Launch UI:  `uv run acestep`
3.  Initialize service → Train LoRA tab → load dataset → Start Training
4.  Training should start without  `ModuleNotFoundError`  for  `tensorboard`

**Environment**

-   OS: Windows 11
-   Python: 3.11
-   PyTorch: 2.7.1+cu128
-   CUDA: 12.8
-   Install method:  `uv`

**Notes**

-   Manual workaround:  `uv pip install tensorboard`


Fixes : https://github.com/ace-step/ACE-Step-1.5/issues/139