### PR TITLE
fix: auto-detect Mac/MPS and apply optimal configuration

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -36,7 +36,7 @@ try:
     from .llm_inference import LLMHandler
     from .dataset_handler import DatasetHandler
     from .gradio_ui import create_gradio_interface
-    from .gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB
+    from .gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB, is_mps_platform
     from .model_downloader import ensure_lm_model
 except ImportError:
     # When executed as a script: `python acestep/acestep_v15_pipeline.py`
@@ -47,7 +47,7 @@ except ImportError:
     from acestep.llm_inference import LLMHandler
     from acestep.dataset_handler import DatasetHandler
     from acestep.gradio_ui import create_gradio_interface
-    from acestep.gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB
+    from acestep.gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB, is_mps_platform
     from acestep.model_downloader import ensure_lm_model
 
 
@@ -93,11 +93,13 @@ def main():
     set_global_gpu_config(gpu_config)  # Set global config for use across modules
     
     gpu_memory_gb = gpu_config.gpu_memory_gb
+    _is_mac = is_mps_platform()
     # Enable auto-offload for GPUs below 20 GB.  16 GB GPUs cannot hold all
     # models simultaneously (DiT ~4.7 + VAE ~0.3 + text_enc ~1.2 + LM ≥1.2 +
     # activations) so they *must* offload.  The old threshold of 16 GB caused
     # 16 GB GPUs to never offload, leading to OOM.
-    auto_offload = gpu_memory_gb > 0 and gpu_memory_gb < VRAM_AUTO_OFFLOAD_THRESHOLD_GB
+    # Mac (Apple Silicon) uses unified memory — offloading provides no benefit.
+    auto_offload = (not _is_mac) and gpu_memory_gb > 0 and gpu_memory_gb < VRAM_AUTO_OFFLOAD_THRESHOLD_GB
     
     # Print GPU configuration info
     print(f"\n{'='*60}")
@@ -113,7 +115,9 @@ def main():
     print(f"  Available LM Models: {gpu_config.available_lm_models or 'None'}")
     print(f"{'='*60}\n")
     
-    if auto_offload:
+    if _is_mac:
+        print(f"Apple Silicon (MPS) detected — unified memory {gpu_memory_gb:.1f}GB, no CPU offload needed, backend={_default_backend}")
+    elif auto_offload:
         print(f"Auto-enabling CPU offload (GPU {gpu_memory_gb:.1f}GB < {VRAM_AUTO_OFFLOAD_THRESHOLD_GB}GB threshold)")
     elif gpu_memory_gb > 0:
         print(f"CPU offload disabled by default (GPU {gpu_memory_gb:.1f}GB >= {VRAM_AUTO_OFFLOAD_THRESHOLD_GB}GB threshold)")
@@ -152,7 +156,8 @@ def main():
     parser.add_argument("--device", type=str, default="auto", choices=["auto", "cuda", "mps", "xpu", "cpu"], help="Processing device (default: auto)")
     parser.add_argument("--init_llm", type=lambda x: x.lower() in ['true', '1', 'yes'], default=None, help="Initialize 5Hz LM (default: auto based on GPU memory)")
     parser.add_argument("--lm_model_path", type=str, default=None, help="5Hz LM model path (e.g., 'acestep-5Hz-lm-0.6B')")
-    parser.add_argument("--backend", type=str, default="vllm", choices=["vllm", "pt", "mlx"], help="5Hz LM backend (default: vllm, use 'mlx' for native Apple Silicon acceleration)")
+    _default_backend = "mlx" if _is_mac else "vllm"
+    parser.add_argument("--backend", type=str, default=_default_backend, choices=["vllm", "pt", "mlx"], help=f"5Hz LM backend (default: {_default_backend}, use 'mlx' for native Apple Silicon acceleration)")
     parser.add_argument("--use_flash_attention", type=lambda x: x.lower() in ['true', '1', 'yes'], default=None, help="Use flash attention (default: auto-detect)")
     parser.add_argument("--offload_to_cpu", type=lambda x: x.lower() in ['true', '1', 'yes'], default=auto_offload, help=f"Offload models to CPU (default: {'True' if auto_offload else 'False'}, auto-detected based on GPU VRAM)")
     parser.add_argument("--offload_dit_to_cpu", type=lambda x: x.lower() in ['true', '1', 'yes'], default=False, help="Offload DiT to CPU (default: False)")

--- a/acestep/gradio_ui/events/generation_handlers.py
+++ b/acestep/gradio_ui/events/generation_handlers.py
@@ -3,6 +3,7 @@ Generation Input Handlers Module
 Contains event handlers and helper functions related to generation inputs
 """
 import os
+import sys
 import json
 import random
 import glob
@@ -448,6 +449,16 @@ def init_service_wrapper(dit_handler, llm_handler, checkpoint, config_path, devi
     
     # --- Tier-aware validation before initialization ---
     gpu_config = get_global_gpu_config()
+    
+    # macOS safety: force-disable compile and quantization even if user checked them
+    if sys.platform == "darwin":
+        if compile_model:
+            logger.info("macOS detected: disabling torch.compile (not supported on MPS)")
+            compile_model = False
+        if quantization:
+            logger.info("macOS detected: disabling INT8 quantization (torchao incompatible with MPS)")
+            quantization = False
+            quant_value = None
     
     # Validate LM request against GPU tier
     if init_llm and not gpu_config.available_lm_models:

--- a/acestep/gradio_ui/interfaces/generation.py
+++ b/acestep/gradio_ui/interfaces/generation.py
@@ -63,9 +63,11 @@ def create_generation_section(dit_handler, llm_handler, init_params=None, langua
     # Tier-aware LM defaults
     default_quantization = gpu_config.quantization_default
     default_compile = gpu_config.compile_model_default
-    # macOS override: disable quantization on macOS due to torchao incompatibilities
+    # macOS override: disable quantization and compile on macOS
+    # (gpu_config already handles this centrally, but keep as safety net)
     if sys.platform == "darwin":
         default_quantization = False
+        default_compile = False
     
     # Backend choices based on tier restriction
     if gpu_config.lm_backend_restriction == "pt_mlx_only":

--- a/cli.py
+++ b/cli.py
@@ -66,7 +66,7 @@ from acestep.handler import AceStepHandler
 from acestep.llm_inference import LLMHandler
 from acestep.inference import GenerationParams, GenerationConfig, generate_music, create_sample, format_sample
 from acestep.constants import DEFAULT_DIT_INSTRUCTION, TASK_INSTRUCTIONS
-from acestep.gpu_config import get_gpu_config, set_global_gpu_config
+from acestep.gpu_config import get_gpu_config, set_global_gpu_config, is_mps_platform
 import torch
 
 
@@ -978,8 +978,9 @@ def main():
 
     gpu_config = get_gpu_config()
     set_global_gpu_config(gpu_config)
-    auto_offload = gpu_config.gpu_memory_gb > 0 and gpu_config.gpu_memory_gb < 16
-    mps_available = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    mps_available = is_mps_platform()
+    # Mac (Apple Silicon) uses unified memory — offloading provides no benefit
+    auto_offload = (not mps_available) and gpu_config.gpu_memory_gb > 0 and gpu_config.gpu_memory_gb < 16
     print(f"\n{'='*60}")
     print("GPU Configuration Detected:")
     print(f"{'='*60}")


### PR DESCRIPTION
- Add is_mps_platform() helper in gpu_config.py for centralized MPS detection
- Disable torch.compile and INT8 quantization on MPS (unsupported)
- Default LM backend to MLX on Apple Silicon for native acceleration
- Disable CPU offload on MPS (unified memory makes it unnecessary)
- Fix VAE decoder slowness: skip VRAM check on MPS to prevent incorrect CPU offload and small chunk tiled decode
- Add safety guards in handler and Gradio event handlers to enforce MPS-compatible settings even if user overrides

Files changed:
  - acestep/gpu_config.py: new is_mps_platform(), MPS overrides in get_gpu_config()
  - acestep/handler.py: MPS safety guard in initialize_service(), skip VRAM check
  - acestep/acestep_v15_pipeline.py: MPS-aware auto_offload and default backend
  - acestep/gradio_ui/interfaces/generation.py: disable compile checkbox on macOS
  - acestep/gradio_ui/events/generation_handlers.py: runtime MPS safety checks
  - cli.py: MPS-aware auto_offload and default backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive native support for Apple Silicon (M-series) Macs with automatic platform detection and hardware-optimized configurations.

* **Improvements**
  * Automatically disables incompatible features (model compilation, INT8 quantization) on Apple Silicon to ensure reliable performance.
  * Optimizes default backend and memory handling for Apple Silicon's unified memory architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->