### PR TITLE
Cli mlx

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1012,6 +1012,13 @@ def main():
     parser.add_argument("-c", "--config", type=str, help="Path to a TOML configuration file to load.")
     parser.add_argument("--configure", action="store_true", help="Run wizard to save configuration without generating.")
     parser.add_argument(
+        "--backend",
+        type=str,
+        default=None,
+        choices=["vllm", "pt", "mlx"],
+        help="5Hz LM backend. Auto-detected if not specified: 'mlx' on Apple Silicon, 'vllm' on CUDA, 'pt' otherwise.",
+    )
+    parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
@@ -1112,6 +1119,10 @@ def main():
         for key, value in config_from_file.items():
             setattr(args, key, value)
         args.config = cli_args.config
+
+    # CLI --backend overrides config file and auto-detection
+    if cli_args.backend is not None:
+        args.backend = cli_args.backend
 
     if cli_args.configure:
         args, _ = run_wizard(


### PR DESCRIPTION
Add --backend CLI argument for explicit LM backend selection
Allows users to specify --backend {vllm,pt,mlx} for CLI,
overriding both TOML config and auto-detection. When not specified,
run auto-detection: mlx on Apple Silicon, vllm on CUDA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New `--backend` CLI flag enables explicit backend selection (vllm, pt, or mlx) to optimize performance for your system
  * Automatic detection of Apple Silicon hardware and MLX framework with intelligent default backend selection and startup notifications

* **Chores**
  * Streamlined prompt setup workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->