### PR TITLE
Doc only: Give coderabbit explicit guidance on module loc limits.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ This document is aligned with the intent from:
 
 - Prefer single-responsibility modules with clear boundaries.
 - Target module size:
-  - Optimal: `<= 150` LOC
+  - Optimal: `<= 150` LOC @coderabbit: Exceeding this limit is NIGGLE, not hard cap or major issue. 
   - Hard cap: `200` LOC
 - Function decomposition rules:
   - Do one thing at a time; if a function description naturally contains "and", split it.


### PR DESCRIPTION
## Summary
- Clarifies reviewer guidance in `AGENTS.md` for module size policy.
- Explicitly marks the `<= 150 LOC` target as a *niggle* when exceeded, not a hard-fail condition.

---

## What Changed
- Updated one line under **Decomposition and Module Size Policy**:
  - "Optimal: <= 150 LOC" now includes explicit guidance that exceeding this target should be treated as minor review feedback.
  - The hard cap remains `<= 200 LOC`.

---

## Why
- Reduces over-enforcement of the soft target during automated review.
- Keeps review focus on the hard cap and real functional risk, consistent with project intent.

---

## Scope
- Docs-only change (`AGENTS.md`)
- No runtime or code-path impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidelines documentation with clarification that exceeding module size targets is permissible for non-critical cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->