### PR TITLE
fix: detect and error on NaN latents to prevent silent audio output

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -2960,8 +2960,22 @@ class AceStepHandler:
             pred_latents = outputs["target_latents"]  # [batch, latent_length, latent_dim]
             time_costs = outputs["time_costs"]
             time_costs["offload_time_cost"] = self.current_offload_cost
-            logger.debug(f"[generate_music] pred_latents: {pred_latents.shape}, dtype={pred_latents.dtype} {pred_latents.min()=}, {pred_latents.max()=}, {pred_latents.mean()=} {pred_latents.std()=}")
+            logger.debug(f"[generate_music] pred_latents: {pred_latents.shape}, dtype={pred_latents.dtype} {pred_latents.min()=}, {pred_latents.max()=}, {pred_latents.mean()=}, {pred_latents.std()=}")
             logger.debug(f"[generate_music] time_costs: {time_costs}")
+
+            if torch.isnan(pred_latents).any() or torch.isinf(pred_latents).any():
+                raise RuntimeError(
+                    "Generation produced NaN or Inf latents. "
+                    "This usually indicates a checkpoint/config mismatch "
+                    "or unsupported quantization/backend combination. "
+                    "Try running with --backend pt or verify your model checkpoints match this release."
+                )
+            if pred_latents.numel() > 0 and pred_latents.abs().sum() == 0:
+                raise RuntimeError(
+                    "Generation produced zero latents. "
+                    "This usually indicates a checkpoint/config mismatch or unsupported setup."
+                )
+
             if progress:
                 progress(0.8, desc="Decoding audio...")
             logger.info("[generate_music] Decoding latents with VAE...")


### PR DESCRIPTION
Silent audio with correct duration can occur when diffusion produces NaN latents (e.g. due to checkpoint/config mismatches or unsupported quantization setups).

Previously, these failures propagated silently through VAE decode, resulting in flat audio output with no error.

This PR adds a validation check after diffusion to detect NaN (or zero) latents and raise a clear runtime error with guidance, preventing confusing silent outputs and improving debuggability. 

#286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added runtime validation checks for generated outputs to detect invalid values (NaN, Inf, zero sums) with improved error messages providing guidance on potential configuration or setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->