### PR TITLE
Update dtype handling for MPS and enhance MLX model loading process

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -421,12 +421,12 @@ class AceStepHandler:
             self.offload_to_cpu = offload_to_cpu
             self.offload_dit_to_cpu = offload_dit_to_cpu
             self.compiled = compile_model
-            # Set dtype based on device: bf16 for CUDA/XPU, fp16 for MPS, fp32 for CPU
-            # MPS fp16 is generally faster and more stable than bf16 on Apple Silicon.
+            # Set dtype based on device: bf16 for CUDA/XPU, fp32 for MPS/CPU
+            # MPS does not support bfloat16 natively, and converting bfloat16-trained
+            # weights to float16 causes NaN/Inf due to the narrower exponent range.
+            # Use float32 on MPS for numerical stability.
             if device in ["cuda", "xpu"]:
                 self.dtype = torch.bfloat16
-            elif device == "mps":
-                self.dtype = torch.float16
             else:
                 self.dtype = torch.float32
             self.quantization = quantization


### PR DESCRIPTION
- Adjusted dtype assignment for MPS to use float32 for numerical stability, as MPS does not support bfloat16 natively.
- Improved MLX model loading by adding error handling for safetensors key remapping, ensuring compatibility with ACE-Step 5Hz LM checkpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced MLX model loading robustness with improved safetensors handling and fallback support.
  * Refined device-specific numerical precision settings to improve stability on MPS devices while maintaining performance on CUDA/XPU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->