### PR TITLE
fix: avoid calling Module.to() on AffineQuantizedTensor parameters

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -579,17 +579,39 @@ class AceStepHandler:
         except Exception:
             target_type = str(target_device)
         return tensor.device.type == target_type
-    
+
+    def _is_quantized_tensor(self, t):
+        """True if t is a torchao AffineQuantizedTensor (calling .to() on it can raise NotImplementedError)."""
+        if t is None:
+            return False
+        try:
+            from torchao.quantization.affine_quantized import AffineQuantizedTensor
+            return isinstance(t, AffineQuantizedTensor)
+        except ImportError:
+            return False
+
+    def _has_quantized_params(self, module):
+        """True if module (or any submodule) has at least one AffineQuantizedTensor parameter."""
+        try:
+            from torchao.quantization.affine_quantized import AffineQuantizedTensor
+        except ImportError:
+            return False
+        for _, param in module.named_parameters():
+            if param is not None and isinstance(param, AffineQuantizedTensor):
+                return True
+        return False
+
     def _ensure_silence_latent_on_device(self):
         """Ensure silence_latent is on the correct device (self.device)."""
         if hasattr(self, "silence_latent") and self.silence_latent is not None:
             if not self._is_on_target_device(self.silence_latent, self.device):
                 self.silence_latent = self.silence_latent.to(self.device).to(self.dtype)
     
-    def _move_module_recursive(self, module, target_device, dtype=None, visited=None):
+    def _move_module_recursive(self, module, target_device, dtype=None, visited=None, skip_quantized=False):
         """
         Recursively move a module and all its submodules to the target device.
-        This handles modules that may not be properly registered.
+        When skip_quantized=True, avoids calling .to() on the module or on AffineQuantizedTensor
+        parameters (torchao quantized tensors that can raise NotImplementedError on .to(device)).
         """
         if visited is None:
             visited = set()
@@ -599,70 +621,82 @@ class AceStepHandler:
             return
         visited.add(module_id)
         
-        # Move the module itself
-        module.to(target_device)
-        if dtype is not None:
-            module.to(dtype)
+        if not skip_quantized:
+            module.to(target_device)
+            if dtype is not None:
+                module.to(dtype)
         
-        # Move all direct parameters
         for param_name, param in module._parameters.items():
-            if param is not None and not self._is_on_target_device(param, target_device):
+            if param is None:
+                continue
+            if self._is_quantized_tensor(param):
+                continue
+            if not self._is_on_target_device(param, target_device):
                 module._parameters[param_name] = param.to(target_device)
                 if dtype is not None:
                     module._parameters[param_name] = module._parameters[param_name].to(dtype)
         
-        # Move all direct buffers
         for buf_name, buf in module._buffers.items():
-            if buf is not None and not self._is_on_target_device(buf, target_device):
+            if buf is None:
+                continue
+            if self._is_quantized_tensor(buf):
+                continue
+            if not self._is_on_target_device(buf, target_device):
                 module._buffers[buf_name] = buf.to(target_device)
         
-        # Recursively process all submodules (registered and unregistered)
         for name, child in module._modules.items():
             if child is not None:
-                self._move_module_recursive(child, target_device, dtype, visited)
+                self._move_module_recursive(child, target_device, dtype, visited, skip_quantized)
         
-        # Also check for any nn.Module attributes that might not be in _modules
         for attr_name in dir(module):
             if attr_name.startswith('_'):
                 continue
             try:
                 attr = getattr(module, attr_name, None)
                 if isinstance(attr, torch.nn.Module) and id(attr) not in visited:
-                    self._move_module_recursive(attr, target_device, dtype, visited)
+                    self._move_module_recursive(attr, target_device, dtype, visited, skip_quantized)
             except Exception:
                 pass
     
     def _recursive_to_device(self, model, device, dtype=None):
         """
         Recursively move all parameters and buffers of a model to the specified device.
-        This is more thorough than model.to() for some custom HuggingFace models.
+        When the model contains torchao AffineQuantizedTensor parameters, avoids calling
+        Module.to(device) (which can raise NotImplementedError via _has_compatible_shallow_copy_type).
         """
         target_device = torch.device(device) if isinstance(device, str) else device
-        
-        # Method 1: Standard .to() call
-        model.to(target_device)
-        if dtype is not None:
-            model.to(dtype)
-        
-        # Method 2: Use our thorough recursive moving for any missed modules
-        self._move_module_recursive(model, target_device, dtype)
-        
-        # Method 3: Force move via state_dict if there are still parameters on wrong device
+        skip_quantized = self._has_quantized_params(model)
+
+        if skip_quantized:
+            logger.warning(
+                "[_recursive_to_device] Model has quantized (AffineQuantizedTensor) parameters; "
+                "skipping Module.to(device) to avoid NotImplementedError. Moving non-quantized parameters only."
+            )
+
+        if not skip_quantized:
+            model.to(target_device)
+            if dtype is not None:
+                model.to(dtype)
+
+        self._move_module_recursive(model, target_device, dtype, skip_quantized=skip_quantized)
+
         wrong_device_params = []
         for name, param in model.named_parameters():
             if not self._is_on_target_device(param, device):
                 wrong_device_params.append(name)
-        
+
         if wrong_device_params and device != "cpu":
             logger.warning(f"[_recursive_to_device] {len(wrong_device_params)} parameters on wrong device, using state_dict method")
-            # Get current state dict and move all tensors
             state_dict = model.state_dict()
             moved_state_dict = {}
             for key, value in state_dict.items():
                 if isinstance(value, torch.Tensor):
-                    moved_state_dict[key] = value.to(target_device)
-                    if dtype is not None and moved_state_dict[key].is_floating_point():
-                        moved_state_dict[key] = moved_state_dict[key].to(dtype)
+                    if self._is_quantized_tensor(value):
+                        moved_state_dict[key] = value
+                    else:
+                        moved_state_dict[key] = value.to(target_device)
+                        if dtype is not None and moved_state_dict[key].is_floating_point():
+                            moved_state_dict[key] = moved_state_dict[key].to(dtype)
                 else:
                     moved_state_dict[key] = value
             model.load_state_dict(moved_state_dict)


### PR DESCRIPTION
Regression introduced after commit 17825ee: moving the quantized DiT model to CUDA triggers `NotImplementedError` because PyTorch's `Module.to()` uses `aten._has_compatible_shallow_copy_type`, which torchao's `AffineQuantizedTensor` does not implement.

This change detects when a model has AffineQuantizedTensor parameters and avoids calling `Module.to(device)` on the model and on those parameters. Non-quantized parameters and buffers are still moved to the target device. A clear warning is logged when this path is used.

No behavior change for non-quantized models.

#334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device movement handling to support quantized models, preventing errors when relocating models containing quantized tensors.
  * Implemented intelligent fallback mechanism for safe parameter transfer when standard device relocation encounters compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->