### PR TITLE
refactor: remove device type checks for MPS in AceStepHandler

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -2844,22 +2844,6 @@ class AceStepHandler:
             offload_wav_to_cpu = self._should_offload_wav_to_cpu()
         B, C, T = latents.shape
         
-        # Check device type (handle both string and torch.device)
-        device_type = self.device if isinstance(self.device, str) else self.device.type
-        if device_type == "mps":
-            # MPS conv1d has an output length limit; use smaller chunks to avoid it.
-            max_chunk_size = 32
-            if chunk_size > max_chunk_size:
-                orig_chunk_size = chunk_size
-                orig_overlap = overlap
-                chunk_size = max_chunk_size
-                overlap = min(overlap, max(1, chunk_size // 4))
-                logger.warning(
-                    f"[tiled_decode] MPS device detected; reducing chunk_size from {orig_chunk_size} "
-                    f"to {max_chunk_size} and overlap from {orig_overlap} to {overlap} "
-                    f"to avoid MPS conv output limit."
-                )
-        
         # If short enough, decode directly
         if T <= chunk_size:
             # Decode and immediately extract .sample to avoid keeping DecoderOutput object


### PR DESCRIPTION
- Eliminated the device type checks and related logic for handling MPS device constraints in the chunk size processing.
- Streamlined the decoding process by directly handling cases where the input tensor length is within the specified chunk size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Performance**
  * Removed artificial chunk size constraints on Apple Silicon devices, allowing the tiled decode function to use consistent chunking parameters across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->