### PR TITLE
Tensor preprocessing & Lora fix

### DIFF
--- a/acestep/gradio_ui/events/__init__.py
+++ b/acestep/gradio_ui/events/__init__.py
@@ -4,6 +4,7 @@ Main entry point for setting up all event handlers
 """
 import gradio as gr
 from typing import Optional
+from loguru import logger
 
 # Import handler modules
 from . import generation_handlers as gen_h
@@ -1181,9 +1182,11 @@ def setup_training_event_handlers(demo, dit_handler, llm_handler, training_secti
     
     # Start training from preprocessed tensors
     def training_wrapper(tensor_dir, r, a, d, lr, ep, bs, ga, se, sh, sd, od, ts):
+        if not isinstance(ts, dict):
+            ts = {"is_training": False, "should_stop": False}
         try:
             for progress, log, plot, state in train_h.start_training(
-                tensor_dir, dit_handler, llm_handler, r, a, d, lr, ep, bs, ga, se, sh, sd, od, ts
+                tensor_dir, dit_handler, r, a, d, lr, ep, bs, ga, se, sh, sd, od, ts
             ):
                 yield progress, log, plot, state
         except Exception as e:

--- a/acestep/gradio_ui/events/training_handlers.py
+++ b/acestep/gradio_ui/events/training_handlers.py
@@ -12,6 +12,7 @@ import gradio as gr
 
 from acestep.training.dataset_builder import DatasetBuilder, AudioSample
 from acestep.debug_utils import debug_log_for, debug_start_for, debug_end_for
+from acestep.gpu_config import get_global_gpu_config
 
 
 def create_dataset_builder() -> DatasetBuilder:
@@ -549,6 +550,37 @@ def start_training(
         yield "� Model not initialized. Please initialize the service first.", "", None, training_state
         return
     
+    # Training preset: LoRA training must run on non-quantized DiT.
+    if getattr(dit_handler, "quantization", None) is not None:
+        gpu_config = get_global_gpu_config()
+        if gpu_config.gpu_memory_gb <= 0:
+            yield (
+                "WARNING: CPU-only training detected. Using best-effort training path "
+                "(non-quantized DiT). Performance will be sub-optimal.",
+                "",
+                None,
+                training_state,
+            )
+        elif gpu_config.tier in {"tier1", "tier2", "tier3", "tier4"}:
+            yield (
+                f"WARNING: Low VRAM tier detected ({gpu_config.gpu_memory_gb:.1f} GB, {gpu_config.tier}). "
+                "Using best-effort training path (non-quantized DiT). Performance may be sub-optimal.",
+                "",
+                None,
+                training_state,
+            )
+
+        yield "Switching model to training preset (disable quantization)...", "", None, training_state
+        if hasattr(dit_handler, "switch_to_training_preset"):
+            switch_status, switched = dit_handler.switch_to_training_preset()
+            if not switched:
+                yield f"ï¿½ {switch_status}", "", None, training_state
+                return
+            yield f"ï¿½ {switch_status}", "", None, training_state
+        else:
+            yield "ï¿½ Training requires non-quantized DiT, and auto-switch is unavailable in this build.", "", None, training_state
+            return
+
     # Check for required training dependencies
     try:
         from lightning.fabric import Fabric
@@ -603,9 +635,23 @@ def start_training(
         # Collect loss history
         step_list = []
         loss_list = []
+        training_failed = False
+        failure_message = ""
         
         # Train with progress updates using preprocessed tensors
         for step, loss, status in trainer.train_from_preprocessed(tensor_dir, training_state):
+            status_text = str(status)
+            status_lower = status_text.lower()
+            if (
+                status_text.startswith("âŒ")
+                or status_text.startswith("❌")
+                or "training failed" in status_lower
+                or "error:" in status_lower
+                or "module not found" in status_lower
+            ):
+                training_failed = True
+                failure_message = status_text
+
             # Calculate elapsed time and ETA
             elapsed_seconds = time.time() - start_time
             time_info = f"⏱️ Elapsed: {_format_duration(elapsed_seconds)}"
@@ -648,6 +694,12 @@ def start_training(
         
         total_time = time.time() - start_time
         training_state["is_training"] = False
+        if training_failed:
+            final_msg = f"{failure_message}\nElapsed: {_format_duration(total_time)}"
+            logger.warning(final_msg)
+            log_lines.append(failure_message)
+            yield final_msg, "\n".join(log_lines[-15:]), loss_data, training_state
+            return
         completion_msg = f"� Training completed! Total time: {_format_duration(total_time)}"
         
         logger.info(completion_msg)

--- a/acestep/gradio_ui/interfaces/training.py
+++ b/acestep/gradio_ui/interfaces/training.py
@@ -7,6 +7,7 @@ Contains the dataset builder and LoRA training interface components.
 import os
 import gradio as gr
 from acestep.gradio_ui.i18n import t
+from acestep.constants import DEBUG_TRAINING
 
 
 def create_training_section(dit_handler, llm_handler, init_params=None) -> dict:
@@ -24,6 +25,11 @@ def create_training_section(dit_handler, llm_handler, init_params=None) -> dict:
     # Check if running in service mode (hide training tab)
     service_mode = init_params is not None and init_params.get('service_mode', False)
     
+    debug_training_enabled = str(DEBUG_TRAINING).strip().upper() != "OFF"
+    epoch_min = 1 if debug_training_enabled else 100
+    epoch_step = 1 if debug_training_enabled else 100
+    epoch_default = 1 if debug_training_enabled else 1000
+
     with gr.Tab(t("training.tab_title"), visible=not service_mode):
         gr.HTML("""
         <div style="text-align: center; padding: 10px; margin-bottom: 15px;">
@@ -421,10 +427,10 @@ def create_training_section(dit_handler, llm_handler, init_params=None) -> dict:
                     )
                     
                     train_epochs = gr.Slider(
-                        minimum=100,
+                        minimum=epoch_min,
                         maximum=4000,
-                        step=100,
-                        value=1000,
+                        step=epoch_step,
+                        value=epoch_default,
                         label=t("training.max_epochs"),
                     )
                     

--- a/acestep/training/dataset_builder_modules/preprocess.py
+++ b/acestep/training/dataset_builder_modules/preprocess.py
@@ -127,15 +127,33 @@ class PreprocessMixin:
                 )
 
                 t0 = debug_start_verbose_for("dataset", f"run_encoder[{i}]")
-                encoder_hidden_states, encoder_attention_mask = run_encoder(
-                    model,
-                    text_hidden_states=text_hidden_states,
-                    text_attention_mask=text_attention_mask,
-                    lyric_hidden_states=lyric_hidden_states,
-                    lyric_attention_mask=lyric_attention_mask,
-                    device=device,
-                    dtype=dtype,
-                )
+                # Ensure DiT encoder runs on the active residency device (GPU when loaded via
+                # offload context). This prevents flash-attn CPU backend crashes.
+                with dit_handler._load_model_context("model"):
+                    model_device = next(model.parameters()).device
+                    model_dtype = next(model.parameters()).dtype
+                    if text_hidden_states.device != model_device:
+                        text_hidden_states = text_hidden_states.to(model_device)
+                    if text_attention_mask.device != model_device:
+                        text_attention_mask = text_attention_mask.to(model_device)
+                    if lyric_hidden_states.device != model_device:
+                        lyric_hidden_states = lyric_hidden_states.to(model_device)
+                    if lyric_attention_mask.device != model_device:
+                        lyric_attention_mask = lyric_attention_mask.to(model_device)
+                    if text_hidden_states.dtype != model_dtype:
+                        text_hidden_states = text_hidden_states.to(model_dtype)
+                    if lyric_hidden_states.dtype != model_dtype:
+                        lyric_hidden_states = lyric_hidden_states.to(model_dtype)
+
+                    encoder_hidden_states, encoder_attention_mask = run_encoder(
+                        model,
+                        text_hidden_states=text_hidden_states,
+                        text_attention_mask=text_attention_mask,
+                        lyric_hidden_states=lyric_hidden_states,
+                        lyric_attention_mask=lyric_attention_mask,
+                        device=model_device,
+                        dtype=model_dtype,
+                    )
                 debug_end_verbose_for("dataset", f"run_encoder[{i}]", t0)
                 debug_log_verbose_for(
                     "dataset",

--- a/acestep/training/dataset_builder_modules/preprocess_lyrics.py
+++ b/acestep/training/dataset_builder_modules/preprocess_lyrics.py
@@ -13,6 +13,13 @@ def encode_lyrics(text_encoder, text_tokenizer, lyrics: str, device, dtype):
     lyric_input_ids = lyric_inputs.input_ids.to(device)
     lyric_attention_mask = lyric_inputs.attention_mask.to(device).to(dtype)
 
+    # Align tensor residency to the actual text encoder device to avoid
+    # CPU/CUDA mismatch in embedding/index_select calls.
+    text_dev = next(text_encoder.parameters()).device
+    if lyric_input_ids.device != text_dev:
+        lyric_input_ids = lyric_input_ids.to(text_dev)
+        lyric_attention_mask = lyric_attention_mask.to(text_dev)
+
     with torch.no_grad():
         lyric_hidden_states = text_encoder.embed_tokens(lyric_input_ids).to(dtype)
 


### PR DESCRIPTION
## PR: Improve Training Reliability on Low-VRAM Systems

Resolves multiple OOM, device residency, feature extraction issues.
#292 #308 #167 
---

This PR improves **training reliability on low-VRAM systems** by:

- Automatically switching **quantized inference presets** to a **training-safe, non-quantized configuration**

- Hardening **CPU/GPU tensor residency and dtype handling** to prevent device mismatch crashes during preprocessing and LoRA training

-Feature added, when training debug flag is set DEBUG_TRAINING = "VERBOSE", Epoch may be set below 100 for quick test cycles.

---

## What Was Fixed (Bugs Found + Resolved)

### **LoRA training could run against quantized DiT and fail**
- **Bug:** LoRA injection (PEFT) is incompatible with quantized decoder modules in this runtime.
- **Fix:** Added quantization guardrails and a best-effort auto-switch to a **training preset with quantization disabled**, with clear user-facing status and error messages.

---

### **Training flow could proceed with invalid training state input**
- **Bug:** Training state could be non-dict and break downstream assumptions.
- **Fix:** Added a **state normalization fallback** in the training event wrapper.

---

### **TensorBoard logger initialization could hard-fail training startup**
- **Bug:** Missing TensorBoard modules could cause logger setup to abort training.
- **Fix:** Logger creation is now **optional**; training proceeds without TensorBoard if unavailable.

---

### **Preprocessing encoder path could crash from CPU/CUDA mismatch**
- **Bug:** Encoder inputs could reside on a different device or dtype than the active DiT model, causing backend or flash-attention failures.
- **Fix:** Run the encoder under the **model load context** and explicitly align all relevant tensors to the model’s device and dtype before execution.

---

### **Lyrics encoding could fail due to device mismatch**
- **Bug:** Token tensors could be created on a device different from the text encoder parameters, causing `embedding` / `index_select` failures.
- **Fix:** Explicitly align lyric input tensors to the **actual text encoder device**.

---

### **Training UI could report success after internal failure**
- **Bug:** Certain failure states were treated as normal progress or completion.
- **Fix:** Added **failure detection** in the progress loop and an explicit **failed finalization path**.

---

### **VAE dtype/device handling unstable for low-VRAM offload paths**
- **Bug:** CPU-offloaded VAE dtype handling was not tier-aware and could be slow or fragile.
- **Fix:** Added **tier-aware CPU dtype selection** (e.g. `float32` on lower-VRAM tiers) and explicit VAE offload dtype handling.

---

### **No reusable initialization context for preset switching**
- **Bug:** Training-safe reinitialization could not reliably occur without access to prior init parameters.
- **Fix:** Persist the **last successful initialization parameters** and reuse them in `switch_to_training_preset()`.

---

## Key Files Updated

- `trainer.py`
- `preprocess.py`
- `preprocess_lyrics.py`
- `training_handlers.py`
- `training.py`
- `handler.py`
- `__init__.py`

---

## User Impact

- **More robust training startup** on constrained GPUs
- **Fewer device/dtype mismatch crashes** during preprocessing and training
- **Clearer and earlier error reporting** for unsupported training configurations
- **Graceful behavior** when optional logging dependencies are missing

---

Copilot review: response and rebuttals

_Pre-check note_: pre-existing mojibake / encoding artifacts are **out of scope** for this commit review and should be ignored. That said, **symbol-based dynamic string matching is fragile** and should be minimized where possible.

---

## **High Severity**

_Copilot comment_: **trainer.py (lines 230–237)** — LoRA fail-fast with quantization enabled should auto-recover.  
_Response_: **Rejected (not a bug for this commit)**. The UI path already attempts automatic recovery via `switch_to_training_preset()`. Trainer-level fail-fast behavior is **intentional defensive behavior** for non-UI callers.

---

_Copilot comment_: **preprocess.py (lines 127–160)** — `next(model.parameters())` may fail if the model has no parameters.  
_Response_: **Accepted (hardening follow-up)**. Not an observed regression, but we should add a **guarded fallback** for `StopIteration` / uninitialized-model edge cases.

---

_Copilot comment_: **handler.py (lines 534–566)** — `last_init_params` reliance could cause silent failure.  
_Response_: **Rejected**. Failure is **explicit** (`False` return + status message), and `last_init_params` is persisted only after **successful initialization by design**.

---

## **Medium Severity**

_Copilot comment_: **training_handlers.py (lines 549–694)** — Low-VRAM warnings are not actionable enough.  
_Response_: **Accepted (UX improvement, non-blocking)**. We should append **concrete mitigation tips** (e.g. smaller batch size, gradient accumulation, disabling optional components).

---

_Copilot comment_: **preprocess_lyrics.py (lines 13–20)** — Assumes single-device text encoder.  
_Response_: **Pre-existing architectural limitation** (single-device / offload lifecycle). Not a regression introduced by this patch.

---

_Copilot comment_: **handler.py (lines 738–780)** — Missing `model_name` validation may cause silent failures.  
_Response_: **Pre-existing behavior, low risk in this context**. Call sites use fixed internal names; this commit only adjusted **VAE dtype handling on offload**.

---

## **Low Severity**

_Copilot comment_: **training.py (lines 24–427)** — Debug epoch defaults may be inconsistent if toggled mid-session.  
_Response_: **Rejected (not a regression)**. This is **config-at-load behavior**, not a new runtime toggle path introduced by this commit.

---

_Copilot comment_: **trainer.py (lines 285–296)** — TensorBoard warning should suggest install command.  
_Response_: **Accepted (minor polish)**. Add `pip install tensorboard` guidance to the warning text.

---

## **Regression Checks Summary**

_Copilot comment_: Reliance on `last_init_params`, user-visible warnings, and multi-device assumptions need follow-up.  
_Response_: **Partially accepted**.  
- Actionable warning text and preprocess parameter-guard hardening are valid follow-ups.  
- `last_init_params` silent-failure concern is **not valid**.  
- Multi-device concerns are **pre-existing and out of scope** for this patch.

---
