### PR TITLE
fix: use per-socket timeout instead of global setdefaulttimeout

### DIFF
--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -94,12 +94,15 @@ DEFAULT_REPO_ID = "ACE-Step/Ace-Step1.5"
 def _can_access_google(timeout: float = 3.0) -> bool:
     """Check if Google is accessible (to determine HuggingFace vs ModelScope)."""
     import socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("www.google.com", 443))
+        sock.settimeout(timeout)
+        sock.connect(("www.google.com", 443))
         return True
     except (socket.timeout, socket.error, OSError):
         return False
+    finally:
+        sock.close()
 
 
 def _download_from_huggingface(repo_id: str, local_dir: str, model_name: str) -> str:

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -30,12 +30,15 @@ def _can_access_google(timeout: float = 3.0) -> bool:
         True if Google is accessible, False otherwise
     """
     import socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("www.google.com", 443))
+        sock.settimeout(timeout)
+        sock.connect(("www.google.com", 443))
         return True
     except (socket.timeout, socket.error, OSError):
         return False
+    finally:
+        sock.close()
 
 
 def _download_from_huggingface_internal(


### PR DESCRIPTION
socket.setdefaulttimeout() sets the timeout for all new sockets process-wide, causing spurious timeouts in unrelated networking code (http clients, model downloads, etc.) after _can_access_google runs. replace with sock.settimeout() to scope the timeout to the check socket only, and properly close the socket afterward.