### PR TITLE
fix: implement platform-specific audio playback reset logic

### DIFF
--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -931,14 +931,23 @@ def generate_with_progress(
     # On other platforms, audio was already sent in loop yields, just reset playback position
     # Use gr.update() to force Gradio to update the audio component (Issue #113)
     audio_playback_updates = []
-    for idx in range(8):
-        path = audio_outputs[idx]
-        if path:
-            # Pass path directly; Gradio Audio component with type="filepath" expects a string path
-            audio_playback_updates.append(gr.update(value=path, label=f"Sample {idx+1} (Ready)", interactive=True))
-            logger.info(f"[generate_with_progress] Audio {idx+1} path: {path}")
-        else:
-            audio_playback_updates.append(gr.update(value=None, label="None", interactive=False))
+    if IS_WINDOWS:
+        for idx in range(8):
+            path = audio_outputs[idx]
+            if path:
+                # Pass path directly; Gradio Audio component with type="filepath" expects a string path
+                audio_playback_updates.append(gr.update(value=path, label=f"Sample {idx+1} (Ready)", playback_position=0, interactive=True))
+                logger.info(f"[generate_with_progress] Audio {idx+1} path: {path}")
+            else:
+                audio_playback_updates.append(gr.update(value=None, label="None", interactive=False))
+    else:
+        # Non-Windows: audio was already progressively yielded, just reset playback position
+        for idx in range(8):
+            path = audio_outputs[idx]
+            if path:
+                audio_playback_updates.append(gr.update(playback_position=0, label=f"Sample {idx+1} (Ready)", interactive=True))
+            else:
+                audio_playback_updates.append(gr.update(value=None, label="None", interactive=False))
 
     yield (
         # Audio outputs - use gr.update() to force component refresh


### PR DESCRIPTION
- On Windows: return audio paths with playback_position=0 reset (progressive yields disabled)
- On other platforms: only reset playback_position without re-setting value (audio already sent via progressive yields)
- Fixes issue where non-Windows platforms were unnecessarily re-setting audio paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback position handling to ensure consistent behavior across different operating systems. Audio samples now properly reset playback position when refreshing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->