### PR TITLE
fix: reset audio playback position on regenerate & add GPU tier i18n …

### DIFF
--- a/acestep/gradio_ui/events/results_handlers.py
+++ b/acestep/gradio_ui/events/results_handlers.py
@@ -617,7 +617,7 @@ def generate_with_progress(
     # Clear lrc_display with empty string - this triggers .change() to clear subtitles
     clear_lrcs = [gr.update(value="", visible=True) for _ in range(8)]
     clear_accordions = [gr.skip() for _ in range(8)]  # Don't change accordion visibility
-    dump_audio = [gr.update(value=None, subtitles=None) for _ in range(8)]
+    dump_audio = [gr.update(value=None, subtitles=None, playback_position=0) for _ in range(8)]
     yield (
         # Audio outputs - just skip, value will be updated in loop
         # Subtitles will be cleared via lrc_display.change()

--- a/acestep/gradio_ui/i18n/en.json
+++ b/acestep/gradio_ui/i18n/en.json
@@ -59,7 +59,10 @@
     "init_btn": "Initialize Service",
     "status_label": "Status",
     "language_label": "UI Language",
-    "language_info": "Select interface language"
+    "language_info": "Select interface language",
+    "gpu_auto_tier": "Auto-detected Tier",
+    "tier_label": "GPU Tier Override",
+    "tier_info": "Manually select GPU tier to adjust optimization defaults (offload, quantization, backend, etc.)"
   },
   "generation": {
     "required_inputs": "📝 Required Inputs",


### PR DESCRIPTION
…strings

- Reset playback_position to 0 when clearing audio outputs during generation to prevent stale playback state
- Add en.json i18n entries for GPU tier override UI (gpu_auto_tier, tier_label, tier_info)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU tier selection options with auto-detection and manual override capabilities to fine-tune optimization defaults.

* **Bug Fixes**
  * Fixed audio playback position to properly reset when clearing audio outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->