### PR TITLE
[NO-MERGE] ROCm Suppor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ace-step"
 version = "1.5.0"
 description = "ACE-Step 1.5"
 readme = "README.md"
-requires-python = "==3.11.*"
+requires-python = "==3.12.*"
 license = {text = "MIT"}
 dependencies = [
     # PyTorch for Windows with CUDA 12.8
@@ -14,6 +14,13 @@ dependencies = [
     "torch==2.10.0+cu128; sys_platform == 'linux'",
     "torchvision==0.25.0+cu128; sys_platform == 'linux'",
     "torchaudio==2.10.0+cu128; sys_platform == 'linux'",
+    ## PyTorch for Linux with ROCm 7.2
+    ## [!] Note the versions of torch and torchaudio differ. These are
+    ## the recommended versions from AMD's website.
+    # "torch==2.9.1; sys_platform == 'linux'",
+    # "torchvision; sys_platform == 'linux'",
+    # "torchaudio==2.9.0; sys_platform == 'linux'",
+    # "triton",
     # PyTorch for macOS (CPU / MPS)
     "torch>=2.9.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "torchvision; sys_platform == 'darwin' and platform_machine == 'arm64'",
@@ -62,6 +69,7 @@ required-environments = [
 
 [tool.uv.sources]
 nano-vllm = { path = "acestep/third_parts/nano-vllm" }
+## CUDA 12.8 wheels
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform == 'win32' or sys_platform == 'linux'" },
 ]
@@ -71,6 +79,20 @@ torchvision = [
 torchaudio = [
     { index = "pytorch-cu128", marker = "sys_platform == 'win32' or sys_platform == 'linux'" },
 ]
+## ROCm 7.2 wheels, from AMD:
+## https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/native_linux/install-pytorch.html
+# torch = [
+#   { url = "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux'" },
+# ]
+# torchvision = [
+#   { url = "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchvision-0.24.0%2Brocm7.2.0.gitb919bd0c-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux'" },
+# ]
+# torchaudio = [
+#   { url = "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchaudio-2.9.0%2Brocm7.2.0.gite3c6ee2b-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux'" },
+# ]
+# triton = [
+#   { url = "https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux'" },
+# ]
 
 [project.scripts]
 acestep = "acestep.acestep_v15_pipeline:main"

--- a/run_cpu.sh
+++ b/run_cpu.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export ACESTEP_LM_OFFLOAD_TO_CPU=true
+export ACESTEP_DEVICE=cpu
+export ACESTEP_USE_FLASH_ATTENTION=false
+
+export ACESTEP_CONFIG_PATH=acestep-v15-turbo
+export ACESTEP_LM_MODEL_PATH=acestep-5Hz-lm-4B
+export ACESTEP_INIT_LLM=true
+export ACESTEP_API_HOST=0.0.0.0
+export ACESTEP_API_PORT=11436
+
+exec nohup uv run acestep-api > /tmp/ace-step.txt 2>&1 &

--- a/run_gpu.sh
+++ b/run_gpu.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Opt-in to flash-attention-2 for ROCm, this is needed
+# until it matures out of "experimental" status.
+export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+
+export ACESTEP_CONFIG_PATH=acestep-v15-turbo
+export ACESTEP_LM_MODEL_PATH=acestep-5Hz-lm-4B
+export ACESTEP_INIT_LLM=true
+export ACESTEP_API_HOST=0.0.0.0
+export ACESTEP_API_PORT=11436
+
+exec nohup uv run acestep-api > /tmp/ace-step.txt 2>&1 &


### PR DESCRIPTION
This PR isn't mergable since I've made a mess in the `pyproject.yaml`, however this is what's required for ROCm support. Hopefully this is useful to someone else, and perhaps in the future ROCm support will be a bit... cleaner...

I'm testing on an Ryzen AI Max+ 395. On this hardware it's an 8x performance improvement.

---
## Benchmark Input

 * acestep-v15-turbo
 * acestep-5Hz-lm-4B

```
curl -X POST http://10.9.8.27:11436/release_task \  -H 'Content-Type: application/json' \    
  -d '{
    "description": "instrumental smooth jazz music for studying",
    "thinking": true,
    "batch_size": 3
  }'
```

---

## CPU Inference:
Start the server via `./run_cpu.sh`
```
**🎯 Average Time per Track: 348.15s** (3 track(s))

**🤖 LM-Generated Metadata:**
- **BPM:** 150
- **Duration:** 120 seconds
- **Key Scale:** B♭ major
- **Time Signature:** 4

**🧠 LM Time:**
  - Phase 2 (Codes): 894.55s
  - Total: 894.55s

**🎵 DiT Time:**
  - Encoder: 0.73s
  - VAE Decode: 60.75s
  - Total: 149.89s

**🎵 Generation Complete**
  - **Seeds:** 677645259,3597110343,763334797
  - **Steps:** 8
  - **Audio Count:** 3 audio(s)

**⏱️ Total Time: 1044.44s**
```

---

## GPU Inference
Start the server via `./run_gpu.sh`
```
**🎯 Average Time per Track: 48.09s** (3 track(s))

**🤖 LM-Generated Metadata:**
- **BPM:** 103
- **Duration:** 109 seconds
- **Key Scale:** B♭ major
- **Time Signature:** 4

**🧠 LM Time:**
  - Phase 2 (Codes): 126.64s
  - Total: 126.64s

**🎵 DiT Time:**
  - Encoder: 0.10s
  - VAE Decode: 9.34s
  - Total: 17.63s

**🎵 Generation Complete**
  - **Seeds:** 4166868054,3669358587,39005461
  - **Steps:** 8
  - **Audio Count:** 3 audio(s)

**⏱️ Total Time: 144.26s**
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added launch scripts for CPU and GPU configurations to simplify API deployment.

* **Bug Fixes**
  * Improved GPU behavior on ROCm systems by forcing PyTorch to use its native convolution path.

* **Chores**
  * Updated Python requirement to 3.12.
  * Adjusted dependency configuration: ROCm options de-emphasized (commented), while existing CUDA wheel configuration remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->