### PR TITLE
fix: resolve intermittent CUDA assertion error in concurrent serving …

### DIFF
--- a/acestep/third_parts/nano-vllm/nanovllm/utils/context.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/utils/context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import threading
 import torch
 
 
@@ -13,15 +14,34 @@ class Context:
     context_lens: torch.Tensor | None = None
     block_tables: torch.Tensor | None = None
 
-_CONTEXT = Context()
+
+# Thread-local storage for context.
+# 
+# ROOT CAUSE FIX: The original implementation used a plain module-level global
+# `_CONTEXT` variable. In concurrent serving scenarios (API server with
+# ThreadPoolExecutor, multiple queue workers, or Gradio with concurrent requests),
+# multiple threads can call set_context() / get_context() / reset_context()
+# concurrently. This creates a race condition:
+#
+#   Thread A: set_context(...)        # sets slot_mapping, block_tables for request A
+#   Thread B: set_context(...)        # OVERWRITES with request B's data
+#   Thread A: run_model(...)          # reads Thread B's context → WRONG KV cache addresses
+#                                     # → CUDA illegal memory access / device-side assertion
+#
+# By using threading.local(), each thread gets its own independent Context,
+# eliminating the race condition entirely.
+_THREAD_LOCAL = threading.local()
+
 
 def get_context():
-    return _CONTEXT
+    ctx = getattr(_THREAD_LOCAL, 'context', None)
+    if ctx is None:
+        ctx = Context()
+        _THREAD_LOCAL.context = ctx
+    return ctx
 
 def set_context(is_prefill, cu_seqlens_q=None, cu_seqlens_k=None, max_seqlen_q=0, max_seqlen_k=0, slot_mapping=None, context_lens=None, block_tables=None):
-    global _CONTEXT
-    _CONTEXT = Context(is_prefill, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables)
+    _THREAD_LOCAL.context = Context(is_prefill, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, context_lens, block_tables)
 
 def reset_context():
-    global _CONTEXT
-    _CONTEXT = Context()
+    _THREAD_LOCAL.context = Context()


### PR DESCRIPTION
…scenarios

This commit fixes two root causes of the intermittent cudaErrorAssert that occurs only in concurrent serving scenarios:

1. Thread-local context storage (nanovllm/utils/context.py):
   - Changed _CONTEXT from module-level global variable to threading.local()
   - Prevents race conditions when multiple threads call set_context()/get_context()
   - Each thread now has its own independent Context instance
   - Eliminates corruption of slot_mapping, block_tables, and context_lens that led to illegal KV cache memory access

2. Thread-safe LLMEngine.generate() (nanovllm/engine/llm_engine.py):
   - Added threading.Lock() (_generate_lock) to serialize access to generate()
   - Protects scheduler state, block manager, CUDA graph buffers, and KV cache
   - Prevents concurrent corruption of shared mutable state in multi-threaded serving scenarios (API server with ThreadPoolExecutor, multiple queue workers)

Root cause analysis:
- The original global _CONTEXT variable was overwritten by concurrent threads, causing CUDA kernels to read wrong KV cache addresses
- LLMEngine internal state (scheduler queues, block tables) was not designed for concurrent access, leading to unpredictable behavior

Testing:
- Fix addresses the concurrency issue that could not be reproduced in local stress tests (which run sequentially)
- Both fixes are complementary: lock protects engine state, thread-local storage protects context propagation channel