### PR TITLE
Revert previous audio playback reset logic changes to restore origina…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     # Common dependencies
     "transformers>=4.51.0,<4.58.0",
     "diffusers",
-    "gradio>=6.5.1",
+    "gradio==6.2.0",
     "matplotlib>=3.7.5",
     "scipy>=1.10.1",
     "soundfile>=0.13.1",

--- a/requirements-rocm-linux.txt
+++ b/requirements-rocm-linux.txt
@@ -2,7 +2,7 @@
 # Core dependencies
 transformers>=4.51.0,<4.58.0
 diffusers
-gradio>=6.5.1
+gradio==6.2.0
 matplotlib>=3.7.5
 scipy>=1.10.1
 soundfile>=0.13.1

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -25,7 +25,7 @@
 # Core dependencies
 transformers>=4.51.0,<4.58.0
 diffusers
-gradio>=6.5.1
+gradio==6.2.0
 matplotlib>=3.7.5
 scipy>=1.10.1
 soundfile>=0.13.1

--- a/requirements-xpu.txt
+++ b/requirements-xpu.txt
@@ -7,7 +7,7 @@ torchvision; sys_platform == 'win32'
 # Core dependencies
 transformers>=4.51.0,<4.58.0
 diffusers
-gradio
+gradio==6.2.0
 matplotlib>=3.7.5
 scipy>=1.10.1
 soundfile>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ torchaudio==2.10.0+cu128; sys_platform != 'win32' and sys_platform != 'darwin'
 # Core dependencies
 transformers>=4.51.0,<4.58.0
 diffusers
-gradio>=6.5.1
+gradio==6.2.0
 matplotlib>=3.7.5
 scipy>=1.10.1
 soundfile>=0.13.1


### PR DESCRIPTION
…l functionality. This reverts the implementation of platform-specific audio playback reset logic that was introduced in the last commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio playback position resets during sample updates without reloading audio files, improving performance and responsiveness.
  * Batch operation intermediate results now stream progressively to the interface, providing real-time feedback during processing.

* **Chores**
  * Locked framework dependency to a specific version across all configuration files to ensure consistent behavior and environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->