### PR TITLE
Bring back generated audio codes

### DIFF
--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -686,6 +686,7 @@ def generate_with_progress(
     )
     time_module.sleep(0.1)
     
+    final_codes_display_updates = [gr.skip() for _ in range(8)]
     for i in range(8):
         if i < len(audios):
             key = audios[i]["key"]
@@ -817,6 +818,7 @@ def generate_with_progress(
             
             codes_display_updates = [gr.skip() for _ in range(8)]
             codes_display_updates[i] = gr.update(value=code_str, visible=True)  # Keep visible=True
+            final_codes_display_updates[i] = gr.update(value=code_str, visible=True)  # Keep visible=True
             
             details_accordion_updates = [gr.skip() for _ in range(8)]
             # Don't change accordion visibility - keep it always expandable
@@ -914,7 +916,6 @@ def generate_with_progress(
     )
     
     # Build final codes display, LRC display, accordion visibility updates
-    final_codes_display_updates = [gr.skip() for _ in range(8)]
     # final_lrc_display_updates = [gr.skip() for _ in range(8)]
     final_accordion_updates = [gr.skip() for _ in range(8)]
 


### PR DESCRIPTION
In f89d00b2b2ce1db9c4044dc73bca19871f41c2f1 progressive updates were disabled (good!) but generated audio codes disappeared as well. That's because the generator returns partial Gradio updates skipping some of the fields and the final update doesn't include the codes sending skips instead. The old logic would simply retain the codes from the previous updates but the new logic only applies the last one. I didn't check for the other fields but if they're also missing now this is where it should be fixed.