### PR TITLE
fix: pin torchao version to >=0.14.1,<0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numba>=0.63.1",
     "vector-quantize-pytorch>=1.27.15",
     "torchcodec>=0.9.1",
-    "torchao",
+    "torchao>=0.14.1,<0.16.0",
     "toml",
     # MLX dependencies (Apple Silicon native acceleration - macOS only)
     "mlx>=0.25.2; sys_platform == 'darwin' and platform_machine == 'arm64'",


### PR DESCRIPTION
Pin torchao dependency to a compatible version range to avoid breaking changes from newer releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Package dependency version constraints have been updated and refined. The constraint now specifies both minimum and maximum supported versions. This change affects environment consistency and version resolution during package installation, ensuring the application remains compatible across supported platforms while validating compatibility across different release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->