### PR TITLE
(fix)Add CORS support for direct open browser-based frontends (studio.html)

### DIFF
--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -41,6 +41,7 @@ except ImportError:  # Optional dependency
     load_dotenv = None  # type: ignore
 
 from fastapi import FastAPI, HTTPException, Request, Depends, Header
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
@@ -2143,6 +2144,16 @@ def create_app() -> FastAPI:
             executor.shutdown(wait=False, cancel_futures=True)
 
     app = FastAPI(title="ACE-Step API", version="1.0", lifespan=lifespan)
+
+    # Enable CORS for browser-based frontends (e.g. studio.html opened via file://)
+    # Restricted to localhost origins and the "null" origin (file:// protocol)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["null", "http://localhost", "http://127.0.0.1"],
+        allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
+    )
 
     # Mount OpenRouter-compatible endpoints (/v1/chat/completions, /v1/models)
     from acestep.openrouter_adapter import create_openrouter_router

--- a/acestep/gradio_ui/api_routes.py
+++ b/acestep/gradio_ui/api_routes.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request, Depends, Header
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 
 # Global results directory inside project root
@@ -512,6 +513,38 @@ async def release_task(request: Request, authorization: Optional[str] = Header(N
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# Origins that are expected to call the API:
+#  - "null"                     → studio.html opened via file:// protocol
+#  - http://localhost:*         → local dev servers / Gradio UI
+#  - http://127.0.0.1:*        → same, numeric form
+_CORS_KWARGS = dict(
+    allow_origins=["null", "http://localhost", "http://127.0.0.1"],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+)
+
+
+def _add_cors_middleware(app):
+    """Add CORS middleware so browser-based frontends (e.g. studio.html via file://) can call the API."""
+    app.add_middleware(CORSMiddleware, **_CORS_KWARGS)
+
+
+def _add_cors_middleware_post_launch(app):
+    """Wrap an already-started app's middleware stack with CORS.
+
+    ``add_middleware`` raises after Starlette has started, so we patch the
+    compiled middleware stack directly instead.
+    """
+    from starlette.middleware.cors import CORSMiddleware as _CORSImpl
+
+    if app.middleware_stack is not None:
+        app.middleware_stack = _CORSImpl(app=app.middleware_stack, **_CORS_KWARGS)
+    else:
+        # App hasn't built its stack yet – safe to use the normal path
+        _add_cors_middleware(app)
+
+
 def setup_api_routes_to_app(app, dit_handler, llm_handler, api_key: Optional[str] = None):
     """
     Mount API routes to a FastAPI application (for use with gr.mount_gradio_app)
@@ -523,6 +556,7 @@ def setup_api_routes_to_app(app, dit_handler, llm_handler, api_key: Optional[str
         api_key: Optional API key for authentication
     """
     set_api_key(api_key)
+    _add_cors_middleware(app)
     app.state.dit_handler = dit_handler
     app.state.llm_handler = llm_handler
     app.include_router(router)
@@ -540,6 +574,7 @@ def setup_api_routes(demo, dit_handler, llm_handler, api_key: Optional[str] = No
     """
     set_api_key(api_key)
     app = demo.app
+    _add_cors_middleware_post_launch(app)
     app.state.dit_handler = dit_handler
     app.state.llm_handler = llm_handler
     app.include_router(router)


### PR DESCRIPTION
Problem
-------
Opening ui/studio.html via file:// protocol and calling the API at http://localhost:8001 fails with:

  "Access to fetch at '…/release_task' from origin 'null' has been
   blocked by CORS policy: Response to preflight request doesn't pass
   access control check"

The browser sends a preflight OPTIONS request for the cross-origin POST, but neither the standalone FastAPI server (api_server.py) nor the Gradio-mounted API routes (api_routes.py) return the required Access-Control-Allow-Origin header.

Changes
-------
1. acestep/api_server.py
   - Import CORSMiddleware from fastapi.middleware.cors.
   - Add CORSMiddleware to the standalone FastAPI app immediately after creation (before the app starts, so add_middleware() works normally).

2. acestep/gradio_ui/api_routes.py
   - Import CORSMiddleware from fastapi.middleware.cors.
   - Add _CORS_KWARGS dict with the shared CORS configuration.
   - Add _add_cors_middleware() for the normal pre-launch path (used by setup_api_routes_to_app).
   - Add _add_cors_middleware_post_launch() that patches the compiled middleware_stack directly, because Gradio's demo.launch() starts the Starlette app before setup_api_routes() is called, and Starlette raises "Cannot add middleware after an application has started" if add_middleware() is used post-launch.
   - Wire both setup functions to their respective CORS helpers.

CORS policy (applied uniformly in both files)
----------------------------------------------
  allow_origins       : ["null", "http://localhost", "http://127.0.0.1"]
  allow_origin_regex  : ^https?://(localhost|127\.0\.0\.1)(:\d+)?$
  allow_methods       : ["GET", "POST", "OPTIONS"]
  allow_headers       : ["Content-Type", "Authorization"]
  allow_credentials   : not set (defaults to False)

Benefits
--------
- studio.html (opened via file://, origin "null") can now call the API.
- Any local dev server on localhost or 127.0.0.1 (any port) also works.
- The Gradio + API path no longer crashes on startup.

Risks & mitigations
--------------------
- Origin "null" is allowed. The "null" origin is sent by file:// pages, sandboxed iframes, and some redirect flows. A malicious local HTML file could call the API if opened in the same browser. Mitigation: the API is bound to localhost by default, and API key auth (--api-key) is available for sensitive deployments.
- If the server is exposed to the network (0.0.0.0 or --share), only localhost origins are allowed — external sites cannot call the API. However, the "null" origin exception still applies to any file:// page on the user's machine.
- The post-launch middleware patching (_add_cors_middleware_post_launch) accesses app.middleware_stack directly, which is a Starlette internal. This could break if Starlette refactors its middleware compilation. Mitigation: guarded by an `if app.middleware_stack is not None` check and falls back to the normal add_middleware path otherwise.
- allow_credentials is intentionally omitted (False). studio.html uses plain JSON fetch without cookies. If cookie-based auth is added later, this will need revisiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-origin resource sharing (CORS) issues, enabling browser-based frontends to access the API from localhost and file:// protocol origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->