### PR TITLE
feat: expose denoise control for audio-conditioned generation in Gradio

### DIFF
--- a/acestep/gradio_ui/events/__init__.py
+++ b/acestep/gradio_ui/events/__init__.py
@@ -113,13 +113,19 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
     
     generation_section["init_llm_checkbox"].change(
         fn=gen_h.update_audio_cover_strength_visibility,
-        inputs=[generation_section["task_type"], generation_section["init_llm_checkbox"]],
+        inputs=[generation_section["task_type"], generation_section["init_llm_checkbox"], generation_section["reference_audio"]],
         outputs=[generation_section["audio_cover_strength"]]
     )
     
     generation_section["task_type"].change(
         fn=gen_h.update_audio_cover_strength_visibility,
-        inputs=[generation_section["task_type"], generation_section["init_llm_checkbox"]],
+        inputs=[generation_section["task_type"], generation_section["init_llm_checkbox"], generation_section["reference_audio"]],
+        outputs=[generation_section["audio_cover_strength"]]
+    )
+    
+    generation_section["reference_audio"].change(
+        fn=gen_h.update_audio_cover_strength_visibility,
+        inputs=[generation_section["task_type"], generation_section["init_llm_checkbox"], generation_section["reference_audio"]],
         outputs=[generation_section["audio_cover_strength"]]
     )
     
@@ -147,7 +153,7 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
     )
     
     # ========== Instruction UI Updates ==========
-    for trigger in [generation_section["task_type"], generation_section["track_name"], generation_section["complete_track_classes"]]:
+    for trigger in [generation_section["task_type"], generation_section["track_name"], generation_section["complete_track_classes"], generation_section["reference_audio"]]:
         trigger.change(
             fn=lambda *args: gen_h.update_instruction_ui(dit_handler, *args),
             inputs=[
@@ -155,7 +161,8 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
                 generation_section["track_name"],
                 generation_section["complete_track_classes"],
                 generation_section["text2music_audio_code_string"],
-                generation_section["init_llm_checkbox"]
+                generation_section["init_llm_checkbox"],
+                generation_section["reference_audio"],
             ],
             outputs=[
                 generation_section["instruction_display_gen"],

--- a/acestep/gradio_ui/events/generation_handlers.py
+++ b/acestep/gradio_ui/events/generation_handlers.py
@@ -519,18 +519,35 @@ def update_negative_prompt_visibility(init_llm_checked):
     return gr.update(visible=init_llm_checked)
 
 
-def update_audio_cover_strength_visibility(task_type_value, init_llm_checked):
-    """Update audio_cover_strength visibility and label"""
-    # Show if task is cover OR if LM is initialized
-    is_visible = (task_type_value == "cover") or init_llm_checked
-    # Change label based on context
-    if init_llm_checked and task_type_value != "cover":
-        label = "LM codes strength"
-        info = "Control how many denoising steps use LM-generated codes"
+def _has_reference_audio(reference_audio) -> bool:
+    """True if reference_audio has a usable value (Gradio Audio returns path string or (path, sr))."""
+    if reference_audio is None:
+        return False
+    if isinstance(reference_audio, str):
+        return bool(reference_audio.strip())
+    if isinstance(reference_audio, (list, tuple)) and reference_audio:
+        return bool(reference_audio[0])
+    return False
+
+
+def update_audio_cover_strength_visibility(task_type_value, init_llm_checked, reference_audio=None):
+    """Update audio_cover_strength visibility and label. Show Similarity/Denoise when reference audio is present."""
+    has_reference = _has_reference_audio(reference_audio)
+    # Show if task is cover, LM is initialized, or reference audio is present (audio-conditioned generation)
+    is_visible = (task_type_value == "cover") or init_llm_checked or has_reference
+    # Label priority: cover -> LM codes -> Similarity/Denoise (reference audio)
+    if task_type_value == "cover":
+        label = t("generation.cover_strength_label")
+        info = t("generation.cover_strength_info")
+    elif init_llm_checked:
+        label = t("generation.codes_strength_label")
+        info = t("generation.codes_strength_info")
+    elif has_reference:
+        label = t("generation.similarity_denoise_label")
+        info = t("generation.similarity_denoise_info")
     else:
-        label = "Audio Cover Strength"
-        info = "Control how many denoising steps use cover mode"
-    
+        label = t("generation.cover_strength_label")
+        info = t("generation.cover_strength_info")
     return gr.update(visible=is_visible, label=label, info=info)
 
 
@@ -546,7 +563,8 @@ def update_instruction_ui(
     track_name_value: Optional[str], 
     complete_track_classes_value: list, 
     audio_codes_content: str = "",
-    init_llm_checked: bool = False
+    init_llm_checked: bool = False,
+    reference_audio=None,
 ) -> tuple:
     """Update instruction and UI visibility based on task type."""
     instruction = dit_handler.generate_instruction(
@@ -559,15 +577,22 @@ def update_instruction_ui(
     track_name_visible = task_type_value in ["lego", "extract"]
     # Show complete_track_classes for complete
     complete_visible = task_type_value == "complete"
-    # Show audio_cover_strength for cover OR when LM is initialized
-    audio_cover_strength_visible = (task_type_value == "cover") or init_llm_checked
-    # Determine label and info based on context
-    if init_llm_checked and task_type_value != "cover":
-        audio_cover_strength_label = "LM codes strength"
-        audio_cover_strength_info = "Control how many denoising steps use LM-generated codes"
+    # Show audio_cover_strength for cover, LM initialized, or reference audio present
+    has_reference = _has_reference_audio(reference_audio)
+    audio_cover_strength_visible = (task_type_value == "cover") or init_llm_checked or has_reference
+    # Label priority: cover -> LM codes -> Similarity/Denoise (reference audio)
+    if task_type_value == "cover":
+        audio_cover_strength_label = t("generation.cover_strength_label")
+        audio_cover_strength_info = t("generation.cover_strength_info")
+    elif init_llm_checked:
+        audio_cover_strength_label = t("generation.codes_strength_label")
+        audio_cover_strength_info = t("generation.codes_strength_info")
+    elif has_reference:
+        audio_cover_strength_label = t("generation.similarity_denoise_label")
+        audio_cover_strength_info = t("generation.similarity_denoise_info")
     else:
-        audio_cover_strength_label = "Audio Cover Strength"
-        audio_cover_strength_info = "Control how many denoising steps use cover mode"
+        audio_cover_strength_label = t("generation.cover_strength_label")
+        audio_cover_strength_info = t("generation.cover_strength_info")
     # Show repainting controls for repaint and lego
     repainting_visible = task_type_value in ["repaint", "lego"]
     # Show text2music_audio_codes if task is text2music OR if it has content

--- a/acestep/gradio_ui/i18n/en.json
+++ b/acestep/gradio_ui/i18n/en.json
@@ -164,6 +164,8 @@
     "lm_batch_chunk_info": "Max items per LM batch chunk (default: 8, limited by GPU memory)",
     "codes_strength_label": "LM Codes Strength",
     "codes_strength_info": "Control how many denoising steps use LM-generated codes",
+    "similarity_denoise_label": "Similarity / Denoise",
+    "similarity_denoise_info": "Controls how closely the output follows the reference audio. Higher values preserve more structure.",
     "cover_strength_label": "Audio Cover Strength",
     "cover_strength_info": "Control how many denoising steps use cover mode",
     "score_sensitivity_label": "Quality Score Sensitivity",

--- a/acestep/gradio_ui/i18n/ja.json
+++ b/acestep/gradio_ui/i18n/ja.json
@@ -164,6 +164,8 @@
     "lm_batch_chunk_info": "LMバッチチャンクあたりの最大アイテム数(デフォルト: 8、GPUメモリによる制限)",
     "codes_strength_label": "LM コード強度",
     "codes_strength_info": "LM生成コードを使用するデノイジングステップ数を制御",
+    "similarity_denoise_label": "類似度 / ノイズ除去",
+    "similarity_denoise_info": "出力が参照オーディオにどれだけ忠実かを制御します。高い値ほど構造を保持します。",
     "cover_strength_label": "オーディオカバー強度",
     "cover_strength_info": "カバーモードを使用するデノイジングステップ数を制御",
     "score_sensitivity_label": "品質スコア感度",

--- a/acestep/gradio_ui/i18n/zh.json
+++ b/acestep/gradio_ui/i18n/zh.json
@@ -164,6 +164,8 @@
     "lm_batch_chunk_info": "每个LM批量块的最大项目数(默认: 8, 受GPU内存限制)",
     "codes_strength_label": "LM 代码强度",
     "codes_strength_info": "控制使用LM生成代码的去噪步骤数量",
+    "similarity_denoise_label": "相似度 / 降噪",
+    "similarity_denoise_info": "控制输出与参考音频的贴合程度。数值越高保留越多结构。",
     "cover_strength_label": "音频覆盖强度",
     "cover_strength_info": "控制使用覆盖模式的去噪步骤数量",
     "score_sensitivity_label": "质量评分敏感度",


### PR DESCRIPTION
This PR exposes a denoise / similarity parameter in the Gradio UI when reference audio is used.

It restores the audio-to-audio resampling control present in earlier ACE-Step workflows,
without changing defaults or affecting text-only generation.

Fixes #133