### PR TITLE
docs: add responsible disclosure security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take security issues seriously and appreciate responsible disclosure.
+
+If you believe you have found a security vulnerability, **please do not report it in a public GitHub issue**.
+
+Instead, use one of the following private channels:
+
+- Open a **GitHub Security Advisory** for this repository (preferred)
+- Or contact the maintainers directly if a private email channel is listed
+
+Please include:
+- A clear description of the issue
+- Steps to reproduce (if applicable)
+- Potential impact
+- Any relevant proof-of-concept or logs
+
+We will acknowledge receipt and work to assess the issue as quickly as possible.
+
+## Bug Bounties
+
+At this time, this project does **not** operate a formal bug bounty program.  
+However, valid and responsibly disclosed security issues may be acknowledged in release notes or documentation at the maintainers’ discretion.
+
+Thank you for helping keep the project and its users safe.


### PR DESCRIPTION
This PR adds a minimal SECURITY.md to provide a clear private disclosure path for security researchers.
Inspired by recent disclosure inquiries and aligns with GitHub’s recommended security practices.

for #168