### PR TITLE
[Bugfix] Only use FlashAttention if GPU supports it

### DIFF
--- a/acestep/core/generation/handler/init_service.py
+++ b/acestep/core/generation/handler/init_service.py
@@ -58,6 +58,17 @@ class InitServiceMixin:
         else:
             if target_device != "cuda" or not torch.cuda.is_available():
                 return False
+        # FlashAttention requires Ampere (compute capability >= 8.0) or newer
+        try:
+            major, _ = torch.cuda.get_device_capability()
+            if major < 8:
+                logger.info(
+                    f"[is_flash_attention_available] GPU compute capability {major}.x < 8.0 "
+                    f"(pre-Ampere) — FlashAttention not supported, will use SDPA instead."
+                )
+                return False
+        except Exception:
+            return False
         try:
             import flash_attn
             return True


### PR DESCRIPTION
Got the following error when running locally on my 2080Ti when trying to generate the music:

❌ Error: FlashAttention only supports Ampere GPUs or newer.
[...]

As it turns out, the code should do a GPU compute capability check, not just whether or not the python package is installed.

__Fix:__ Added `torch.cuda.get_device_capability()` check before the `flash_attn` import check. Pre-Ampere GPUs now correctly return `False`, causing the model to load with SDPA (Scaled Dot Product Attention) instead, which works on all GPU architectures.

__Files changed:__

- `acestep/core/generation/handler/init_service.py` — Added compute capability check in `is_flash_attention_available()`
- `acestep/core/generation/handler/init_service_test.py` — Updated existing tests to mock `get_device_capability`, added new test for pre-Ampere GPU scenario

All 20 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU hardware detection to verify support for optimized computation features, ensuring compatibility across various GPU architectures with automatic fallback for unsupported devices.

* **Tests**
  * Added comprehensive test coverage for GPU capability detection across different hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->