### PR TITLE
refactor: update audio uploads accordion behavior in results section

### DIFF
--- a/acestep/gradio_ui/events/__init__.py
+++ b/acestep/gradio_ui/events/__init__.py
@@ -484,7 +484,8 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
                 generation_section["key_scale"],
                 generation_section["vocal_language"],
                 generation_section["time_signature"],
-                results_section["is_format_caption_state"]
+                results_section["is_format_caption_state"],
+                generation_section["audio_uploads_accordion"]
             ]
         )
     

--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -450,18 +450,19 @@ def send_audio_to_src_with_metadata(audio_file, lm_metadata):
     
     This function ONLY sets the src_audio field. All other metadata fields (caption, lyrics, etc.)
     are preserved by returning gr.skip() to avoid overwriting user's existing inputs.
+    Also opens the audio_uploads_accordion so the user can see the uploaded audio.
     
     Args:
         audio_file: Audio file path
         lm_metadata: Dictionary containing LM-generated metadata (unused, kept for API compatibility)
         
     Returns:
-        Tuple of (audio_file, bpm, caption, lyrics, duration, key_scale, language, time_signature, is_format_caption)
-        All values except audio_file are gr.skip() to preserve existing UI values
+        Tuple of (audio_file, bpm, caption, lyrics, duration, key_scale, language, time_signature, is_format_caption, audio_uploads_accordion)
+        All values except audio_file and audio_uploads_accordion are gr.skip() to preserve existing UI values
     """
     if audio_file is None:
         # Return all skip to not modify anything
-        return (gr.skip(),) * 9
+        return (gr.skip(),) * 10
     
     # Only set the audio file, skip all other fields to preserve existing values
     # This ensures user's caption, lyrics, bpm, etc. are NOT cleared
@@ -475,6 +476,7 @@ def send_audio_to_src_with_metadata(audio_file, lm_metadata):
         gr.skip(),       # language - preserve existing value
         gr.skip(),       # time_signature - preserve existing value
         gr.skip(),       # is_format_caption - preserve existing value
+        gr.Accordion(open=True),  # audio_uploads_accordion - expand to show uploaded audio
     )
 
 

--- a/acestep/gradio_ui/interfaces/result.py
+++ b/acestep/gradio_ui/interfaces/result.py
@@ -443,7 +443,7 @@ def create_results_section(dit_handler) -> dict:
             size="sm"
         )
         
-        with gr.Accordion(t("results.batch_results_title"), open=False):
+        with gr.Accordion(t("results.batch_results_title"), open=True):
             generated_audio_batch = gr.File(
                 label=t("results.all_files_label"),
                 file_count="multiple",


### PR DESCRIPTION
- Changed the default state of the results batch accordion to open for better visibility of uploaded audio files.
- Modified the return tuple in the audio metadata handling function to include the expanded audio uploads accordion state, ensuring users can see their uploaded audio.
- Updated event handler setup to accommodate the new accordion state in the results section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Audio uploads accordion now automatically refreshes when sending audio files to SRC, maintaining proper interface state
  * Batch results accordion is now expanded by default, immediately displaying analysis results without requiring manual expansion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->