### PR TITLE
fix(repaint): pass lyrics conditioning to repaint generation pipeline

### DIFF
--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -2725,6 +2725,13 @@ class AceStepHandler(LoraManagerMixin, ProgressMixin):
         # Get batch size from captions
         batch_size = len(captions)
 
+        # Normalize lyrics to match batch size (so conditioning always has caption + lyric per item, including repaint)
+        if len(lyrics) < batch_size:
+            fill = lyrics[-1] if lyrics else ""
+            lyrics = list(lyrics) + [fill] * (batch_size - len(lyrics))
+        elif len(lyrics) > batch_size:
+            lyrics = lyrics[:batch_size]
+
         # Normalize instructions and audio_code_hints to match batch size
         instructions = self._normalize_instructions(instructions, batch_size, DEFAULT_DIT_INSTRUCTION) if instructions is not None else None
         audio_code_hints = self._normalize_audio_code_hints(audio_code_hints, batch_size) if audio_code_hints is not None else None

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -568,6 +568,11 @@ def generate_music(
             if params.use_cot_language:
                 dit_input_vocal_language = lm_generated_metadata.get("vocal_language", dit_input_vocal_language)
 
+        # Repaint/cover: no LM run, so conditioning must come from params (caption + lyrics from GUI).
+        if params.task_type in ("repaint", "cover"):
+            dit_input_caption = params.caption or dit_input_caption
+            dit_input_lyrics = params.lyrics if params.lyrics is not None else dit_input_lyrics
+
         # Phase 2: DiT music generation
         # Use seed_for_generation (from config.seed or params.seed) instead of params.seed for actual generation
         result = dit_handler.generate_music(


### PR DESCRIPTION
- handler: normalize lyrics list to batch_size so conditioning always has caption + lyric per item
- inference: for repaint/cover, explicitly use params.caption and params.lyrics so GUI lyrics reach the model

Fixes repaint mode not forwarding lyrics from UI, resulting in silent segments instead of repainted vocals. Closes #458.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed batch processing to properly align captions and lyrics across items
  * Repaint and cover tasks now correctly use user-provided captions and lyrics instead of auto-generated alternatives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->