### PR TITLE
fix: clamp batch_size to GPU limit when loading metadata

### DIFF
--- a/acestep/gradio_ui/events/generation_handlers.py
+++ b/acestep/gradio_ui/events/generation_handlers.py
@@ -144,6 +144,11 @@ def load_metadata(file_obj, llm_handler=None):
             audio_duration = -1
         
         batch_size = metadata.get('batch_size', 2)
+        # Clamp batch_size to GPU memory limit
+        gpu_config = get_global_gpu_config()
+        lm_initialized = llm_handler.llm_initialized if llm_handler else False
+        max_batch_size = gpu_config.max_batch_size_with_lm if lm_initialized else gpu_config.max_batch_size_without_lm
+        batch_size = min(int(batch_size), max_batch_size)
         inference_steps = metadata.get('inference_steps', 8)
         guidance_scale = metadata.get('guidance_scale', 7.0)
         seed = metadata.get('seed', '-1')


### PR DESCRIPTION
## Problem

On low-VRAM GPUs (e.g. GTX 1650 with 4GB), the tier1 GPU config sets `max_batch_size` to 1. When loading parameters from a JSON file via `load_metadata()`, the `batch_size` defaults to 2 if not specified in the file. This value exceeds the Gradio `Number` component's `maximum=1` constraint, causing:

```
gradio.exceptions.Error: 'Value 2 is greater than maximum value 1.'
```

## Fix

Clamp `batch_size` to the GPU's `max_batch_size` after reading it from metadata, consistent with how duration is already clamped via `clamp_duration_to_gpu_limit()`.

## Testing

- Verified that on tier1 config (`max_batch_size=1`), loading a JSON with `batch_size: 2` now correctly clamps to 1.
- No impact on GPUs with higher batch size limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU memory management by automatically adjusting batch size settings to respect available GPU memory constraints. The system now intelligently limits batch size based on the current model configuration to prevent out-of-memory errors during generation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->