### PR TITLE
docs: clarify ROCm / AMD usage and uv behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ Star ACE-Step on GitHub and be instantly notified of new releases
 
 > **Requirements:** Python 3.11, CUDA GPU recommended (works on CPU/MPS but slower)
 
+### AMD / ROCm GPUs
+
+ACE-Step can run on AMD GPUs via ROCm, but `uv run acestep` currently forces CUDA PyTorch wheels, even if ROCm PyTorch is already installed. This is expected behavior with uv’s dependency resolver.
+
+Until uv dependency resolution is made backend-aware, **AMD users should run ACE-Step directly from an activated virtual environment**, not via `uv run acestep`.
+
+**Recommended workflow (Linux):**
+
+```bash
+source .venv/bin/activate
+python -m acestep.acestep_v15_pipeline --server-name 127.0.0.1 --port 7680
+```
+
+Windows users can follow the same approach using the activated `.venv`. This avoids uv reinstalling CUDA PyTorch and allows ROCm PyTorch to be used correctly.
+
 ### 🪟 Windows Portable Package (Recommended for Windows)
 
 For Windows users, we provide a portable package with pre-installed dependencies:


### PR DESCRIPTION
## Summary

This PR clarifies how to run ACE-Step on AMD / ROCm GPUs and documents a current limitation with `uv run acestep`.

ACE-Step *does* work with ROCm PyTorch, but `uv run acestep` currently forces CUDA PyTorch wheels during dependency resolution, even when ROCm PyTorch is already installed. This can unintentionally break AMD setups.

Rather than changing runtime behavior, this PR documents the correct and working workflow for AMD users.

---

## What Changed

- Added documentation explaining that `uv run acestep` currently forces CUDA PyTorch
- Documented the recommended workaround for AMD / ROCm users:
  - Run ACE-Step from an activated virtual environment instead of `uv run`
- Clarified that this is a packaging / dependency resolution issue, not a lack of AMD support in the pipeline itself

---

## Why This Is Needed

Several users reported that:
- ROCm PyTorch gets replaced by CUDA when using `uv run acestep`
- AMD GPUs appear unsupported even though the pipeline works correctly when run directly

This PR reduces confusion and provides an immediate, reliable path for AMD users without introducing risky code changes.

---

## Example (Linux)

```bash
source .venv/bin/activate
python -m acestep.acestep_v15_pipeline --server-name 127.0.0.1 --port 7680