### PR TITLE
fix: guard against missing reference audio in text2music

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -1628,7 +1628,11 @@ class AceStepHandler:
 
         # Normalize audio_code_hints to batch list
         audio_code_hints = self._normalize_audio_code_hints(audio_code_hints, batch_size)
-        
+
+        # Guard: refer_audios can be None when reference audio UI path didn't populate it (e.g. TEXT2MUSIC)
+        if refer_audios is None:
+            refer_audios = [[torch.zeros(2, 30 * self.sample_rate)] for _ in range(batch_size)]
+
         for ii, refer_audio_list in enumerate(refer_audios):
             if isinstance(refer_audio_list, list):
                 for idx, refer_audio in enumerate(refer_audio_list):


### PR DESCRIPTION
This PR fixes a crash when using reference audio with TEXT2MUSIC.

If reference audio is missing or not populated, the code previously
assumed an iterable and raised a `TypeError`. This change adds a
defensive guard so the path fails gracefully instead of crashing.

No changes to model behavior or dependencies.

for issue #160