### PR TITLE
fix: prevent arbitrary code execution via unsafe torch.load()

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -469,7 +469,7 @@ class AceStepHandler:
                     
                 silence_latent_path = os.path.join(acestep_v15_checkpoint_path, "silence_latent.pt")
                 if os.path.exists(silence_latent_path):
-                    self.silence_latent = torch.load(silence_latent_path).transpose(1, 2)
+                    self.silence_latent = torch.load(silence_latent_path, weights_only=True).transpose(1, 2)
                     # Always keep silence_latent on GPU - it's used in many places outside model context
                     # and is small enough that it won't significantly impact VRAM
                     self.silence_latent = self.silence_latent.to(device).to(self.dtype)

--- a/acestep/training/data_module.py
+++ b/acestep/training/data_module.py
@@ -82,7 +82,7 @@ class PreprocessedTensorDataset(Dataset):
             Dictionary containing all pre-computed tensors for training
         """
         tensor_path = self.valid_paths[idx]
-        data = torch.load(tensor_path, map_location='cpu')
+        data = torch.load(tensor_path, map_location='cpu', weights_only=True)
         
         return {
             "target_latents": data["target_latents"],  # [T, 64]

--- a/acestep/training/lora_utils.py
+++ b/acestep/training/lora_utils.py
@@ -225,7 +225,7 @@ def load_lora_weights(
         model, _ = inject_lora_into_dit(model, lora_config)
         
         # Load weights
-        lora_state_dict = torch.load(lora_path, map_location='cpu')
+        lora_state_dict = torch.load(lora_path, map_location='cpu', weights_only=True)
         
         # Load into model
         model_state = model.state_dict()
@@ -325,7 +325,7 @@ def load_training_checkpoint(
     state_path = os.path.join(checkpoint_dir, "training_state.pt")
     if os.path.exists(state_path):
         map_location = device if device else "cpu"
-        training_state = torch.load(state_path, map_location=map_location)
+        training_state = torch.load(state_path, map_location=map_location, weights_only=True)
 
         result["epoch"] = training_state.get("epoch", 0)
         result["global_step"] = training_state.get("global_step", 0)

--- a/acestep/training/trainer.py
+++ b/acestep/training/trainer.py
@@ -399,7 +399,7 @@ class LoRATrainer:
                         if adapter_weights_path.endswith(".safetensors"):
                             state_dict = load_file(adapter_weights_path)
                         else:
-                            state_dict = torch.load(adapter_weights_path, map_location=self.module.device)
+                            state_dict = torch.load(adapter_weights_path, map_location=self.module.device, weights_only=True)
 
                         # Get the decoder (might be wrapped by Fabric)
                         decoder = self.module.model.decoder


### PR DESCRIPTION
add weights_only=True to all torch.load() calls to prevent arbitrary code execution through malicious .pt files.

torch.load() uses pickle deserialization by default, which can execute arbitrary code when loading crafted checkpoint files. this is especially dangerous for lora weight loading, where users may load community-shared weights from untrusted sources.

affected files:
- acestep/handler.py (silence_latent loading)
- acestep/training/data_module.py (training data loading)
- acestep/training/trainer.py (adapter weights loading)
- acestep/training/lora_utils.py (lora weights and training state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized model file loading operations across handler, data module, LoRA utilities, and trainer components for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->