### PR TITLE
Position Audio time labels lower to avoid scrollbar overlap

### DIFF
--- a/acestep/gradio_ui/interfaces/__init__.py
+++ b/acestep/gradio_ui/interfaces/__init__.py
@@ -58,7 +58,11 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             height: 100%;
             width: 100%;
         }
-        """
+        /* Position Audio time labels lower to avoid scrollbar overlap */
+        .component-wrapper > .timestamps {
+            transform: translateY(15px);
+        }
+        """,
     ) as demo:
         
         gr.HTML(f"""


### PR DESCRIPTION
Very small change makes the time labels visible again. Maybe it's not a common issue but in Brave with Adwaita-dark theme horizontal scrollbars are too wide and they cover the labels.
Before:
<img width="517" height="257" alt="2026-02-06_17-04-24" src="https://github.com/user-attachments/assets/57333feb-5f3d-4b31-a0db-3a962a73516c" />
After:
<img width="499" height="276" alt="2026-02-06_17-04-33" src="https://github.com/user-attachments/assets/a19b540e-6fd6-4f96-a67a-293201d70709" />
