### PR TITLE
fix: add KV cache headroom to gpu_memory_utilization calculation

### DIFF
--- a/acestep/gpu_config.py
+++ b/acestep/gpu_config.py
@@ -391,22 +391,29 @@ def get_lm_gpu_memory_ratio(model_path: str, total_gpu_memory_gb: float) -> Tupl
     """
     model_size = get_lm_model_size(model_path)
     
-    # Target memory allocation for each model size
-    target_memory = {
+    # Model weight memory (approximate) for each model size
+    model_weight_memory = {
         "0.6B": 3.0,
         "1.7B": 8.0,
         "4B": 12.0,
     }
     
-    target_gb = target_memory.get(model_size, 3.0)
+    target_gb = model_weight_memory.get(model_size, 3.0)
+    
+    # gpu_memory_utilization in nano-vllm caps the TOTAL GPU memory usage
+    # (model weights + KV cache + overhead). If we set it to just the model
+    # weight size, there is almost no room left for KV cache and inference
+    # fails with "Insufficient KV cache" errors.
+    # We therefore add generous headroom so the KV cache can hold at least
+    # max_model_len (4096) tokens comfortably.
+    total_target_gb = target_gb * 1.5  # 50% headroom for KV cache + overhead
     
     # For large GPUs (>=24GB), don't restrict memory too much
     if total_gpu_memory_gb >= 24:
-        # Use a reasonable ratio that allows the model to run efficiently
-        ratio = min(0.9, max(0.2, target_gb / total_gpu_memory_gb))
+        ratio = min(0.9, max(0.2, total_target_gb / total_gpu_memory_gb))
     else:
         # For smaller GPUs, strictly limit memory usage
-        ratio = min(0.9, max(0.1, target_gb / total_gpu_memory_gb))
+        ratio = min(0.9, max(0.1, total_target_gb / total_gpu_memory_gb))
     
     return ratio, target_gb
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dependencies = [
     "lightning>=2.0.0",
     "tensorboard>=2.0.0",
     # Local third-party packages
-    # nano-vllm is a local package - install separately: pip install -e acestep/third_parts/nano-vllm
-    # For uv users: automatically handled via [tool.uv.sources]
+    # nano-vllm source is configured in [tool.uv.sources]
+    "nano-vllm; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "modelscope",
     "tensorboard>=2.20.0",
 ]


### PR DESCRIPTION
The target_memory values only accounted for model weights, leaving almost no room for KV cache on large GPUs. For example, 1.7B model on 47.4GB GPU resulted in only 3 KV cache blocks (768 tokens), insufficient for prompts
>768 tokens. Adding 50% headroom ensures adequate KV cache allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized GPU memory allocation for language models with improved headroom calculation, enhancing inference stability and reducing out-of-memory errors.

* **Chores**
  * Updated platform-specific dependency configuration for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->