### PR TITLE
fix: add tolerance to 16GB VRAM detection

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -36,7 +36,7 @@ try:
     from .llm_inference import LLMHandler
     from .dataset_handler import DatasetHandler
     from .gradio_ui import create_gradio_interface
-    from .gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config
+    from .gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB
 except ImportError:
     # When executed as a script: `python acestep/acestep_v15_pipeline.py`
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -46,7 +46,7 @@ except ImportError:
     from acestep.llm_inference import LLMHandler
     from acestep.dataset_handler import DatasetHandler
     from acestep.gradio_ui import create_gradio_interface
-    from acestep.gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config
+    from acestep.gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB
 
 
 def create_demo(init_params=None, language='en'):
@@ -91,7 +91,7 @@ def main():
     set_global_gpu_config(gpu_config)  # Set global config for use across modules
     
     gpu_memory_gb = gpu_config.gpu_memory_gb
-    auto_offload = gpu_memory_gb > 0 and gpu_memory_gb < 16
+    auto_offload = gpu_memory_gb > 0 and gpu_memory_gb < VRAM_16GB_MIN_GB
     
     # Print GPU configuration info
     print(f"\n{'='*60}")

--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -66,6 +66,7 @@ from acestep.gpu_config import (
     get_recommended_lm_model,
     is_lm_model_supported,
     GPUConfig,
+    VRAM_16GB_MIN_GB,
 )
 
 
@@ -1562,7 +1563,7 @@ def create_app() -> FastAPI:
         app.state.gpu_config = gpu_config
 
         gpu_memory_gb = gpu_config.gpu_memory_gb
-        auto_offload = gpu_memory_gb > 0 and gpu_memory_gb < 16
+        auto_offload = gpu_memory_gb > 0 and gpu_memory_gb < VRAM_16GB_MIN_GB
 
         # Print GPU configuration info
         print(f"\n{'='*60}")

--- a/acestep/gpu_config.py
+++ b/acestep/gpu_config.py
@@ -19,6 +19,10 @@ from loguru import logger
 # Environment variable for debugging/testing different GPU memory configurations
 DEBUG_MAX_CUDA_VRAM_ENV = "MAX_CUDA_VRAM"
 
+# Tolerance for 16GB detection: reported VRAM like 15.99GB is effectively 16GB hardware
+VRAM_16GB_TOLERANCE_GB = 0.1
+VRAM_16GB_MIN_GB = 16.0 - VRAM_16GB_TOLERANCE_GB  # treat as 16GB class if >= this
+
 
 @dataclass
 class GPUConfig:
@@ -170,9 +174,11 @@ def get_gpu_tier(gpu_memory_gb: float) -> str:
         return "tier3"
     elif gpu_memory_gb <= 12:
         return "tier4"
-    elif gpu_memory_gb <= 16:
+    elif gpu_memory_gb < VRAM_16GB_MIN_GB:
         return "tier5"
     elif gpu_memory_gb <= 24:
+        if gpu_memory_gb < 16.0:
+            logger.info(f"Detected {gpu_memory_gb:.2f}GB VRAM — treating as 16GB class GPU")
         return "tier6"
     else:
         return "unlimited"


### PR DESCRIPTION
This PR adds a small tolerance when detecting 16GB GPUs to account for floating-point reporting differences (e.g. 15.99GB).

Fixes #138