### PR TITLE
fix: add tiled VAE encoding and CPU offloading to training preprocessing

### DIFF
--- a/acestep/training/dataset_builder_modules/preprocess.py
+++ b/acestep/training/dataset_builder_modules/preprocess.py
@@ -1,3 +1,12 @@
+"""Preprocess labeled audio samples to tensor files for LoRA/LoKr training.
+
+Orchestrates VAE encoding, text encoding, lyric encoding, and the DiT
+condition-encoder pass.  Each model phase is wrapped in the handler's
+``_load_model_context`` so that only the active model resides on the GPU
+when CPU offloading is enabled.  VAE encoding uses overlap-discard
+tiling to cap peak VRAM on long audio.
+"""
+
 import os
 from typing import List, Tuple
 
@@ -12,13 +21,26 @@ from .preprocess_lyrics import encode_lyrics
 from .preprocess_manifest import save_manifest
 from .preprocess_text import build_text_prompt, encode_text
 from .preprocess_utils import select_genre_indices
-from .preprocess_vae import vae_encode
+from .preprocess_vae import tiled_vae_encode
 from acestep.debug_utils import (
     debug_log_for,
     debug_log_verbose_for,
     debug_start_verbose_for,
     debug_end_verbose_for,
 )
+
+
+def _empty_gpu_cache() -> None:
+    """Release cached GPU memory (CUDA / MPS / XPU)."""
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        torch.xpu.empty_cache()
+    if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+        try:
+            torch.mps.empty_cache()
+        except Exception:
+            pass
 
 
 class PreprocessMixin:
@@ -32,7 +54,22 @@ class PreprocessMixin:
         preprocess_mode: str = "lora",
         progress_callback=None,
     ) -> Tuple[List[str], str]:
-        """Preprocess all labeled samples to tensor files for efficient training."""
+        """Preprocess all labeled samples to tensor files for efficient training.
+
+        Each model phase (VAE, text-encoder, DiT encoder) is wrapped in
+        ``dit_handler._load_model_context`` so that only one model is on
+        the GPU at a time when CPU offloading is active.
+
+        Args:
+            dit_handler: Initialised ``AceStepHandler`` with models loaded.
+            output_dir: Directory for output ``.pt`` files.
+            max_duration: Maximum audio duration in seconds.
+            preprocess_mode: ``"lora"`` or ``"lokr"``.
+            progress_callback: Optional ``(message) -> None`` callback.
+
+        Returns:
+            ``(output_paths, status_message)`` tuple.
+        """
         mode = str(preprocess_mode or "lora").strip().lower()
         if mode not in {"lora", "lokr"}:
             mode = "lora"
@@ -78,21 +115,31 @@ class PreprocessMixin:
 
                 use_genre = i in genre_indices
 
+                # -- Load audio ------------------------------------------------
                 t0 = debug_start_verbose_for("dataset", f"load_audio_stereo[{i}]")
                 audio, _ = load_audio_stereo(sample.audio_path, target_sample_rate, max_duration)
                 debug_end_verbose_for("dataset", f"load_audio_stereo[{i}]", t0)
                 debug_log_verbose_for("dataset", f"audio shape={tuple(audio.shape)} dtype={audio.dtype}")
-                audio = audio.unsqueeze(0).to(device).to(vae.dtype)
-                debug_log_verbose_for(
-                    "dataset",
-                    f"vae device={next(vae.parameters()).device} vae dtype={vae.dtype} "
-                    f"audio device={audio.device} audio dtype={audio.dtype}",
-                )
+                audio = audio.unsqueeze(0)
 
-                with torch.no_grad():
-                    t0 = debug_start_verbose_for("dataset", f"vae_encode[{i}]")
-                    target_latents = vae_encode(vae, audio, dtype)
-                    debug_end_verbose_for("dataset", f"vae_encode[{i}]", t0)
+                # -- VAE encode (tiled, with CPU offloading) -------------------
+                with dit_handler._load_model_context("vae"):
+                    vae_device = next(vae.parameters()).device
+                    audio_gpu = audio.to(vae_device).to(vae.dtype)
+                    debug_log_verbose_for(
+                        "dataset",
+                        f"vae device={vae_device} vae dtype={vae.dtype} "
+                        f"audio device={audio_gpu.device} audio dtype={audio_gpu.dtype}",
+                    )
+
+                    with torch.no_grad():
+                        t0 = debug_start_verbose_for("dataset", f"vae_encode[{i}]")
+                        target_latents = tiled_vae_encode(vae, audio_gpu, dtype)
+                        debug_end_verbose_for("dataset", f"vae_encode[{i}]", t0)
+
+                    del audio_gpu
+
+                _empty_gpu_cache()
 
                 latent_length = target_latents.shape[1]
                 attention_mask = torch.ones(1, latent_length, device=device, dtype=dtype)
@@ -101,6 +148,7 @@ class PreprocessMixin:
                     f"target_latents shape={tuple(target_latents.shape)} latent_length={latent_length}",
                 )
 
+                # -- Text / lyric encode (with CPU offloading) -----------------
                 caption = sample.get_training_prompt(self.metadata.tag_position, use_genre=use_genre)
                 text_prompt = build_text_prompt(sample, self.metadata.tag_position, use_genre)
 
@@ -111,29 +159,33 @@ class PreprocessMixin:
                     logger.info(f"text_prompt:\n{text_prompt}")
                     logger.info(f"{'='*70}\n")
 
-                t0 = debug_start_verbose_for("dataset", f"encode_text[{i}]")
-                text_hidden_states, text_attention_mask = encode_text(
-                    text_encoder, text_tokenizer, text_prompt, device, dtype
-                )
-                debug_end_verbose_for("dataset", f"encode_text[{i}]", t0)
-                debug_log_verbose_for(
-                    "dataset",
-                    f"text_hidden_states shape={tuple(text_hidden_states.shape)} "
-                    f"text_attention_mask shape={tuple(text_attention_mask.shape)}",
-                )
+                with dit_handler._load_model_context("text_encoder"):
+                    t0 = debug_start_verbose_for("dataset", f"encode_text[{i}]")
+                    text_hidden_states, text_attention_mask = encode_text(
+                        text_encoder, text_tokenizer, text_prompt, device, dtype
+                    )
+                    debug_end_verbose_for("dataset", f"encode_text[{i}]", t0)
+                    debug_log_verbose_for(
+                        "dataset",
+                        f"text_hidden_states shape={tuple(text_hidden_states.shape)} "
+                        f"text_attention_mask shape={tuple(text_attention_mask.shape)}",
+                    )
 
-                lyrics = sample.lyrics if sample.lyrics else "[Instrumental]"
-                t0 = debug_start_verbose_for("dataset", f"encode_lyrics[{i}]")
-                lyric_hidden_states, lyric_attention_mask = encode_lyrics(
-                    text_encoder, text_tokenizer, lyrics, device, dtype
-                )
-                debug_end_verbose_for("dataset", f"encode_lyrics[{i}]", t0)
-                debug_log_verbose_for(
-                    "dataset",
-                    f"lyric_hidden_states shape={tuple(lyric_hidden_states.shape)} "
-                    f"lyric_attention_mask shape={tuple(lyric_attention_mask.shape)}",
-                )
+                    lyrics = sample.lyrics if sample.lyrics else "[Instrumental]"
+                    t0 = debug_start_verbose_for("dataset", f"encode_lyrics[{i}]")
+                    lyric_hidden_states, lyric_attention_mask = encode_lyrics(
+                        text_encoder, text_tokenizer, lyrics, device, dtype
+                    )
+                    debug_end_verbose_for("dataset", f"encode_lyrics[{i}]", t0)
+                    debug_log_verbose_for(
+                        "dataset",
+                        f"lyric_hidden_states shape={tuple(lyric_hidden_states.shape)} "
+                        f"lyric_attention_mask shape={tuple(lyric_attention_mask.shape)}",
+                    )
 
+                _empty_gpu_cache()
+
+                # -- DiT condition encoder (with CPU offloading) ---------------
                 t0 = debug_start_verbose_for("dataset", f"run_encoder[{i}]")
                 # Ensure DiT encoder runs on the active residency device (GPU when loaded via
                 # offload context). This prevents flash-attn CPU backend crashes.
@@ -181,6 +233,8 @@ class PreprocessMixin:
                     f"encoder_hidden_states shape={tuple(encoder_hidden_states.shape)} "
                     f"encoder_attention_mask shape={tuple(encoder_attention_mask.shape)}",
                 )
+
+                _empty_gpu_cache()
 
                 t0 = debug_start_verbose_for("dataset", f"build_context_latents[{i}]")
                 context_src = target_latents if mode == "lokr" else None

--- a/acestep/training/dataset_builder_modules/preprocess_vae.py
+++ b/acestep/training/dataset_builder_modules/preprocess_vae.py
@@ -1,8 +1,34 @@
+"""VAE encoding helpers for training preprocessing.
+
+Provides both a simple one-shot ``vae_encode`` (kept for backward
+compatibility) and a tiled variant ``tiled_vae_encode`` that processes
+long audio in overlapping chunks to cap peak VRAM usage.
+"""
+
+import math
+from typing import Optional
+
 import torch
 
 
+# Target sample rate for ACE-Step models (used for chunk-size heuristics)
+_TARGET_SR = 48000
+
+
 def vae_encode(vae, audio, dtype):
-    """VAE encode audio to get target latents."""
+    """VAE encode audio to get target latents (one-shot, no tiling).
+
+    For long audio this may OOM on low-VRAM GPUs.  Prefer
+    :func:`tiled_vae_encode` when peak memory is a concern.
+
+    Args:
+        vae: ``AutoencoderOobleck`` model (on device, eval mode).
+        audio: ``[B, C, S]`` audio tensor.
+        dtype: Target dtype for the output latents.
+
+    Returns:
+        Latent tensor ``[B, T, 64]``.
+    """
     model_device = next(vae.parameters()).device
     if audio.device != model_device:
         audio = audio.to(model_device)
@@ -10,3 +36,115 @@ def vae_encode(vae, audio, dtype):
     latent = vae.encode(audio).latent_dist.sample()
     target_latents = latent.transpose(1, 2).to(dtype)
     return target_latents
+
+
+def tiled_vae_encode(
+    vae,
+    audio: torch.Tensor,
+    dtype: torch.dtype,
+    chunk_size: Optional[int] = None,
+    overlap: int = 96000,
+) -> torch.Tensor:
+    """Encode audio through the VAE using overlap-discard tiling.
+
+    Processes long audio in chunks to avoid OOM on the monolithic
+    ``vae.encode()`` call.  Short audio (shorter than *chunk_size*) is
+    encoded directly without tiling overhead.
+
+    Args:
+        vae: ``AutoencoderOobleck`` VAE model (on device, eval mode).
+        audio: Audio tensor ``[B, C, S]`` (batch, channels, samples).
+        dtype: Target dtype for the output latents.
+        chunk_size: Audio samples per chunk.  ``None`` = auto-select
+            based on available GPU memory (30 s for >=8 GB, 15 s
+            otherwise).
+        overlap: Overlap in audio samples between adjacent chunks
+            (default 2 s at 48 kHz = 96 000).
+
+    Returns:
+        Latent tensor ``[B, T, 64]``, cast to *dtype*.
+    """
+    vae_device = next(vae.parameters()).device
+    vae_dtype = vae.dtype
+
+    # Auto-select chunk size based on GPU VRAM
+    if chunk_size is None:
+        gpu_mem_gb = 0.0
+        if torch.cuda.is_available():
+            try:
+                props = torch.cuda.get_device_properties(vae_device)
+                gpu_mem_gb = props.total_mem / (1024 ** 3)
+            except Exception:
+                pass
+        chunk_size = _TARGET_SR * 15 if gpu_mem_gb <= 8 else _TARGET_SR * 30
+
+    B, C, S = audio.shape
+
+    # Short audio -- direct encode (no tiling needed)
+    if S <= chunk_size:
+        vae_input = audio.to(vae_device, dtype=vae_dtype)
+        with torch.inference_mode():
+            latents = vae.encode(vae_input).latent_dist.sample()
+        return latents.transpose(1, 2).to(dtype)
+
+    # Calculate stride (core region per chunk, excluding overlap)
+    stride = chunk_size - 2 * overlap
+    if stride <= 0:
+        raise ValueError(
+            f"chunk_size ({chunk_size}) must be > 2 * overlap ({overlap})"
+        )
+
+    num_steps = math.ceil(S / stride)
+    downsample_factor: Optional[float] = None
+    latent_write_pos = 0
+    final_latents: Optional[torch.Tensor] = None
+
+    for i in range(num_steps):
+        core_start = i * stride
+        core_end = min(core_start + stride, S)
+
+        # Window with overlap on both sides
+        win_start = max(0, core_start - overlap)
+        win_end = min(S, core_end + overlap)
+
+        chunk = audio[:, :, win_start:win_end].to(vae_device, dtype=vae_dtype)
+
+        with torch.inference_mode():
+            latent_chunk = vae.encode(chunk).latent_dist.sample()
+
+        # Determine downsample factor from the first chunk
+        if downsample_factor is None:
+            downsample_factor = chunk.shape[-1] / latent_chunk.shape[-1]
+            total_latent_len = int(round(S / downsample_factor))
+            final_latents = torch.zeros(
+                B, latent_chunk.shape[1], total_latent_len,
+                dtype=latent_chunk.dtype, device="cpu",
+            )
+
+        # Trim the overlap regions from the latent
+        added_start = core_start - win_start
+        trim_start = int(round(added_start / downsample_factor))
+
+        added_end = win_end - core_end
+        trim_end = int(round(added_end / downsample_factor))
+
+        lat_len = latent_chunk.shape[-1]
+        end_idx = lat_len - trim_end if trim_end > 0 else lat_len
+        latent_core = latent_chunk[:, :, trim_start:end_idx]
+
+        # Copy to pre-allocated CPU tensor
+        core_len = latent_core.shape[-1]
+        assert final_latents is not None
+        final_latents[:, :, latent_write_pos:latent_write_pos + core_len] = (
+            latent_core.cpu()
+        )
+        latent_write_pos += core_len
+
+        del chunk, latent_chunk, latent_core
+
+    # Trim to actual written length
+    assert final_latents is not None
+    final_latents = final_latents[:, :, :latent_write_pos]
+
+    # Transpose to (B, T, 64) and cast -- matches vae_encode output format
+    return final_latents.transpose(1, 2).to(dtype)


### PR DESCRIPTION
Prevent OOM during LoRA training data preprocessing on GPUs with limited VRAM (tested for RTX 5090 32 GB).

V1 path (Gradio UI — preprocess.py / preprocess_vae.py):
- Add tiled_vae_encode() with overlap-discard chunking and auto chunk-size selection (15 s for ≤8 GB, 30 s for larger GPUs).
- Wrap each model phase in _load_model_context() so only one model (VAE / text_encoder / DiT) resides on GPU at a time when CPU offloading is enabled.
- Add _empty_gpu_cache() calls between phases to release fragmented VRAM.

V2 path (CLI — training_v2/preprocess.py):
- Add _empty_gpu_cache() after VAE encode, between Pass 1 and Pass 2, and after each sample in Pass 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced tiled VAE encoding to optimize GPU memory usage during audio processing, enabling handling of larger audio inputs.

* **Improvements**
  * Enhanced GPU memory management with automatic cache clearing between model operations and processing steps.
  * Improved CPU-offload contexts for text and lyrics encoding to maximize memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->