### PR TITLE
fix: disable CUDA graph capture for 5Hz LM during LoRA training

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -274,7 +274,8 @@ def main():
                         backend=args.backend,
                         device=args.device,
                         offload_to_cpu=args.offload_to_cpu,
-                        dtype=dit_handler.dtype
+                        dtype=dit_handler.dtype,
+                        disable_cuda_graphs=True,
                     )
                     
                     if lm_success:

--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -1781,6 +1781,7 @@ def create_app() -> FastAPI:
                 device=lm_device,
                 offload_to_cpu=lm_offload,
                 dtype=handler.dtype,
+                disable_cuda_graphs=True,
             )
             if llm_ok:
                 app.state._llm_initialized = True

--- a/acestep/gradio_ui/events/generation_handlers.py
+++ b/acestep/gradio_ui/events/generation_handlers.py
@@ -462,7 +462,8 @@ def init_service_wrapper(dit_handler, llm_handler, checkpoint, config_path, devi
             backend=backend,
             device=device,
             offload_to_cpu=offload_to_cpu,
-            dtype=dit_handler.dtype
+            dtype=dit_handler.dtype,
+            disable_cuda_graphs=True,
         )
         
         if lm_success:


### PR DESCRIPTION
CUDA graph capture is incompatible with LoRA training due to dynamic graph mutations (dropout, adapter updates).
This change skips CUDA graph capture for the 5Hz LM when training is active, preventing cudaErrorStreamCaptureInvalidated and Offset increment outside graph capture failures.

#120