### PR TITLE
gpu_config for MPS support

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -2569,7 +2569,7 @@ class AceStepHandler:
         """
         # Default values for 48kHz audio, adaptive to GPU memory
         if chunk_size is None:
-            gpu_memory = get_gpu_memory_gb()
+            gpu_memory, _ = get_gpu_memory_gb()
             if gpu_memory <= 8:
                 chunk_size = 48000 * 15  # 15 seconds for low VRAM (<4GB)
             else:

--- a/cli.py
+++ b/cli.py
@@ -66,7 +66,7 @@ from acestep.handler import AceStepHandler
 from acestep.llm_inference import LLMHandler
 from acestep.inference import GenerationParams, GenerationConfig, generate_music, create_sample, format_sample
 from acestep.constants import DEFAULT_DIT_INSTRUCTION, TASK_INSTRUCTIONS
-from acestep.gpu_config import get_gpu_config, set_global_gpu_config, GPUConfig, GPU_TIER_CONFIGS
+from acestep.gpu_config import get_gpu_config, set_global_gpu_config, GPUConfig, GPU_TIER_CONFIGS, _get_mps_wired_limit_mb
 import torch
 
 
@@ -466,21 +466,6 @@ def _resolve_device(device: str) -> str:
             return "mps"
         return "cpu"
     return device
-
-
-def _get_mps_wired_limit_mb() -> Optional[int]:
-    """Best-effort read of iogpu.wired_limit_mb on macOS (may be unavailable)."""
-    try:
-        import subprocess
-        out = subprocess.check_output(["sysctl", "iogpu.wired_limit_mb"], text=True).strip()
-        # Expected: "iogpu.wired_limit_mb: 12345"
-        parts = out.split(":")
-        if len(parts) == 2:
-            value = parts[1].strip()
-            return int(value)
-    except Exception:
-        pass
-    return None
 
 
 def _default_instruction_for_task(task_type: str, tracks: Optional[List[str]] = None) -> str:
@@ -991,51 +976,13 @@ def main():
     Main function to run ACE-Step music generation from the command line.
     """
     gpu_config = get_gpu_config()
-    # Override tier thresholds in CLI without modifying gpu_config.py.
-    # For MPS, use iogpu.wired_limit_mb as a proxy for memory when available.
-    mem_gib = None
-    if gpu_config.gpu_memory_gb > 0:
-        mem_gib = gpu_config.gpu_memory_gb
-    else:
-        mps_available = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
-        if mps_available:
-            wired_limit_mb = _get_mps_wired_limit_mb()
-            if wired_limit_mb is not None and wired_limit_mb > 0:
-                mem_gib = wired_limit_mb / 1024.0
-    if mem_gib is not None and mem_gib > 0:
-        if mem_gib <= 24:
-            effective_tier = "tier1"
-        elif mem_gib <= 32:
-            effective_tier = "tier2"
-        elif mem_gib <= 40:
-            effective_tier = "tier3"
-        elif mem_gib <= 48:
-            effective_tier = "tier4"
-        elif mem_gib <= 56:
-            effective_tier = "tier5"
-        elif mem_gib <= 64:
-            effective_tier = "tier6"
-        else:
-            effective_tier = "unlimited"
-        if effective_tier != gpu_config.tier:
-            tier_config = GPU_TIER_CONFIGS[effective_tier]
-            gpu_config = GPUConfig(
-                tier=effective_tier,
-                gpu_memory_gb=mem_gib,
-                max_duration_with_lm=tier_config["max_duration_with_lm"],
-                max_duration_without_lm=tier_config["max_duration_without_lm"],
-                max_batch_size_with_lm=tier_config["max_batch_size_with_lm"],
-                max_batch_size_without_lm=tier_config["max_batch_size_without_lm"],
-                init_lm_default=tier_config["init_lm_default"],
-                available_lm_models=tier_config["available_lm_models"],
-                lm_memory_gb=tier_config["lm_memory_gb"],
-            )
     set_global_gpu_config(gpu_config)
 
     auto_offload = gpu_config.gpu_memory_gb > 0 and gpu_config.gpu_memory_gb < 16
     print(f"\n{'='*60}")
     print("GPU Configuration Detected:")
     print(f"{'='*60}")
+    print(f"  Device Type: {gpu_config.device_type}")
     print(f"  GPU Memory: {gpu_config.gpu_memory_gb:.2f} GiB")
     print(f"  Configuration Tier: {gpu_config.tier}")
     print(f"  Max Duration (with LM): {gpu_config.max_duration_with_lm}s ({gpu_config.max_duration_with_lm // 60} min)")
@@ -1044,30 +991,22 @@ def main():
     print(f"  Max Batch Size (without LM): {gpu_config.max_batch_size_without_lm}")
     print(f"  Default LM Init: {gpu_config.init_lm_default}")
     print(f"  Available LM Models: {gpu_config.available_lm_models or 'None'}")
-    mps_available = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
-    if mps_available and gpu_config.gpu_memory_gb <= 0:
+    if gpu_config.device_type == "mps":
         wired_limit_mb = _get_mps_wired_limit_mb()
         if wired_limit_mb is not None:
-            print(f"  MPS Available: True (wired limit: {wired_limit_mb} MB)")
+            print(f"  MPS Wired Limit: {wired_limit_mb} MB")
+        if gpu_config.gpu_memory_gb <= 0:
+            print("  Note: MPS wired limit could not be read; tier may be inaccurate.")
         else:
-            print("  MPS Available: True (wired limit: unknown)")
-        print("  Note: MPS memory is not reported here; tier may be inaccurate.")
-    elif mps_available and gpu_config.gpu_memory_gb > 0:
-        wired_limit_mb = _get_mps_wired_limit_mb()
-        if wired_limit_mb is not None:
-            print(f"  MPS Available: True (wired limit: {wired_limit_mb} MB)")
-            print("  Note: Tiering uses MPS wired limit as a proxy for GPU memory.")
-        else:
-            print("  MPS Available: True (wired limit: unknown)")
-            print("  Note: Tiering uses MPS wired limit when available.")
+            print("  Note: MPS uses unified memory; tier thresholds are higher than CUDA.")
     print(f"{'='*60}\n")
 
-    if auto_offload:
+    if gpu_config.device_type == "mps":
+        print("MPS detected, running on Apple GPU")
+    elif auto_offload:
         print("Auto-enabling CPU offload (GPU < 16GB)")
     elif gpu_config.gpu_memory_gb > 0:
         print("CPU offload disabled by default (GPU >= 16GB)")
-    elif mps_available:
-        print("MPS detected, running on Apple GPU")
     else:
         print("No GPU detected, running on CPU")
 


### PR DESCRIPTION
Claude implemented Apple MPS GPU detection and tier configuration in acestep/gpu_config.py so all entry points (CLI, API server, Gradio UI) get MPS tiering automatically.

It fixes the problem where it reports 0GB memory and assigns tier 1 on MPS regardless memory capacity.

MPS uses unified memory, but flash attention is not available. Thus, it consumes much more memory than dedicated CUDA VRAM.

Right now the tier assignments are just guesstimates, so it would need adjustment.