### PR TITLE
fix: Wrap audio paths in FileData for Gradio 6.x compatibility

### DIFF
--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -14,6 +14,7 @@ import time as time_module
 import sys
 from typing import Dict, Any, Optional, List
 import gradio as gr
+from gradio import FileData
 from loguru import logger
 from acestep.gradio_ui.i18n import t
 from acestep.gradio_ui.events.generation_handlers import parse_and_validate_timesteps
@@ -929,7 +930,9 @@ def generate_with_progress(
     for idx in range(8):
         path = audio_outputs[idx]
         if path:
-            audio_playback_updates.append(gr.update(value=path, label=f"Sample {idx+1} (Ready)", interactive=True))
+            # Wrap path in FileData for Gradio 6.x compatibility
+            file_data = FileData(path=path)
+            audio_playback_updates.append(gr.update(value=file_data, label=f"Sample {idx+1} (Ready)", interactive=True))
             logger.info(f"[generate_with_progress] Audio {idx+1} path: {path}")
         else:
             audio_playback_updates.append(gr.update(value=None, label="None", interactive=False))
@@ -2007,7 +2010,8 @@ def navigate_to_previous_batch(current_batch_index, batch_queue):
     for idx in range(8):
         if idx < len(real_audio_paths):
             audio_path = real_audio_paths[idx].replace("\\", "/")  # Normalize path
-            audio_updates.append(gr.update(value=audio_path))
+            # Wrap path in FileData for Gradio 6.x compatibility
+            audio_updates.append(gr.update(value=FileData(path=audio_path)))
         else:
             audio_updates.append(gr.update(value=None))
 
@@ -2130,7 +2134,8 @@ def navigate_to_next_batch(autogen_enabled, current_batch_index, total_batches, 
     for idx in range(8):
         if idx < len(real_audio_paths):
             audio_path = real_audio_paths[idx].replace("\\", "/")  # Normalize path
-            audio_updates.append(gr.update(value=audio_path))
+            # Wrap path in FileData for Gradio 6.x compatibility
+            audio_updates.append(gr.update(value=FileData(path=audio_path)))
         else:
             audio_updates.append(gr.update(value=None))
 


### PR DESCRIPTION
## Summary

When updating Audio components with `gr.update()`, Gradio 6.x with Pydantic 2.x requires file paths to be wrapped in `FileData` objects.

## Problem

Without this fix, the Results section fails to display generated audio files with error:
```
pydantic_core.ValidationError: The 'meta' field must be explicitly provided in the input data and be equal to {'_type': 'gradio.FileData'}
```

## Changes

- Import `FileData` from gradio
- Wrap audio paths in `FileData()` in `generate_with_progress()`
- Wrap audio paths in `FileData()` in `navigate_batch()`
- Wrap audio paths in `FileData()` in `restore_batch_from_queue()`

## Test Plan

- [x] Tested on RunPod with A100 GPU
- [x] Generated audio now displays correctly in Results section
- [x] Cover feature works and shows output

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)