### PR TITLE
fix: detect and surface silent audio generation failures

### DIFF
--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -698,19 +698,22 @@ def generate_with_progress(
             audio_tensor = audios[i]["tensor"]
             sample_rate = audios[i]["sample_rate"]
             audio_params = audios[i]["params"]
-            # Use local output directory instead of system temp
+            is_silent = audios[i].get("silent", False)
             timestamp = int(time_module.time())
             temp_dir = os.path.join(DEFAULT_RESULTS_DIR, f"batch_{timestamp}")
             temp_dir = os.path.abspath(temp_dir).replace("\\", "/")
             os.makedirs(temp_dir, exist_ok=True)
             json_path = os.path.join(temp_dir, f"{key}.json").replace("\\", "/")
             audio_path = os.path.join(temp_dir, f"{key}.{audio_format}").replace("\\", "/")
-            save_audio(audio_data=audio_tensor, output_path=audio_path, sample_rate=sample_rate, format=audio_format, channels_first=True)
-            with open(json_path, 'w', encoding='utf-8') as f:
-                json.dump(audio_params, f, indent=2, ensure_ascii=False)
-            audio_outputs[i] = audio_path
-            all_audio_paths.append(audio_path)
-            all_audio_paths.append(json_path)
+            if not is_silent and audio_tensor is not None:
+                save_audio(audio_data=audio_tensor, output_path=audio_path, sample_rate=sample_rate, format=audio_format, channels_first=True)
+                with open(json_path, 'w', encoding='utf-8') as f:
+                    json.dump(audio_params, f, indent=2, ensure_ascii=False)
+                audio_outputs[i] = audio_path
+                all_audio_paths.append(audio_path)
+                all_audio_paths.append(json_path)
+            else:
+                audio_outputs[i] = None
             
             code_str = audio_params.get("audio_codes", "")
             final_codes_list[i] = code_str


### PR DESCRIPTION
## Summary

This PR adds defensive validation around audio generation to detect and surface
cases where the pipeline completes successfully but produces silent (or near-silent)
audio output.

Instead of exporting zeroed audio without warning, the system now explicitly
checks generated waveforms and provides actionable diagnostics when silence
is detected.

## Problem

Several users have reported cases where:
- audio files are generated with the correct duration
- no runtime errors are thrown
- output audio is silent or near-zero amplitude

This indicates that the DiT pipeline ran, but upstream conditioning (e.g. LLM
output or device fallback paths) failed silently, resulting in zeroed tensors.

Currently, these failures are not detected or surfaced.

## Changes

- Add post-generation audio validation (RMS / peak amplitude check)
- Detect silent or near-silent outputs before export
- Emit clear warnings explaining likely causes:
  - LLM backend failure
  - incompatible torch / triton / flash-attn combinations
  - CPU or fallback execution paths
- Improve user guidance by suggesting `--backend pt` as a quick diagnostic step
- Prevent exporting misleading silent audio without explanation

No changes are made to model weights or generation logic.

## Why this approach

This is a correctness and UX fix:
- fails loudly instead of silently producing invalid output
- reduces confusion during setup and debugging
- makes backend / environment issues diagnosable without deep logs

## Testing

- Verified silent output is detected when conditioning tensors are zeroed
- Confirmed normal audio generation paths are unaffected
- Manually tested vLLM and PyTorch backends

## Related issues

- Silent Audio Tracks? #286