### PR TITLE
Fix: {TRACK_NAME} not replaced by actual track name in API.

### DIFF
--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -2357,7 +2357,7 @@ def create_app() -> FastAPI:
                 src_audio_path = _validate_audio_path(str(form.get("ctx_audio_path") or form.get("src_audio_path") or "").strip() or None)
 
             req = _build_request(
-                RequestParser(dict(form)),
+                RequestParser(dict(form_dict)),
                 reference_audio_path=reference_audio_path,
                 src_audio_path=src_audio_path,
             )


### PR DESCRIPTION
When you use Extract in the API, this is shown in the debug log:

```
======================================================================
2026-02-12 01:38:31.514 | INFO     | acestep.handler:_prepare_batch:2373 - 🔍 [DEBUG] DiT TEXT ENCODER INPUT (Inference)
2026-02-12 01:38:31.514 | INFO     | acestep.handler:_prepare_batch:2374 - ======================================================================
2026-02-12 01:38:31.514 | INFO     | acestep.handler:_prepare_batch:2375 - text_prompt:
# Instruction
Extract the **{TRACK_NAME}** track from the audio:

# Caption
An upbeat pop duet featuring clean male and female vocals over an energetic arrangement driven by acoustic guitar strumming and prominent percussion like bongos or congas. The track opens with wordless vocalizations before settling into alternating verses between the male and female singers. The chorus is catchy and melodic, leading to vibrant instrumental breaks highlighted by a lively brass section fanfare that adds a festive, almost mariachi-like flavor to the song's middle section. The production is polished and bright, maintaining a consistent mid-tempo groove throughout.

# Metas
- bpm: 120
- timesignature: 4
- keyscale: C minor
- duration: 179 seconds <|endoftext|>
```

{TRACK_NAME} did not contain the actual track to be extracted, so this change updates the prompt to match the desired track.

```
After this fix you can see this in the debug log:
2026-02-12 10:19:47.017 | INFO     | acestep.handler:_prepare_batch:2335 -
======================================================================
2026-02-12 10:19:47.017 | INFO     | acestep.handler:_prepare_batch:2336 - 🔍 [DEBUG] DiT TEXT ENCODER INPUT (Inference)
2026-02-12 10:19:47.018 | INFO     | acestep.handler:_prepare_batch:2337 - ======================================================================
2026-02-12 10:19:47.018 | INFO     | acestep.handler:_prepare_batch:2338 - text_prompt:
# Instruction
Extract the **DRUMS** track from the audio:

# Caption
An upbeat pop duet featuring clean male and female vocals over an energetic arrangement driven by acoustic guitar strumming and prominent percussion like bongos or congas. The track opens with wordless vocalizations before settling into alternating verses between the male and female singers. The chorus is catchy and melodic, leading to vibrant instrumental breaks highlighted by a lively brass section fanfare that adds a festive, almost mariachi-like flavor to the song's middle section. The production is polished and bright, maintaining a consistent mid-tempo groove throughout.

# Metas
- bpm: 120
- timesignature: 4
- keyscale: C minor
- duration: 179 seconds <|endoftext|>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-track metadata: optional track name can be provided and is incorporated into generation and task instructions (uppercased when substituted).
  * Track classes/instruments: optional list accepted under multiple parameter names; values are normalized, uppercased, and pipe-separated when inserted into instructions.
  * Form parsing: multi-value form fields are consolidated into lists for multi-part submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->