### PR TITLE
[Fix] Eliminate redundant LLM load/offload cycles in PT batch mode

### DIFF
--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -134,17 +134,17 @@ class LLMHandler:
 
         models.sort()
         return models
-    
+
     def get_gpu_memory_utilization(self, model_path: str = None, minimal_gpu: float = 8, min_ratio: float = 0.2, max_ratio: float = 0.9) -> Tuple[float, bool]:
         """
         Get GPU memory utilization ratio based on LM model size and available GPU memory.
-        
+
         Args:
             model_path: LM model path (e.g., "acestep-5Hz-lm-0.6B"). Used to determine target memory.
             minimal_gpu: Minimum GPU memory requirement in GB (fallback)
             min_ratio: Minimum memory utilization ratio
             max_ratio: Maximum memory utilization ratio
-            
+
         Returns:
             Tuple of (gpu_memory_utilization_ratio, low_gpu_memory_mode)
         """
@@ -152,50 +152,50 @@ class LLMHandler:
             device = torch.device("cuda:0")
             total_gpu_mem_bytes = torch.cuda.get_device_properties(device).total_memory
             total_gpu = total_gpu_mem_bytes / 1024**3
-            
+
             low_gpu_memory_mode = False
-            
+
             # Use adaptive GPU memory ratio based on model size
             if model_path:
                 ratio, target_memory_gb = get_lm_gpu_memory_ratio(model_path, total_gpu)
                 logger.info(f"Adaptive LM memory allocation: model={model_path}, target={target_memory_gb}GB, ratio={ratio:.3f}, total_gpu={total_gpu:.1f}GB")
-                
+
                 # Enable low memory mode for small GPUs
                 if total_gpu < 8:
                     low_gpu_memory_mode = True
-                    
+
                 return ratio, low_gpu_memory_mode
-            
+
             # Fallback to original logic if no model_path provided
             reserved_mem_bytes = torch.cuda.memory_reserved(device)
             reserved_gpu = reserved_mem_bytes / 1024**3
             available_gpu = total_gpu - reserved_gpu
-            
+
             if total_gpu < minimal_gpu:
                 minimal_gpu = 0.5 * total_gpu
                 low_gpu_memory_mode = True
-            
+
             if available_gpu >= minimal_gpu:
                 ratio = min(max_ratio, max(min_ratio, minimal_gpu / total_gpu))
             else:
                 ratio = min(max_ratio, max(min_ratio, (available_gpu * 0.8) / total_gpu))
-            
+
             return ratio, low_gpu_memory_mode
         except Exception as e:
             logger.warning(f"Failed to calculate GPU memory utilization: {e}")
             return 0.9, False
-    
+
     def _has_meaningful_negative_prompt(self, negative_prompt: str) -> bool:
         """Check if negative prompt is meaningful (not default/empty)"""
         return negative_prompt and negative_prompt.strip() and negative_prompt.strip() != "NO USER INPUT"
-    
+
     def _build_logits_processor(self, repetition_penalty: float) -> LogitsProcessorList:
         """Build logits processor list with repetition penalty if needed"""
         logits_processor = LogitsProcessorList()
         if repetition_penalty != 1.0:
             logits_processor.append(RepetitionPenaltyLogitsProcessor(penalty=repetition_penalty))
         return logits_processor
-    
+
     def _setup_constrained_processor(
         self,
         use_constrained_decoding: bool,
@@ -213,17 +213,17 @@ class LLMHandler:
     ) -> Optional[MetadataConstrainedLogitsProcessor]:
         """Setup and configure constrained processor for generation"""
         use_phase_temperatures = not is_batch and (metadata_temperature is not None or codes_temperature is not None)
-        
+
         if not use_constrained_decoding and not use_phase_temperatures:
             return None
-        
+
         # Reset processor state for new generation
         self.constrained_processor.reset()
-        
+
         # Use shared processor, just update settings
         self.constrained_processor.enabled = use_constrained_decoding
         self.constrained_processor.debug = constrained_decoding_debug
-        
+
         # Phase temperatures only supported in single mode
         if use_phase_temperatures:
             self.constrained_processor.metadata_temperature = metadata_temperature
@@ -231,9 +231,9 @@ class LLMHandler:
         else:
             self.constrained_processor.metadata_temperature = None
             self.constrained_processor.codes_temperature = None
-        
+
         self.constrained_processor.set_target_duration(target_duration)
-        
+
         # Batch mode uses default/disabled settings for these options
         if is_batch:
             self.constrained_processor.set_user_metadata(None)
@@ -248,12 +248,12 @@ class LLMHandler:
             self.constrained_processor.set_skip_genres(skip_genres)
             self.constrained_processor.set_skip_caption(skip_caption)
             self.constrained_processor.set_skip_language(skip_language)
-        
+
         # Set generation phase for phase-aware processing
         self.constrained_processor.set_generation_phase(generation_phase)
-        
+
         return self.constrained_processor
-    
+
     def _build_unconditional_prompt(
         self,
         caption: str,
@@ -275,7 +275,7 @@ class LLMHandler:
             return self.build_formatted_prompt(
                 caption, lyrics, is_negative_prompt=True, generation_phase="cot", negative_prompt=negative_prompt
             )
-    
+
     def _load_pytorch_model(self, model_path: str, device: str) -> Tuple[bool, str]:
         """Load PyTorch model from path and return (success, status_message)"""
         try:
@@ -292,14 +292,14 @@ class LLMHandler:
             return True, status_msg
         except Exception as e:
             return False, f"❌ Error initializing 5Hz LM: {str(e)}\n\nTraceback:\n{traceback.format_exc()}"
-    
+
     def _apply_top_k_filter(self, logits: torch.Tensor, top_k: Optional[int]) -> torch.Tensor:
         """Apply top-k filtering to logits"""
         if top_k is not None and top_k > 0:
             indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
             logits[indices_to_remove] = float('-inf')
         return logits
-    
+
     def _apply_top_p_filter(self, logits: torch.Tensor, top_p: Optional[float]) -> torch.Tensor:
         """Apply top-p (nucleus) filtering to logits"""
         if top_p is not None and 0.0 < top_p < 1.0:
@@ -312,10 +312,10 @@ class LLMHandler:
             indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
             logits[indices_to_remove] = float('-inf')
         return logits
-    
+
     def _sample_tokens(self, logits: torch.Tensor, temperature: float) -> torch.Tensor:
         """Sample tokens from logits with temperature.
-        
+
         Upcasts to float32 for numerical stability (float16 logits can overflow
         during softmax, especially after CFG scaling).
         """
@@ -326,7 +326,7 @@ class LLMHandler:
             return torch.multinomial(probs, num_samples=1).squeeze(1)
         else:
             return torch.argmax(logits, dim=-1)
-    
+
     def _check_eos_token(self, tokens: torch.Tensor, eos_token_id: int, pad_token_id: Optional[int]) -> bool:
         """Check if any token in the batch is EOS or pad token"""
         if torch.any(tokens == eos_token_id):
@@ -335,13 +335,13 @@ class LLMHandler:
             if torch.any(tokens == pad_token_id):
                 return True
         return False
-    
+
     def _update_constrained_processor_state(self, constrained_processor: Optional[MetadataConstrainedLogitsProcessor], tokens: torch.Tensor):
         """Update constrained processor state with generated tokens"""
         if constrained_processor is not None:
             for b in range(tokens.shape[0]):
                 constrained_processor.update_state(tokens[b].item())
-    
+
     def _forward_pass(
         self,
         model: Any,
@@ -365,7 +365,7 @@ class LLMHandler:
                 use_cache=use_cache,
             )
         return outputs
-    
+
     def _normalize_batch_input(self, formatted_prompts: Union[str, List[str]]) -> Tuple[List[str], bool]:
         """Normalize batch input: convert single string to list and return (list, is_batch)"""
         is_batch = isinstance(formatted_prompts, list)
@@ -373,7 +373,7 @@ class LLMHandler:
             return formatted_prompts, is_batch
         else:
             return [formatted_prompts], is_batch
-    
+
     def initialize(
         self,
         checkpoint_dir: str,
@@ -385,7 +385,7 @@ class LLMHandler:
     ) -> Tuple[str, bool]:
         """
         Initialize 5Hz LM model
-        
+
         Args:
             checkpoint_dir: Checkpoint directory path
             lm_model_path: LM model path (relative to checkpoint_dir)
@@ -393,7 +393,7 @@ class LLMHandler:
             device: Device type ("auto", "cuda", "mps", "xpu", or "cpu")
             offload_to_cpu: Whether to offload to CPU
             dtype: Data type (if None, auto-detect based on device)
-        
+
         Returns:
             (status_message, success)
         """
@@ -480,17 +480,17 @@ class LLMHandler:
             llm_tokenizer = AutoTokenizer.from_pretrained(full_lm_model_path, use_fast=True)
             logger.info(f"5Hz LM tokenizer loaded successfully in {time.time() - start_time:.2f} seconds")
             self.llm_tokenizer = llm_tokenizer
-            
+
             # Initialize shared constrained decoding processor (one-time initialization)
             # Use GPU-based max_duration to limit duration values in constrained decoding
             logger.info("Initializing constrained decoding processor...")
             processor_start = time.time()
-            
+
             gpu_config = get_global_gpu_config()
             # Use max_duration_with_lm since LM is being initialized
             max_duration_for_constraint = gpu_config.max_duration_with_lm
             logger.info(f"Setting constrained decoding max_duration to {max_duration_for_constraint}s based on GPU config (tier: {gpu_config.tier})")
-            
+
             self.constrained_processor = MetadataConstrainedLogitsProcessor(
                 tokenizer=self.llm_tokenizer,
                 enabled=True,
@@ -498,7 +498,7 @@ class LLMHandler:
                 max_duration=max_duration_for_constraint,
             )
             logger.info(f"Constrained processor initialized in {time.time() - processor_start:.2f} seconds")
-            
+
             # Disable CUDA/HIP graph capture on ROCm (unverified on RDNA3 Windows)
             is_rocm = hasattr(torch.version, 'hip') and torch.version.hip is not None
             enforce_eager_for_vllm = bool(is_rocm)
@@ -583,12 +583,12 @@ class LLMHandler:
                 success, status_msg = self._load_pytorch_model(full_lm_model_path, device)
                 if not success:
                     return status_msg, False
-            
+
             return status_msg, True
-            
+
         except Exception as e:
             return f"❌ Error initializing 5Hz LM: {str(e)}\n\nTraceback:\n{traceback.format_exc()}", False
-    
+
     def _initialize_5hz_lm_vllm(self, model_path: str, enforce_eager: bool = False) -> str:
         """Initialize 5Hz LM model using vllm backend. When enforce_eager is True, CUDA graph
         capture is disabled (required when LoRA training may run in the same process)."""
@@ -602,13 +602,13 @@ class LLMHandler:
             self.llm_initialized = False
             logger.error("nano-vllm is not installed. Please install it using 'cd acestep/third_parts/nano-vllm && pip install .")
             return "❌ nano-vllm is not installed. Please install it using 'cd acestep/third_parts/nano-vllm && pip install ."
-        
+
         try:
             current_device = torch.cuda.current_device()
             device_name = torch.cuda.get_device_name(current_device)
-            
+
             torch.cuda.empty_cache()
-            
+
             # Use adaptive GPU memory utilization based on model size
             gpu_memory_utilization, low_gpu_memory_mode = self.get_gpu_memory_utilization(
                 model_path=model_path,
@@ -616,12 +616,12 @@ class LLMHandler:
                 min_ratio=0.1,
                 max_ratio=0.9
             )
-            
+
             if low_gpu_memory_mode:
                 self.max_model_len = 2048
             else:
                 self.max_model_len = 4096
-            
+
             logger.info(f"Initializing 5Hz LM with model: {model_path}, enforce_eager: {enforce_eager}, tensor_parallel_size: 1, max_model_len: {self.max_model_len}, gpu_memory_utilization: {gpu_memory_utilization:.3f}")
             start_time = time.time()
             self.llm = LLM(
@@ -732,7 +732,7 @@ class LLMHandler:
                 is_batch=is_batch,
             )
             unconditional_prompts = [formatted_unconditional_prompt] * batch_size
-            
+
             outputs = self.llm.generate(
                 formatted_prompt_list,
                 sampling_params,
@@ -802,7 +802,7 @@ class LLMHandler:
 
         with self._load_model_context():
             inputs = {k: v.to(self.device) for k, v in inputs.items()}
-            
+
             # Calculate max_new_tokens based on target_duration if specified
             # 5 audio codes = 1 second, plus ~500 tokens for CoT metadata and safety margin
             if target_duration is not None and target_duration > 0:
@@ -811,7 +811,7 @@ class LLMHandler:
                 max_new_tokens = int(effective_duration * 5) + 500
             else:
                 max_new_tokens = getattr(self.llm.config, "max_new_tokens", 4096)
-            
+
             # Cap at model's max length
             if hasattr(self, "max_model_len"):
                 max_new_tokens = min(max_new_tokens, self.max_model_len - 64)
@@ -829,7 +829,7 @@ class LLMHandler:
                     generation_phase=generation_phase,
                     is_batch=False,
                 )
-                
+
                 # Tokenize both prompts together to ensure same length (with left padding)
                 # Left padding is important for generation tasks
                 batch_texts = [formatted_prompt, formatted_unconditional_prompt]
@@ -843,7 +843,7 @@ class LLMHandler:
                 )
                 self.llm_tokenizer.padding_side = original_padding_side
                 batch_inputs_tokenized = {k: v.to(self.device) for k, v in batch_inputs_tokenized.items()}
-                
+
                 # Extract batch inputs
                 batch_input_ids = batch_inputs_tokenized['input_ids']
                 batch_attention_mask = batch_inputs_tokenized.get('attention_mask', None)
@@ -862,7 +862,7 @@ class LLMHandler:
                     streamer=None,
                     constrained_processor=constrained_processor,
                 )
-                
+
                 # Extract only the conditional output (first in batch)
                 outputs = outputs[0:1]  # Keep only conditional output
             elif use_constrained_decoding:
@@ -903,7 +903,7 @@ class LLMHandler:
                 generated_ids = outputs
         else:
             generated_ids = outputs[0]
-        
+
         # Only decode the newly generated tokens (skip the input prompt)
         # Use the original input length (before batch processing for CFG)
         if cfg_scale > 1.0:
@@ -912,13 +912,13 @@ class LLMHandler:
             input_length = batch_inputs_tokenized['input_ids'].shape[1]
         else:
             input_length = inputs["input_ids"].shape[1]
-        
+
         generated_ids = generated_ids[input_length:]
-        
+
         # Move to CPU for decoding (tokenizer needs CPU tensors)
         if generated_ids.device.type != "cpu":
             generated_ids = generated_ids.cpu()
-        
+
         output_text = self.llm_tokenizer.decode(generated_ids, skip_special_tokens=False)
         return output_text
 
@@ -954,48 +954,51 @@ class LLMHandler:
         # Determine if batch mode
         formatted_prompt_list, is_batch = self._normalize_batch_input(formatted_prompts)
 
-        # For batch mode, process each item sequentially with different seeds
+        # For batch mode, process each item sequentially with different seeds.
+        # Wrap the entire loop in a single _load_model_context() so the model
+        # loads to GPU once and offloads once, instead of per-item.
         if is_batch:
             output_texts = []
-            for i, formatted_prompt in enumerate(formatted_prompt_list):
-                # Set seed for this item if provided
-                if seeds and i < len(seeds):
-                    torch.manual_seed(seeds[i])
-                    if torch.cuda.is_available():
-                        torch.cuda.manual_seed_all(seeds[i])
-                    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                        torch.mps.manual_seed(seeds[i])
-                
-                # Generate using single-item method with batch-mode defaults
-                output_text = self._run_pt_single(
-                    formatted_prompt=formatted_prompt,
-                    temperature=temperature,
-                    cfg_scale=cfg_scale,
-                    negative_prompt=negative_prompt,
-                    top_k=top_k,
-                    top_p=top_p,
-                    repetition_penalty=repetition_penalty,
-                    use_constrained_decoding=use_constrained_decoding,
-                    constrained_decoding_debug=constrained_decoding_debug,
-                    target_duration=target_duration,
-                    user_metadata=None,
-                    stop_at_reasoning=False,
-                    skip_genres=True,
-                    skip_caption=True,
-                    skip_language=True,
-                    generation_phase=generation_phase,
-                    caption=caption,
-                    lyrics=lyrics,
-                    cot_text=cot_text,
-                )
-                
-                output_texts.append(output_text)
-            
+            with self._load_model_context():
+                for i, formatted_prompt in enumerate(formatted_prompt_list):
+                    # Set seed for this item if provided
+                    if seeds and i < len(seeds):
+                        torch.manual_seed(seeds[i])
+                        if torch.cuda.is_available():
+                            torch.cuda.manual_seed_all(seeds[i])
+                        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                            torch.mps.manual_seed(seeds[i])
+
+                    # Generate using single-item method with batch-mode defaults
+                    output_text = self._run_pt_single(
+                        formatted_prompt=formatted_prompt,
+                        temperature=temperature,
+                        cfg_scale=cfg_scale,
+                        negative_prompt=negative_prompt,
+                        top_k=top_k,
+                        top_p=top_p,
+                        repetition_penalty=repetition_penalty,
+                        use_constrained_decoding=use_constrained_decoding,
+                        constrained_decoding_debug=constrained_decoding_debug,
+                        target_duration=target_duration,
+                        user_metadata=None,
+                        stop_at_reasoning=False,
+                        skip_genres=True,
+                        skip_caption=True,
+                        skip_language=True,
+                        generation_phase=generation_phase,
+                        caption=caption,
+                        lyrics=lyrics,
+                        cot_text=cot_text,
+                    )
+
+                    output_texts.append(output_text)
+
             return output_texts
 
         # Single mode: process the formatted prompt
         formatted_prompt = formatted_prompt_list[0]
-        
+
         return self._run_pt_single(
             formatted_prompt=formatted_prompt,
             temperature=temperature,
@@ -1025,14 +1028,14 @@ class LLMHandler:
         if 'bpm' in user_metadata and 'keyscale' in user_metadata and 'timesignature' in user_metadata and 'duration' in user_metadata:
             return True
         return False
-    
+
     def _format_metadata_as_cot(self, metadata: Dict[str, Any]) -> str:
         """
         Format parsed metadata as CoT text using YAML format (matching training format).
-        
+
         Args:
             metadata: Dictionary with keys: bpm, caption, duration, keyscale, language, timesignature
-            
+
         Returns:
             Formatted CoT text: "<think>\n{yaml_content}\n</think>"
         """
@@ -1046,13 +1049,13 @@ class LLMHandler:
                 if isinstance(value, str) and value.isdigit():
                     value = int(value)
                 cot_items[key] = value
-        
+
         # Format as YAML (sorted keys, unicode support)
         if len(cot_items) > 0:
             cot_yaml = yaml.dump(cot_items, allow_unicode=True, sort_keys=True).strip()
         else:
             cot_yaml = ""
-        
+
         return f"<think>\n{cot_yaml}\n</think>"
 
     def generate_with_stop_condition(
@@ -1081,7 +1084,7 @@ class LLMHandler:
 
         - infer_type='dit': Phase 1 only - generate CoT and return metas (no audio codes)
         - infer_type='llm_dit': Phase 1 + Phase 2 - generate CoT then audio codes
-        
+
         Args:
             target_duration: Target duration in seconds for codes generation constraint.
                             5 codes = 1 second. If specified, blocks EOS until target reached.
@@ -1093,7 +1096,7 @@ class LLMHandler:
                        If > 1, returns batch results (lists).
             seeds: Optional list of seeds for batch generation (for reproducibility).
                   Only used when batch_size > 1. TODO: not used yet
-        
+
         Returns:
             Dictionary containing:
                 - metadata: Dict or List[Dict] - Generated metadata
@@ -1116,18 +1119,18 @@ class LLMHandler:
                 "error": error_msg,
                 "extra_outputs": {"time_costs": {}},
             }
-        
+
         # Determine if batch mode
         is_batch = batch_size and batch_size > 1
         actual_batch_size = batch_size if is_batch else 1
-        
+
         # Initialize variables
         metadata = {}
         audio_codes = ""
         has_all_metas = self.has_all_metas(user_metadata)
         phase1_time = 0.0
         phase2_time = 0.0
-        
+
         # Handle seeds for batch mode
         if is_batch:
             if seeds is None:
@@ -1136,7 +1139,7 @@ class LLMHandler:
                 seeds = list(seeds) + [random.randint(0, 2**32 - 1) for _ in range(actual_batch_size - len(seeds))]
             else:
                 seeds = seeds[:actual_batch_size]
-        
+
         # ========== PHASE 1: CoT Generation ==========
         # Skip CoT if all metadata are user-provided OR caption is already formatted
         progress(0.1, f"Phase 1: Generating CoT metadata (once for all items)...")
@@ -1146,10 +1149,10 @@ class LLMHandler:
             else:
                 logger.info("Phase 1: Generating CoT metadata...")
             phase1_start = time.time()
-            
+
             # Build formatted prompt for CoT phase
             formatted_prompt = self.build_formatted_prompt(caption, lyrics, generation_phase="cot")
-            
+
             logger.info(f"generate_with_stop_condition: formatted_prompt={formatted_prompt}")
             # Generate CoT (stop at </think>)
             cot_output_text, status = self.generate_from_formatted_prompt(
@@ -1175,9 +1178,9 @@ class LLMHandler:
                 constrained_decoding_debug=constrained_decoding_debug,
                 stop_at_reasoning=True,  # Always stop at </think> in Phase 1
             )
-            
+
             phase1_time = time.time() - phase1_start
-            
+
             if not cot_output_text:
                 return {
                     "metadata": [] if is_batch else {},
@@ -1186,7 +1189,7 @@ class LLMHandler:
                     "error": status,
                     "extra_outputs": {"time_costs": {"phase1_time": phase1_time}},
                 }
-            
+
             # Parse metadata from CoT output
             metadata, _ = self.parse_lm_output(cot_output_text)
             if is_batch:
@@ -1200,7 +1203,7 @@ class LLMHandler:
             else:
                 logger.info("Phase 1: Using user-provided metadata (skipping generation)")
             metadata = {k: v for k, v in user_metadata.items() if v is not None}
-        
+
         # If infer_type is 'dit', stop here and return only metadata
         if infer_type == "dit":
             if is_batch:
@@ -1230,26 +1233,26 @@ class LLMHandler:
                         }
                     },
                 }
-        
+
         # ========== PHASE 2: Audio Codes Generation ==========
         if is_batch:
             logger.info(f"Batch Phase 2: Generating audio codes for {actual_batch_size} items...")
         else:
             logger.info("Phase 2: Generating audio codes...")
         phase2_start = time.time()
-        
+
         # Format metadata as CoT using YAML (matching training format)
         cot_text = self._format_metadata_as_cot(metadata)
-        
+
         # Build formatted prompt with CoT for codes generation phase
         formatted_prompt_with_cot = self.build_formatted_prompt_with_cot(caption, lyrics, cot_text)
         logger.info(f"generate_with_stop_condition: formatted_prompt_with_cot={formatted_prompt_with_cot}")
-        
+
         progress(0.5, f"Phase 2: Generating audio codes for {actual_batch_size} items...")
         if is_batch:
             # Batch mode: generate codes for all items
             formatted_prompts = [formatted_prompt_with_cot] * actual_batch_size
-            
+
             # Call backend-specific batch generation
             try:
                 if self.llm_backend == "vllm":
@@ -1322,7 +1325,7 @@ class LLMHandler:
                         }
                     },
                 }
-            
+
             # Parse audio codes from each output
             audio_codes_list = []
             metadata_list = []
@@ -1330,13 +1333,13 @@ class LLMHandler:
                 _, audio_codes_item = self.parse_lm_output(output_text)
                 audio_codes_list.append(audio_codes_item)
                 metadata_list.append(metadata.copy())  # Same metadata for all
-            
+
             phase2_time = time.time() - phase2_start
-            
+
             # Log results
             codes_counts = [len(codes.split('<|audio_code_')) - 1 if codes else 0 for codes in audio_codes_list]
             logger.info(f"Batch Phase 2 completed in {phase2_time:.2f}s. Generated codes: {codes_counts}")
-            
+
             total_time = phase1_time + phase2_time
             return {
                 "metadata": metadata_list,
@@ -1378,7 +1381,7 @@ class LLMHandler:
                 constrained_decoding_debug=constrained_decoding_debug,
                 stop_at_reasoning=False,  # Generate codes until EOS
             )
-            
+
             if not codes_output_text:
                 total_time = phase1_time + phase2_time
                 return {
@@ -1394,15 +1397,15 @@ class LLMHandler:
                         }
                     },
                 }
-            
+
             phase2_time = time.time() - phase2_start
-            
+
             # Parse audio codes from output (metadata should be same as Phase 1)
             _, audio_codes = self.parse_lm_output(codes_output_text)
-            
+
             codes_count = len(audio_codes.split('<|audio_code_')) - 1 if audio_codes else 0
             logger.info(f"Phase 2 completed in {phase2_time:.2f}s. Generated {codes_count} audio codes")
-            
+
             total_time = phase1_time + phase2_time
             return {
                 "metadata": metadata,
@@ -1418,7 +1421,7 @@ class LLMHandler:
                     "codes_count": codes_count,
                 },
             }
-    
+
     def build_formatted_prompt(self, caption: str, lyrics: str = "", is_negative_prompt: bool = False, generation_phase: str = "cot", negative_prompt: str = "NO USER INPUT") -> str:
         """
         Build the chat-formatted prompt for 5Hz LM from caption/lyrics.
@@ -1430,18 +1433,18 @@ class LLMHandler:
             is_negative_prompt: If True, builds unconditional prompt for CFG
             generation_phase: "cot" or "codes" - affects unconditional prompt format
             negative_prompt: Negative prompt for CFG (used when is_negative_prompt=True)
-            
+
         Example:
             prompt = handler.build_formatted_prompt("calm piano", "hello world")
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
-        
+
         if is_negative_prompt:
             # Unconditional prompt for CFG
             # Check if user provided a meaningful negative prompt (not the default)
             has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-            
+
             if generation_phase == "cot":
                 # CoT phase unconditional prompt
                 if has_negative_prompt:
@@ -1457,7 +1460,7 @@ class LLMHandler:
         else:
             # Conditional prompt: include both caption and lyrics
             prompt = f"# Caption\n{caption}\n\n# Lyric\n{lyrics}\n"
-        
+
         return self.llm_tokenizer.apply_chat_template(
             [
                 {"role": "system", "content": f"# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n"},
@@ -1466,36 +1469,36 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=True,
         )
-    
+
     def build_formatted_prompt_with_cot(self, caption: str, lyrics: str, cot_text: str, is_negative_prompt: bool = False, negative_prompt: str = "NO USER INPUT") -> str:
         """
         Build the chat-formatted prompt for codes generation phase with pre-generated CoT.
-        
+
         Args:
             caption: Caption text
-            lyrics: Lyrics text  
+            lyrics: Lyrics text
             cot_text: Pre-generated CoT text (e.g., "<think>\\nbpm: 120\\n...\\n</think>")
             is_negative_prompt: If True, uses empty CoT for CFG unconditional prompt
             negative_prompt: Negative prompt for CFG (used when is_negative_prompt=True)
-            
+
         Returns:
             Formatted prompt string
-            
+
         Example:
             cot = "<think>\\nbpm: 120\\ncaption: calm piano\\n...\\n</think>"
             prompt = handler.build_formatted_prompt_with_cot("calm piano", "hello", cot)
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
-        
+
         if is_negative_prompt:
             # Unconditional prompt for codes phase
             # Check if user provided a meaningful negative prompt
             has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-            
+
             # Use empty CoT for unconditional
             cot_for_prompt = "<think>\n</think>"
-            
+
             if has_negative_prompt:
                 # If negative prompt provided, use it as caption
                 caption_for_prompt = negative_prompt
@@ -1506,11 +1509,11 @@ class LLMHandler:
             # Conditional prompt: use the full CoT and original caption
             cot_for_prompt = cot_text
             caption_for_prompt = caption
-        
+
         # Build user prompt with caption and lyrics ONLY (no COT)
         # COT should be in the assistant's message, not user's
         user_prompt = f"# Caption\n{caption_for_prompt}\n\n# Lyric\n{lyrics}\n"
-        
+
         # Build the chat with assistant message containing the COT
         # The model will continue generation after the COT
         formatted = self.llm_tokenizer.apply_chat_template(
@@ -1522,13 +1525,13 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=False,  # Don't add generation prompt, COT is already in assistant
         )
-        
+
         # Add a newline after </think> so model generates audio codes on next line
         if not formatted.endswith('\n'):
             formatted += '\n'
-        
+
         return formatted
-    
+
     def build_formatted_prompt_for_understanding(
         self,
         audio_codes: str,
@@ -1537,31 +1540,31 @@ class LLMHandler:
     ) -> str:
         """
         Build the chat-formatted prompt for audio understanding from codes.
-        
+
         This is the reverse of generation: given audio codes, generate metadata and lyrics.
-        
+
         Args:
             audio_codes: Audio code string (e.g., "<|audio_code_123|><|audio_code_456|>...")
             is_negative_prompt: If True, builds unconditional prompt for CFG
             negative_prompt: Negative prompt for CFG (used when is_negative_prompt=True)
-            
+
         Returns:
             Formatted prompt string
-            
+
         Example:
             codes = "<|audio_code_18953|><|audio_code_13833|>..."
             prompt = handler.build_formatted_prompt_for_understanding(codes)
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
-        
+
         # For understanding task, user provides audio codes
         # Unconditional prompt uses negative_prompt or empty string
         if is_negative_prompt:
             user_content = negative_prompt if negative_prompt and negative_prompt.strip() else ""
         else:
             user_content = audio_codes
-        
+
         return self.llm_tokenizer.apply_chat_template(
             [
                 {
@@ -1576,7 +1579,7 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=True,
         )
-    
+
     def understand_audio_from_codes(
         self,
         audio_codes: str,
@@ -1604,7 +1607,7 @@ class LLMHandler:
             repetition_penalty: Repetition penalty (1.0 = no penalty)
             use_constrained_decoding: Whether to use FSM-based constrained decoding for metadata
             constrained_decoding_debug: Whether to enable debug logging for constrained decoding
-            
+
         Returns:
             Tuple of (metadata_dict, status_message)
             metadata_dict contains:
@@ -1615,7 +1618,7 @@ class LLMHandler:
                 - language: str
                 - timesignature: str
                 - lyrics: str (extracted from output after </think>)
-        
+
         Example:
             codes = "<|audio_code_18953|><|audio_code_13833|>..."
             metadata, status = handler.understand_audio_from_codes(codes)
@@ -1624,12 +1627,12 @@ class LLMHandler:
         """
         if not getattr(self, "llm_initialized", False):
             return {}, "❌ 5Hz LM not initialized. Please initialize it first."
-        
+
         if not audio_codes or not audio_codes.strip():
             return {}, "❌ No audio codes provided. Please paste audio codes first."
-        
+
         logger.info(f"Understanding audio codes (length: {len(audio_codes)} chars)")
-        
+
         # Build formatted prompt for understanding
         formatted_prompt = self.build_formatted_prompt_for_understanding(audio_codes)
         print(f"formatted_prompt: {formatted_prompt}")
@@ -1657,64 +1660,64 @@ class LLMHandler:
             constrained_decoding_debug=constrained_decoding_debug,
             stop_at_reasoning=False,  # Continue after </think> to generate lyrics
         )
-        
+
         if not output_text:
             return {}, status
-        
+
         # Parse metadata and extract lyrics
         metadata, _ = self.parse_lm_output(output_text)
-        
+
         # Extract lyrics section (everything after </think>)
         lyrics = self._extract_lyrics_from_output(output_text)
         if lyrics:
             metadata['lyrics'] = lyrics
-        
+
         logger.info(f"Understanding completed. Generated {len(metadata)} metadata fields")
         if constrained_decoding_debug:
             logger.debug(f"Generated metadata: {list(metadata.keys())}")
             logger.debug(f"Output text preview: {output_text[:200]}...")
-        
+
         status_msg = f"✅ Understanding completed successfully\nGenerated fields: {', '.join(metadata.keys())}"
         return metadata, status_msg
-    
+
     def _extract_lyrics_from_output(self, output_text: str) -> str:
         """
         Extract lyrics section from LLM output.
-        
+
         The lyrics appear after the </think> tag and typically start with "# Lyric"
         or directly with lyric content.
-        
+
         Args:
             output_text: Full LLM output text
-            
+
         Returns:
             Extracted lyrics string, or empty string if no lyrics found
         """
         import re
-        
+
         # Find the </think> tag
         think_end_pattern = r'</think>'
         match = re.search(think_end_pattern, output_text)
-        
+
         if not match:
             # No </think> tag found, no lyrics
             return ""
-        
+
         # Extract everything after </think>
         after_think = output_text[match.end():].strip()
-        
+
         if not after_think:
             return ""
-        
+
         # Remove "# Lyric" header if present
         lyric_header_pattern = r'^#\s*Lyri[c|cs]?\s*\n'
         after_think = re.sub(lyric_header_pattern, '', after_think, flags=re.IGNORECASE)
-        
+
         # Remove <|im_end|> tag at the end if present
         after_think = re.sub(r'<\|im_end\|>\s*$', '', after_think)
-        
+
         return after_think.strip()
-    
+
     def build_formatted_prompt_for_inspiration(
         self,
         query: str,
@@ -1724,36 +1727,36 @@ class LLMHandler:
     ) -> str:
         """
         Build the chat-formatted prompt for inspiration/simple mode.
-        
+
         This generates a complete sample (caption, lyrics, metadata) from a user's
         natural language music description query.
-        
+
         Args:
             query: User's natural language music description
             instrumental: Whether to generate instrumental music (no vocals)
             is_negative_prompt: If True, builds unconditional prompt for CFG
             negative_prompt: Negative prompt for CFG (used when is_negative_prompt=True)
-            
+
         Returns:
             Formatted prompt string
-            
+
         Example:
             query = "a soft Bengali love song for a quiet evening"
             prompt = handler.build_formatted_prompt_for_inspiration(query, instrumental=False)
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
-        
+
         # Build user content with query and instrumental flag
         instrumental_str = "true" if instrumental else "false"
-        
+
         if is_negative_prompt:
             # For CFG unconditional prompt
             user_content = negative_prompt if negative_prompt and negative_prompt.strip() else ""
         else:
             # Normal prompt: query + instrumental flag
             user_content = f"{query}\n\ninstrumental: {instrumental_str}"
-        
+
         return self.llm_tokenizer.apply_chat_template(
             [
                 {
@@ -1768,7 +1771,7 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=True,
         )
-    
+
     def create_sample_from_query(
         self,
         query: str,
@@ -1783,11 +1786,11 @@ class LLMHandler:
     ) -> Tuple[Dict[str, Any], str]:
         """
         Create a complete music sample from a user's natural language query.
-        
+
         This is the "Simple Mode" / "Inspiration Mode" feature that generates:
         - Metadata (bpm, caption, duration, keyscale, language, timesignature)
         - Lyrics (unless instrumental=True)
-        
+
         Args:
             query: User's natural language music description
             instrumental: Whether to generate instrumental music (no vocals)
@@ -1799,7 +1802,7 @@ class LLMHandler:
             repetition_penalty: Repetition penalty (1.0 = no penalty)
             use_constrained_decoding: Whether to use FSM-based constrained decoding
             constrained_decoding_debug: Whether to enable debug logging
-            
+
         Returns:
             Tuple of (metadata_dict, status_message)
             metadata_dict contains:
@@ -1811,7 +1814,7 @@ class LLMHandler:
                 - timesignature: str
                 - lyrics: str (extracted from output after </think>)
                 - instrumental: bool (echoed back)
-        
+
         Example:
             query = "a soft Bengali love song for a quiet evening"
             metadata, status = handler.create_sample_from_query(query, instrumental=False, vocal_language="bn")
@@ -1820,19 +1823,19 @@ class LLMHandler:
         """
         if not getattr(self, "llm_initialized", False):
             return {}, "❌ 5Hz LM not initialized. Please initialize it first."
-        
+
         if not query or not query.strip():
             query = "NO USER INPUT"
-        
+
         logger.info(f"Creating sample from query: {query[:100]}... (instrumental={instrumental}, vocal_language={vocal_language})")
-        
+
         # Build formatted prompt for inspiration
         formatted_prompt = self.build_formatted_prompt_for_inspiration(
             query=query,
             instrumental=instrumental,
         )
         logger.debug(f"Formatted prompt for inspiration: {formatted_prompt}")
-        
+
         # Build user_metadata if vocal_language is specified and is not "unknown"
         user_metadata = None
         skip_language = False
@@ -1841,7 +1844,7 @@ class LLMHandler:
             user_metadata = {"language": vocal_language.strip()}
             # skip_language = True  # Skip language generation since we're injecting it
             logger.info(f"Using user-specified language: {vocal_language.strip()}")
-        
+
         # Generate using constrained decoding (inspiration phase)
         # Similar to understand mode - generate metadata first (CoT), then lyrics
         # Note: cfg_scale and negative_prompt are not used in create_sample mode
@@ -1865,13 +1868,13 @@ class LLMHandler:
             constrained_decoding_debug=constrained_decoding_debug,
             stop_at_reasoning=False,  # Continue after </think> to generate lyrics
         )
-        
+
         if not output_text:
             return {}, status
-        
+
         # Parse metadata and extract lyrics
         metadata, _ = self.parse_lm_output(output_text)
-        
+
         # Extract lyrics section (everything after </think>)
         lyrics = self._extract_lyrics_from_output(output_text)
         if lyrics:
@@ -1879,18 +1882,18 @@ class LLMHandler:
         elif instrumental:
             # For instrumental, set empty lyrics or placeholder
             metadata['lyrics'] = "[Instrumental]"
-        
+
         # Echo back the instrumental flag
         metadata['instrumental'] = instrumental
-        
+
         logger.info(f"Sample created successfully. Generated {metadata} fields")
         if constrained_decoding_debug:
             logger.debug(f"Generated metadata: {list(metadata.keys())}")
             logger.debug(f"Output text preview: {output_text[:300]}...")
-        
+
         status_msg = f"✅ Sample created successfully\nGenerated fields: {metadata}"
         return metadata, status_msg
-    
+
     def build_formatted_prompt_for_format(
         self,
         caption: str,
@@ -1900,19 +1903,19 @@ class LLMHandler:
     ) -> str:
         """
         Build the chat-formatted prompt for format/rewrite mode.
-        
+
         This formats user-provided caption and lyrics into a more detailed and specific
         musical description with metadata.
-        
+
         Args:
             caption: User's caption/description of the music
             lyrics: User's lyrics
             is_negative_prompt: If True, builds unconditional prompt for CFG
             negative_prompt: Negative prompt for CFG (used when is_negative_prompt=True)
-            
+
         Returns:
             Formatted prompt string
-            
+
         Example:
             caption = "Latin pop, reggaeton, flamenco-pop"
             lyrics = "[Verse 1]\\nTengo un nudo..."
@@ -1920,14 +1923,14 @@ class LLMHandler:
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
-        
+
         if is_negative_prompt:
             # For CFG unconditional prompt
             user_content = negative_prompt if negative_prompt and negative_prompt.strip() else ""
         else:
             # Normal prompt: caption + lyrics
             user_content = f"# Caption\n{caption}\n\n# Lyric\n{lyrics}"
-        
+
         return self.llm_tokenizer.apply_chat_template(
             [
                 {
@@ -1942,7 +1945,7 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=True,
         )
-    
+
     def format_sample_from_input(
         self,
         caption: str,
@@ -1957,14 +1960,14 @@ class LLMHandler:
     ) -> Tuple[Dict[str, Any], str]:
         """
         Format user-provided caption and lyrics into structured music metadata.
-        
+
         This is the "Format" feature that takes user input and generates:
         - Enhanced caption with detailed music description
         - Metadata (bpm, duration, keyscale, language, timesignature)
         - Formatted lyrics (preserved from input)
-        
+
         Note: cfg_scale and negative_prompt are not supported in format mode.
-        
+
         Args:
             caption: User's caption/description (e.g., "Latin pop, reggaeton")
             lyrics: User's lyrics with structure tags
@@ -1976,7 +1979,7 @@ class LLMHandler:
             repetition_penalty: Repetition penalty (1.0 = no penalty)
             use_constrained_decoding: Whether to use FSM-based constrained decoding
             constrained_decoding_debug: Whether to enable debug logging
-            
+
         Returns:
             Tuple of (metadata_dict, status_message)
             metadata_dict contains:
@@ -1987,7 +1990,7 @@ class LLMHandler:
                 - language: str
                 - timesignature: str
                 - lyrics: str (from input, possibly formatted)
-        
+
         Example:
             caption = "Latin pop, reggaeton, flamenco-pop"
             lyrics = "[Verse 1]\\nTengo un nudo en la garganta..."
@@ -1997,21 +2000,21 @@ class LLMHandler:
         """
         if not getattr(self, "llm_initialized", False):
             return {}, "❌ 5Hz LM not initialized. Please initialize it first."
-        
+
         if not caption or not caption.strip():
             caption = "NO USER INPUT"
         if not lyrics or not lyrics.strip():
             lyrics = "[Instrumental]"
-        
+
         logger.info(f"Formatting sample from input: caption={caption[:50]}..., lyrics length={len(lyrics)}")
-        
+
         # Build formatted prompt for format task
         formatted_prompt = self.build_formatted_prompt_for_format(
             caption=caption,
             lyrics=lyrics,
         )
         logger.debug(f"Formatted prompt for format: {formatted_prompt}")
-        
+
         # Build constrained decoding metadata from user_metadata
         constrained_metadata = None
         if user_metadata:
@@ -2036,13 +2039,13 @@ class LLMHandler:
                 constrained_metadata['timesignature'] = user_metadata['timesignature']
             if user_metadata.get('language'):
                 constrained_metadata['language'] = user_metadata['language']
-            
+
             # Only use if we have at least one field
             if not constrained_metadata:
                 constrained_metadata = None
             else:
                 logger.info(f"Using user-provided metadata constraints: {constrained_metadata}")
-        
+
         # Generate using constrained decoding (format phase)
         # Similar to understand/inspiration mode - generate metadata first (CoT), then formatted lyrics
         # Note: cfg_scale and negative_prompt are not used in format mode
@@ -2066,13 +2069,13 @@ class LLMHandler:
             constrained_decoding_debug=constrained_decoding_debug,
             stop_at_reasoning=False,  # Continue after </think> to get formatted lyrics
         )
-        
+
         if not output_text:
             return {}, status
-        
+
         # Parse metadata and extract lyrics
         metadata, _ = self.parse_lm_output(output_text)
-        
+
         # Extract formatted lyrics section (everything after </think>)
         formatted_lyrics = self._extract_lyrics_from_output(output_text)
         if formatted_lyrics:
@@ -2080,15 +2083,15 @@ class LLMHandler:
         else:
             # If no lyrics generated, keep original input
             metadata['lyrics'] = lyrics
-        
+
         logger.info(f"Format completed successfully. Generated {metadata} fields")
         if constrained_decoding_debug:
             logger.debug(f"Generated metadata: {list(metadata.keys())}")
             logger.debug(f"Output text preview: {output_text[:300]}...")
-        
+
         status_msg = f"✅ Format completed successfully\nGenerated fields: {', '.join(metadata.keys())}"
         return metadata, status_msg
-    
+
     def generate_from_formatted_prompt(
         self,
         formatted_prompt: str,
@@ -2252,7 +2255,7 @@ class LLMHandler:
                 torch.mps.empty_cache()
                 torch.mps.synchronize()
             return "", f"❌ Error generating from formatted prompt: {type(e).__name__}: {e or error_detail.splitlines()[-1]}"
-    
+
     def _generate_with_constrained_decoding(
         self,
         input_ids: torch.Tensor,
@@ -2272,80 +2275,80 @@ class LLMHandler:
         """
         model = self.llm
         device = self.device
-        
+
         # Initialize generated sequences
         generated_ids = input_ids.clone()
         if attention_mask is not None:
             attn_mask = attention_mask.clone()
         else:
             attn_mask = torch.ones_like(input_ids)
-        
+
         # Prepare model inputs
         model_kwargs = {'attention_mask': attn_mask}
-        
+
         # Past key values for KV cache
         past_key_values = None
         use_cache = hasattr(model, 'generation_config') and getattr(model.generation_config, 'use_cache', True)
-        
+
         # Get EOS token ID
         eos_token_id = self.llm_tokenizer.eos_token_id
         if eos_token_id is None:
             eos_token_id = pad_token_id
-        
+
         # Build logits processor for repetition penalty
         logits_processor = self._build_logits_processor(repetition_penalty)
-        
+
         with torch.inference_mode():
             for step in tqdm(range(max_new_tokens), desc="LLM Constrained Decoding", unit="token", disable=self.disable_tqdm):
                 # Forward pass
                 outputs = self._forward_pass(model, generated_ids, model_kwargs, past_key_values, use_cache)
-                
+
                 # Get logits for the last position
                 next_token_logits = outputs.logits[:, -1, :]  # [batch_size, vocab_size]
-                
+
                 # Apply constrained processor FIRST (modifies logits based on FSM state)
                 if constrained_processor is not None:
                     next_token_logits = constrained_processor(generated_ids, next_token_logits)
-                
+
                 # Apply other logits processors (repetition penalty)
                 for processor in logits_processor:
                     next_token_logits = processor(generated_ids, next_token_logits)
-                
+
                 # Apply top-k and top-p filtering
                 next_token_logits = self._apply_top_k_filter(next_token_logits, top_k)
                 next_token_logits = self._apply_top_p_filter(next_token_logits, top_p)
-                
+
                 # Apply temperature and sample
                 next_tokens = self._sample_tokens(next_token_logits, temperature)
-                
+
                 # Update constrained processor state
                 self._update_constrained_processor_state(constrained_processor, next_tokens)
-                
+
                 # Check for EOS token
                 should_stop = self._check_eos_token(next_tokens, eos_token_id, pad_token_id)
-                
+
                 # Append token to sequence
                 next_tokens_unsqueezed = next_tokens.unsqueeze(1)
                 generated_ids = torch.cat([generated_ids, next_tokens_unsqueezed], dim=1)
                 attn_mask = torch.cat([attn_mask, torch.ones((input_ids.shape[0], 1), device=device, dtype=attn_mask.dtype)], dim=1)
                 model_kwargs['attention_mask'] = attn_mask
-                
+
                 # Update KV cache
                 if use_cache and hasattr(outputs, 'past_key_values'):
                     past_key_values = outputs.past_key_values
-                
+
                 # Update streamer
                 if streamer is not None:
                     streamer.put(next_tokens_unsqueezed)
-                
+
                 if should_stop:
                     break
-        
+
         if streamer is not None:
             streamer.end()
-        
+
         return generated_ids
-    
+
     def _generate_with_cfg_custom(
         self,
         batch_input_ids: torch.Tensor,
@@ -2367,7 +2370,7 @@ class LLMHandler:
         3. Samples tokens only for conditional sequences
         4. Applies the same sampled tokens to both conditional and unconditional sequences
         5. Optionally applies constrained decoding via FSM-based logits processor
-        
+
         Batch format: [cond_input, uncond_input]
         """
         model = self.llm
@@ -2375,102 +2378,102 @@ class LLMHandler:
         batch_size = batch_input_ids.shape[0] // 2  # Half are conditional, half are unconditional
         cond_start_idx = 0
         uncond_start_idx = batch_size
-        
+
         # Initialize generated sequences
         generated_ids = batch_input_ids.clone()
         if batch_attention_mask is not None:
             attention_mask = batch_attention_mask.clone()
         else:
             attention_mask = torch.ones_like(batch_input_ids)
-        
+
         # Prepare model inputs
         model_kwargs = {}
         if batch_attention_mask is not None:
             model_kwargs['attention_mask'] = attention_mask
-        
+
         # Past key values for KV cache (if model supports it)
         past_key_values = None
         use_cache = hasattr(model, 'generation_config') and getattr(model.generation_config, 'use_cache', True)
-        
+
         # Get EOS token ID for stopping condition
         eos_token_id = self.llm_tokenizer.eos_token_id
         if eos_token_id is None:
             eos_token_id = pad_token_id
-        
+
         # Build logits processor for non-CFG operations (repetition penalty, top_k, top_p)
         logits_processor = self._build_logits_processor(repetition_penalty)
-        
+
         with torch.inference_mode():
             for step in tqdm(range(max_new_tokens), desc="LLM CFG Generation", unit="token", disable=self.disable_tqdm):
                 # Forward pass for the entire batch (conditional + unconditional)
                 outputs = self._forward_pass(model, generated_ids, model_kwargs, past_key_values, use_cache)
-                
+
                 # Get logits for the last position
                 next_token_logits = outputs.logits[:, -1, :]  # [batch_size*2, vocab_size]
-                
+
                 # Split conditional and unconditional logits
                 cond_logits = next_token_logits[cond_start_idx:cond_start_idx+batch_size]
                 uncond_logits = next_token_logits[uncond_start_idx:uncond_start_idx+batch_size]
-                
+
                 # Apply CFG formula: cfg_logits = uncond_logits + cfg_scale * (cond_logits - uncond_logits)
                 # Upcast to float32 to prevent overflow in float16 (CFG scaling can exceed fp16 range)
                 cfg_logits = uncond_logits.float() + cfg_scale * (cond_logits.float() - uncond_logits.float())
-                
+
                 # Apply constrained processor FIRST (modifies logits based on FSM state)
                 if constrained_processor is not None:
                     current_input_ids = generated_ids[cond_start_idx:cond_start_idx+batch_size]
                     cfg_logits = constrained_processor(current_input_ids, cfg_logits)
-                
+
                 # Apply logits processors (repetition penalty, top-k, top-p)
                 # Get current input_ids for repetition penalty (only conditional part)
                 current_input_ids = generated_ids[cond_start_idx:cond_start_idx+batch_size]
                 for processor in logits_processor:
                     cfg_logits = processor(current_input_ids, cfg_logits)
-                
+
                 # Apply top-k and top-p filtering
                 cfg_logits = self._apply_top_k_filter(cfg_logits, top_k)
                 cfg_logits = self._apply_top_p_filter(cfg_logits, top_p)
-                
+
                 # Apply temperature and sample
                 next_tokens = self._sample_tokens(cfg_logits, temperature)
-                
+
                 # Update constrained processor state AFTER sampling
                 self._update_constrained_processor_state(constrained_processor, next_tokens)
-                
+
                 # Check for EOS token in conditional sequences BEFORE unsqueezing
                 # Stop if any conditional sequence generates EOS token
                 # next_tokens shape: [batch_size] (only conditional tokens)
                 should_stop = self._check_eos_token(next_tokens, eos_token_id, pad_token_id)
-                
+
                 # Apply the same sampled tokens to both conditional and unconditional sequences
                 next_tokens_unsqueezed = next_tokens.unsqueeze(1)
                 generated_ids = torch.cat([generated_ids, next_tokens_unsqueezed.repeat(2, 1)], dim=1)
                 attention_mask = torch.cat([attention_mask, torch.ones((batch_size*2, 1), device=device, dtype=attention_mask.dtype)], dim=1)
                 model_kwargs['attention_mask'] = attention_mask
-                
+
                 # Update past_key_values for next iteration
                 if use_cache and hasattr(outputs, 'past_key_values'):
                     past_key_values = outputs.past_key_values
-                
+
                 # Update streamer
                 if streamer is not None:
                     streamer.put(next_tokens_unsqueezed)  # Stream conditional tokens
-                
+
                 # Stop generation if EOS token detected
                 if should_stop:
                     break
-        
+
         if streamer is not None:
             streamer.end()
-        
+
         # Return the full batch (both conditional and unconditional)
         # The caller will extract only the conditional output
         return generated_ids
-    
+
     def parse_lm_output(self, output_text: str) -> Tuple[Dict[str, Any], str]:
         """
         Parse LM output to extract metadata and audio codes.
-        
+
         Expected format:
         <think>
         bpm: 73
@@ -2481,9 +2484,9 @@ class LLMHandler:
         language: en
         timesignature: 4
         </think>
-        
+
         <|audio_code_56535|><|audio_code_62918|>...
-        
+
         Returns:
             Tuple of (metadata_dict, audio_codes_string)
         """
@@ -2491,15 +2494,15 @@ class LLMHandler:
         logger.debug(f"Debug output text: {debug_output_text}")
         metadata = {}
         audio_codes = ""
-        
+
         import re
-        
+
         # Extract audio codes - find all <|audio_code_XXX|> patterns
         code_pattern = r'<\|audio_code_\d+\|>'
         code_matches = re.findall(code_pattern, output_text)
         if code_matches:
             audio_codes = "".join(code_matches)
-        
+
         # Extract metadata from reasoning section
         # Try different reasoning tag patterns
         reasoning_patterns = [
@@ -2507,33 +2510,33 @@ class LLMHandler:
             r'<think>(.*?)</think>',
             r'<reasoning>(.*?)</reasoning>',
         ]
-        
+
         reasoning_text = None
         for pattern in reasoning_patterns:
             match = re.search(pattern, output_text, re.DOTALL)
             if match:
                 reasoning_text = match.group(1).strip()
                 break
-        
+
         # If no reasoning tags found, try to parse metadata from the beginning of output
         if not reasoning_text:
             # Look for metadata lines before audio codes
             lines_before_codes = output_text.split('<|audio_code_')[0] if '<|audio_code_' in output_text else output_text
             reasoning_text = lines_before_codes.strip()
-        
+
         # Parse metadata fields with YAML multi-line value support
         if reasoning_text:
             lines = reasoning_text.split('\n')
             current_key = None
             current_value_lines = []
-            
+
             def save_current_field():
                 """Save the accumulated field value"""
                 nonlocal current_key, current_value_lines
                 if current_key and current_value_lines:
                     # Join multi-line value
                     value = '\n'.join(current_value_lines)
-                    
+
                     if current_key == 'bpm':
                         try:
                             metadata['bpm'] = int(value.strip())
@@ -2555,20 +2558,20 @@ class LLMHandler:
                         metadata['language'] = value.strip()
                     elif current_key == 'timesignature':
                         metadata['timesignature'] = value.strip()
-                
+
                 current_key = None
                 current_value_lines = []
-            
+
             for line in lines:
                 # Skip lines starting with '<' (tags)
                 if line.strip().startswith('<'):
                     continue
-                
+
                 # Check if this is a new field (no leading spaces and contains ':')
                 if line and not line[0].isspace() and ':' in line:
                     # Save previous field if any
                     save_current_field()
-                    
+
                     # Parse new field
                     parts = line.split(':', 1)
                     if len(parts) == 2:
@@ -2581,12 +2584,12 @@ class LLMHandler:
                     # Continuation line (YAML multi-line value)
                     if current_key:
                         current_value_lines.append(line)
-            
+
             # Don't forget to save the last field
             save_current_field()
-        
+
         return metadata, audio_codes
-    
+
     # =========================================================================
     # MLX Backend Methods (Apple Silicon native acceleration)
     # =========================================================================
@@ -2604,10 +2607,10 @@ class LLMHandler:
     def _load_mlx_model(self, model_path: str) -> Tuple[bool, str]:
         """
         Load the 5Hz LM model using mlx-lm for native Apple Silicon acceleration.
-        
+
         Args:
             model_path: Path to the HuggingFace model directory
-            
+
         Returns:
             Tuple of (success, status_message)
         """
@@ -3783,17 +3786,29 @@ class LLMHandler:
         if not self.offload_to_cpu:
             yield
             return
-        
+
         # If using nanovllm or MLX, do not offload (managed differently)
         if self.llm_backend in ("vllm", "mlx"):
             yield
             return
-        
+
         model = self.llm
         if model is None:
             yield
             return
-        
+
+        # Reentrancy guard: if an outer context already loaded the model
+        # to the target device, skip the inner load/offload to avoid
+        # redundant CPU↔GPU transfers during batch processing.
+        try:
+            current_device = next(model.parameters()).device.type
+        except StopIteration:
+            current_device = None
+        target_device = str(self.device).split(":")[0]
+        if current_device == target_device:
+            yield
+            return
+
         # Load to GPU
         logger.info(f"Loading LLM to {self.device}")
         start_time = time.time()
@@ -3819,32 +3834,32 @@ class LLMHandler:
                 torch.mps.empty_cache()
             offload_time = time.time() - start_time
             logger.info(f"Offloaded LLM to CPU in {offload_time:.4f}s")
-    
+
     def get_hf_model_for_scoring(self):
         """
         Get HuggingFace model for perplexity scoring.
-        
+
         For vllm backend, loads HuggingFace model from disk (weights are cached by transformers).
         For pt backend, returns the existing model.
         For mlx backend, loads HuggingFace model from disk (MLX model can't be used for torch scoring).
-        
+
         Returns:
             HuggingFace model instance
         """
         if self.llm_backend == "pt":
             # For PyTorch backend, directly return the model
             return self.llm
-        
+
         elif self.llm_backend == "vllm":
             # For vllm backend, load HuggingFace model from disk
             # Note: transformers caches model weights, so this doesn't duplicate disk I/O
             if self._hf_model_for_scoring is None:
                 logger.info("Loading HuggingFace model for scoring (from checkpoint)")
-                
+
                 # Get model path from vllm config
                 model_runner = self.llm.model_runner
                 model_path = model_runner.config.model
-                
+
                 # Load HuggingFace model from the same checkpoint
                 # This will load the original unfused weights
                 import time
@@ -3856,7 +3871,7 @@ class LLMHandler:
                 )
                 load_time = time.time() - start_time
                 logger.info(f"HuggingFace model loaded in {load_time:.2f}s")
-                
+
                 # When offload_to_cpu is enabled, keep the model on CPU to save
                 # VRAM.  The caller (_load_scoring_model_context in
                 # test_time_scaling.py) will move it to the accelerator only for
@@ -3869,19 +3884,19 @@ class LLMHandler:
                     self._hf_model_for_scoring = self._hf_model_for_scoring.to(device)
                     self._hf_model_for_scoring.eval()
                     logger.info(f"HuggingFace model for scoring ready on {device}")
-            
+
             return self._hf_model_for_scoring
-        
+
         elif self.llm_backend == "mlx":
             # For MLX backend, load HuggingFace model from disk for PyTorch scoring
             if self._hf_model_for_scoring is None:
                 logger.info("Loading HuggingFace model for scoring (MLX backend, need PyTorch model)")
-                
+
                 # Get model path from stored path
                 model_path = getattr(self, '_mlx_model_path', None)
                 if model_path is None:
                     raise ValueError("MLX model path not stored. Cannot load HuggingFace model for scoring.")
-                
+
                 import time
                 start_time = time.time()
                 self._hf_model_for_scoring = AutoModelForCausalLM.from_pretrained(
@@ -3891,7 +3906,7 @@ class LLMHandler:
                 )
                 load_time = time.time() - start_time
                 logger.info(f"HuggingFace model loaded in {load_time:.2f}s")
-                
+
                 # When offload_to_cpu is enabled, keep on CPU; the scoring
                 # context manager will move it to the accelerator as needed.
                 if self.offload_to_cpu:
@@ -3902,8 +3917,8 @@ class LLMHandler:
                     self._hf_model_for_scoring = self._hf_model_for_scoring.to(device)
                     self._hf_model_for_scoring.eval()
                     logger.info(f"HuggingFace model for scoring ready on {device}")
-            
+
             return self._hf_model_for_scoring
-        
+
         else:
             raise ValueError(f"Unknown backend: {self.llm_backend}")

--- a/tests/test_load_model_context_reentrant.py
+++ b/tests/test_load_model_context_reentrant.py
@@ -1,0 +1,168 @@
+"""Tests for _load_model_context reentrancy and batch load/offload behaviour.
+
+Background (perf regression):
+    When using the PyTorch backend with offload_to_cpu=True and batch > 1,
+    each batch item triggered a full LLM load (CPU→GPU) and offload (GPU→CPU)
+    cycle inside _run_pt_single.  For batch=4 this added ~6 seconds of pure
+    model-transfer overhead (4 loads + 4 offloads instead of 1+1) and prevented
+    the GPU from staying warm between items.
+
+Fix:
+    1. _load_model_context() was made *reentrant*: if the model is already on
+       the target device it yields immediately without loading or offloading.
+    2. _run_pt() wraps the entire batch loop in a single _load_model_context()
+       call.  The per-item calls inside _run_pt_single become no-ops.
+
+These tests verify that the reentrancy guard works correctly and that batch
+mode triggers exactly one load/offload cycle regardless of batch size.
+"""
+import unittest
+from unittest.mock import MagicMock
+import torch
+
+from acestep.llm_inference import LLMHandler
+
+
+class _FakeParam:
+    """Minimal stand-in for a model parameter with a device attribute."""
+
+    def __init__(self, device_type: str = "cpu"):
+        self.device = torch.device(device_type)
+
+
+class _FakeModel:
+    """Minimal model stub that tracks .to() calls."""
+
+    def __init__(self, device_type: str = "cpu"):
+        self._device_type = device_type
+        self.to_calls = []
+
+    def parameters(self):
+        yield _FakeParam(self._device_type)
+
+    def to(self, target, *args, **kwargs):
+        self.to_calls.append(str(target))
+        if isinstance(target, str):
+            self._device_type = target.split(":")[0]
+        return self
+
+
+class TestLoadModelContextReentrancy(unittest.TestCase):
+    """Verify _load_model_context is reentrant (no redundant load/offload).
+
+    Reentrancy is critical for performance: when an outer caller (e.g. the
+    batch loop in _run_pt) already holds the model on the GPU, inner callers
+    (_run_pt_single) must *not* offload and reload it.  Without reentrancy
+    each batch item pays ~1.5 s of model transfer overhead.
+    """
+
+    def _make_handler(self, device="cuda"):
+        handler = LLMHandler.__new__(LLMHandler)
+        handler.offload_to_cpu = True
+        handler.device = device
+        handler.dtype = torch.float32
+        handler.llm_backend = "pt"
+        handler.llm = _FakeModel("cpu")
+        return handler
+
+    def test_single_entry_loads_and_offloads(self):
+        handler = self._make_handler()
+        with handler._load_model_context():
+            self.assertEqual(handler.llm._device_type, "cuda")
+        self.assertEqual(handler.llm._device_type, "cpu")
+        # .to(device).to(dtype) on load, then .to("cpu") on offload
+        self.assertEqual(handler.llm.to_calls, ["cuda", "torch.float32", "cpu"])
+
+    def test_reentrant_skips_inner_load_offload(self):
+        """Inner context must be a no-op when model is already on device."""
+        handler = self._make_handler()
+        with handler._load_model_context():
+            handler.llm.to_calls.clear()  # reset after outer load
+            with handler._load_model_context():
+                # Inner should NOT have called .to()
+                self.assertEqual(handler.llm.to_calls, [])
+                self.assertEqual(handler.llm._device_type, "cuda")
+            # After inner exits, model must still be on cuda (no offload)
+            self.assertEqual(handler.llm.to_calls, [])
+            self.assertEqual(handler.llm._device_type, "cuda")
+        # After outer exits, model offloaded
+        self.assertEqual(handler.llm._device_type, "cpu")
+
+    def test_offload_disabled_is_noop(self):
+        handler = self._make_handler()
+        handler.offload_to_cpu = False
+        handler.llm = _FakeModel("cpu")
+        with handler._load_model_context():
+            self.assertEqual(handler.llm.to_calls, [])
+
+    def test_vllm_backend_is_noop(self):
+        handler = self._make_handler()
+        handler.llm_backend = "vllm"
+        handler.llm = _FakeModel("cpu")
+        with handler._load_model_context():
+            self.assertEqual(handler.llm.to_calls, [])
+
+
+class TestRunPtBatchSingleLoadOffload(unittest.TestCase):
+    """Verify _run_pt batch mode wraps the loop in one _load_model_context.
+
+    Performance context:
+        Before the fix, batch=N caused N separate load→generate→offload cycles.
+        Each load/offload pair costs ~1.5 s on a typical GPU, so batch=4 wasted
+        ~6 s on model transfers alone.  After the fix the model loads once before
+        the loop and offloads once after, reducing transfer overhead to ~1.5 s
+        regardless of batch size.
+    """
+
+    def test_batch_triggers_single_load_offload(self):
+        """With batch=3, _load_model_context should be entered once (outer),
+        and _run_pt_single's inner calls should be no-ops due to reentrancy."""
+        handler = LLMHandler.__new__(LLMHandler)
+        handler.offload_to_cpu = True
+        handler.device = "cuda"
+        handler.dtype = torch.float32
+        handler.llm_backend = "pt"
+        handler.llm = _FakeModel("cpu")
+        handler.llm_tokenizer = MagicMock()
+        handler.disable_tqdm = True
+        handler.constrained_processor = None
+        handler.max_model_len = 4096
+
+        # Patch _run_pt_single to avoid actual generation but still exercise
+        # the context manager reentrancy.
+        call_count = {"n": 0}
+        original_device_types = []
+
+        def fake_run_pt_single(**kwargs):
+            call_count["n"] += 1
+            # Record device at call time to prove model is on GPU
+            original_device_types.append(handler.llm._device_type)
+            return f"output_{call_count['n']}"
+
+        handler._run_pt_single = fake_run_pt_single
+
+        prompts = ["prompt_a", "prompt_b", "prompt_c"]
+        results = handler._run_pt(
+            formatted_prompts=prompts,
+            temperature=0.8,
+            cfg_scale=1.0,
+            negative_prompt="",
+            top_k=None,
+            top_p=None,
+            repetition_penalty=1.0,
+        )
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(call_count["n"], 3)
+        # Each call should have seen the model on cuda
+        self.assertEqual(original_device_types, ["cuda", "cuda", "cuda"])
+        # After batch completes, model should be back on cpu
+        self.assertEqual(handler.llm._device_type, "cpu")
+        # Total .to() calls: 1 load (cuda) + 1 offload (cpu) = 2
+        to_calls = [c for c in handler.llm.to_calls if c in ("cuda", "cpu")]
+        self.assertEqual(to_calls.count("cuda"), 1, "Model should load to cuda exactly once")
+        self.assertEqual(to_calls.count("cpu"), 1, "Model should offload to cpu exactly once")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When using the PyTorch backend with offload_to_cpu=True and batch > 1, the LLM was loaded to GPU and offloaded back to CPU for every batch item. With batch=4 this caused 4 load + 4 offload cycles (~6s overhead).

Changes:
- Make _load_model_context() reentrant: skip load/offload if model is already on the target device (reentrancy guard).
- Wrap _run_pt() batch loop in a single _load_model_context() call so the model loads once before the loop and offloads once after.
- Add tests/test_load_model_context_reentrant.py (5 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized model loading during batch processing to eliminate redundant GPU memory transfers, resulting in improved processing speed and reduced latency across all iterations. The model now remains on the target device throughout the batch lifecycle.

* **Tests**
  * Added comprehensive test coverage to validate batch processing optimizations and memory management efficiency improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->