### PR TITLE
Revert "Pin torchao to 0.12.0 for torch 2.7.1+cu128 compatibility"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numba>=0.63.1",
     "vector-quantize-pytorch>=1.27.15",
     "torchcodec>=0.9.1",
-    "torchao==0.12.0",
+    "torchao",
     "toml",
     # MLX dependencies (Apple Silicon native acceleration - macOS only)
     "mlx>=0.25.2; sys_platform == 'darwin' and platform_machine == 'arm64'",

--- a/requirements-rocm-linux.txt
+++ b/requirements-rocm-linux.txt
@@ -14,7 +14,7 @@ uvicorn[standard]>=0.27.0
 numba>=0.63.1
 vector-quantize-pytorch>=1.27.15
 torchcodec>=0.9.1
-torchao==0.12.0
+torchao
 toml
 modelscope
 

--- a/requirements-xpu.txt
+++ b/requirements-xpu.txt
@@ -19,7 +19,7 @@ uvicorn[standard]>=0.27.0
 numba>=0.63.1
 vector-quantize-pytorch>=1.27.15
 torchcodec>=0.9.1; sys_platform != 'darwin' or platform_machine == 'arm64'
-torchao==0.12.0
+torchao
 modelscope
 
 # LoRA Training dependencies (optional)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ uvicorn[standard]>=0.27.0
 numba>=0.63.1
 vector-quantize-pytorch>=1.27.15
 torchcodec>=0.9.1; sys_platform != 'darwin' or platform_machine == 'arm64'
-torchao==0.12.0
+torchao
 toml
 modelscope
 


### PR DESCRIPTION
Reverts ace-step/ACE-Step-1.5#363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unpinned the torchao dependency across configuration files, transitioning from strict version 0.12.0 to flexible version resolution for improved compatibility and transitive dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->