### PR TITLE
fix(training): guard pin_memory_device when None to prevent DataLoader crash

### DIFF
--- a/acestep/training/data_module.py
+++ b/acestep/training/data_module.py
@@ -226,19 +226,20 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
         """Create training dataloader."""
         prefetch_factor = None if self.num_workers == 0 else self.prefetch_factor
         persistent_workers = False if self.num_workers == 0 else self.persistent_workers
-        pin_memory_device = self.pin_memory_device if self.pin_memory else ""
-        return DataLoader(
-            self.train_dataset,
+        kwargs = dict(
+            dataset=self.train_dataset,
             batch_size=self.batch_size,
             shuffle=True,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
-            pin_memory_device=pin_memory_device,
             collate_fn=collate_preprocessed_batch,
             drop_last=False,
             prefetch_factor=prefetch_factor,
             persistent_workers=persistent_workers,
         )
+        if self.pin_memory_device:
+            kwargs["pin_memory_device"] = self.pin_memory_device
+        return DataLoader(**kwargs)
     
     def val_dataloader(self) -> Optional[DataLoader]:
         """Create validation dataloader."""
@@ -246,18 +247,19 @@ class PreprocessedDataModule(LightningDataModule if LIGHTNING_AVAILABLE else obj
             return None
         prefetch_factor = None if self.num_workers == 0 else self.prefetch_factor
         persistent_workers = False if self.num_workers == 0 else self.persistent_workers
-        pin_memory_device = self.pin_memory_device if self.pin_memory else ""
-        return DataLoader(
-            self.val_dataset,
+        kwargs = dict(
+            dataset=self.val_dataset,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
-            pin_memory_device=pin_memory_device,
             collate_fn=collate_preprocessed_batch,
             prefetch_factor=prefetch_factor,
             persistent_workers=persistent_workers,
         )
+        if self.pin_memory_device:
+            kwargs["pin_memory_device"] = self.pin_memory_device
+        return DataLoader(**kwargs)
 
 
 # ============================================================================


### PR DESCRIPTION
PyTorch DataLoader expects pin_memory_device to be a non-empty string; passing None causes TypeError: object of type 'NoneType' has no len().

Conditionally include pin_memory_device in DataLoader kwargs only when truthy (so None or empty string are not passed). Restores training.

Closes #454.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data loading configuration to improve code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->