### PR TITLE
fix: escape Rich markup in user-provided paths to prevent MarkupError

### DIFF
--- a/acestep/training_v2/model_discovery.py
+++ b/acestep/training_v2/model_discovery.py
@@ -244,9 +244,11 @@ def prompt_base_model(model_name: str) -> str:
     from acestep.training_v2.ui import console, is_rich_active
     from acestep.training_v2.ui.prompt_helpers import menu
 
+    from acestep.training_v2.ui.prompt_helpers import _esc
+
     if is_rich_active() and console is not None:
         console.print(
-            f"\n  [yellow]'{model_name}' appears to be a custom fine-tune.[/]"
+            f"\n  [yellow]'{_esc(model_name)}' appears to be a custom fine-tune.[/]"
         )
         console.print(
             "  [dim]Knowing the base model helps condition timestep sampling.[/]\n"

--- a/acestep/training_v2/ui/config_panel.py
+++ b/acestep/training_v2/ui/config_panel.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional
 
 from acestep.training_v2.configs import LoRAConfigV2, TrainingConfigV2
 from acestep.training_v2.ui import console, is_rich_active
+from acestep.training_v2.ui.prompt_helpers import _esc
 
 # ---- Default values (for highlighting non-default settings) -----------------
 
@@ -221,9 +222,9 @@ def _show_rich(
             formatted = _fmt_value(value)
             is_def = _is_default(key, value)
             if is_def:
-                table.add_row(f"  {label}", formatted)
+                table.add_row(f"  {label}", _esc(formatted))
             else:
-                table.add_row(f"  {label}", f"[bold yellow]{formatted}[/]")
+                table.add_row(f"  {label}", f"[bold yellow]{_esc(formatted)}[/]")
 
     console.print(
         Panel(

--- a/acestep/training_v2/ui/flows_preprocess.py
+++ b/acestep/training_v2/ui/flows_preprocess.py
@@ -14,6 +14,7 @@ from acestep.training_v2.ui import console, is_rich_active
 from acestep.training_v2.ui.prompt_helpers import (
     DEFAULT_NUM_WORKERS,
     GoBack,
+    _esc,
     ask,
     ask_path,
     native_path,
@@ -154,8 +155,8 @@ def _resolve_dataset_json(raw_path: str) -> Path | None:
 def _print_found_nearby(original: str, found: Path) -> None:
     """Tell the user we found their file at a different path."""
     if is_rich_active() and console is not None:
-        console.print(f"  [yellow]'{original}' not at that exact path,[/]")
-        console.print(f"  [green]but found it at: {found}[/]")
+        console.print(f"  [yellow]'{_esc(original)}' not at that exact path,[/]")
+        console.print(f"  [green]but found it at: {_esc(found)}[/]")
     else:
         print(f"  '{original}' not at that exact path,")
         print(f"  but found it at: {found}")
@@ -164,7 +165,7 @@ def _print_found_nearby(original: str, found: Path) -> None:
 def _print_not_found(path: str) -> None:
     """Tell the user the file was not found anywhere."""
     if is_rich_active() and console is not None:
-        console.print(f"  [red]Not found: {path}[/]")
+        console.print(f"  [red]Not found: {_esc(path)}[/]")
         console.print("  [dim]Searched CWD, datasets/, data/, and one level deep.[/]")
     else:
         print(f"  Not found: {path}")

--- a/acestep/training_v2/ui/flows_setup.py
+++ b/acestep/training_v2/ui/flows_setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from acestep.training_v2.ui import console, is_rich_active
 from acestep.training_v2.ui.prompt_helpers import (
+    _esc,
     ask_bool,
     ask_path,
     native_path,
@@ -96,7 +97,7 @@ def run_first_setup() -> dict:
         ckpt_dir = ask_path("Checkpoint directory", default=default_ckpt)
         ckpt_path = Path(ckpt_dir)
         if not ckpt_path.is_dir():
-            _print(f"  [red]Directory not found: {ckpt_dir}[/]")
+            _print(f"  [red]Directory not found: {_esc(ckpt_dir)}[/]")
             if not ask_bool("Try a different path?", default=True):
                 break
             continue
@@ -122,7 +123,7 @@ def run_first_setup() -> dict:
 
     # -- Summary ------------------------------------------------------------
     section("Setup Complete")
-    _print(f"  Checkpoint dir : [bold]{data['checkpoint_dir']}[/]")
+    _print(f"  Checkpoint dir : [bold]{_esc(data['checkpoint_dir'])}[/]")
     if data["vanilla_enabled"]:
         _print("  Vanilla mode   : [bold green]enabled[/]")
     else:

--- a/acestep/training_v2/ui/flows_train.py
+++ b/acestep/training_v2/ui/flows_train.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 
 from acestep.training_v2.ui import console, is_rich_active
-from acestep.training_v2.ui.prompt_helpers import GoBack, menu, step_indicator
+from acestep.training_v2.ui.prompt_helpers import GoBack, _esc, menu, step_indicator
 from acestep.training_v2.ui.flows_common import build_train_namespace
 from acestep.training_v2.ui.flows_train_steps import (
     step_config_mode,
@@ -112,15 +112,15 @@ def _offer_save_preset(answers: dict) -> None:
             size = path.stat().st_size
             if is_rich_active() and console is not None:
                 console.print(
-                    f"  [green]Preset '{name}' saved ({size} bytes)[/]\n"
-                    f"  [dim]Location: {path}[/]\n"
+                    f"  [green]Preset '{_esc(name)}' saved ({size} bytes)[/]\n"
+                    f"  [dim]Location: {_esc(path)}[/]\n"
                 )
             else:
                 print(f"  Preset '{name}' saved ({size} bytes)")
                 print(f"  Location: {path}\n")
         else:
             if is_rich_active() and console is not None:
-                console.print(f"  [red]Warning: preset file not found after save: {path}[/]\n")
+                console.print(f"  [red]Warning: preset file not found after save: {_esc(path)}[/]\n")
             else:
                 print(f"  Warning: preset file not found after save: {path}\n")
     except (KeyboardInterrupt, EOFError):
@@ -128,7 +128,7 @@ def _offer_save_preset(answers: dict) -> None:
     except Exception as exc:
         # Catch ValueError (bad name), OSError/PermissionError, etc.
         if is_rich_active() and console is not None:
-            console.print(f"  [red]Failed to save preset: {exc}[/]\n")
+            console.print(f"  [red]Failed to save preset: {_esc(exc)}[/]\n")
         else:
             print(f"  Failed to save preset: {exc}\n")
 

--- a/acestep/training_v2/ui/flows_train_steps.py
+++ b/acestep/training_v2/ui/flows_train_steps.py
@@ -11,6 +11,7 @@ from acestep.training_v2.ui import console, is_rich_active
 from acestep.training_v2.ui.prompt_helpers import (
     IS_WINDOWS,
     DEFAULT_NUM_WORKERS,
+    _esc,
     menu,
     ask,
     ask_path,
@@ -219,7 +220,7 @@ def step_logging(a: dict) -> None:
             parent = os.path.dirname(resume_raw)
             if is_rich_active() and console is not None:
                 console.print(
-                    f"  [yellow]That's a file -- using checkpoint directory: {parent}[/]"
+                    f"  [yellow]That's a file -- using checkpoint directory: {_esc(parent)}[/]"
                 )
             else:
                 print(f"  That's a file -- using checkpoint directory: {parent}")


### PR DESCRIPTION
## Summary

- Paths containing square brackets (e.g. `/media/user/[volume]/checkpoints`) are interpreted as Rich markup tags, causing a `MarkupError` crash in the wizard when displayed as default values or in error messages.
- Added `_esc()` helper in `prompt_helpers.py` that escapes `[` → `\[` for safe Rich display, and applied it across all files that interpolate user-provided values into Rich markup strings.

## Repro

Any path with square brackets triggers it — common on Linux with NTFS/exFAT volume labels:

```
rich.errors.MarkupError: closing tag '[/media/user/1E420E927574298D/checkpoints]'
  at position 23 doesn't match any open tag
```

Full traceback starts at `wizard.py` → `flows_train.py` → `flows_train_steps.py` → `prompt_helpers.py:ask()` → `console.input()`, where the default path value `[/path/with/brackets]` is parsed as a Rich closing tag.

## Changes

| File | What |
|------|------|
| `prompt_helpers.py` | Added `_esc()`, fixed `ask()` default display and `ask_path()` error msg |
| `flows_train_steps.py` | Escaped path in resume-from-checkpoint message |
| `flows_preprocess.py` | Escaped paths in "not found" / "found nearby" messages |
| `flows_setup.py` | Escaped paths in setup validation and summary |
| `flows_train.py` | Escaped paths/exceptions in preset save messages |
| `model_discovery.py` | Escaped model name in fine-tune detection message |
| `config_panel.py` | Escaped config values in Rich training config table |

## Test plan

- [ ] Run wizard with a checkpoint path containing square brackets (e.g. symlink to `/media/user/[vol]/checkpoints`) — should display correctly instead of crashing
- [ ] Run wizard with a normal path (e.g. `./checkpoints`) — should display unchanged
- [ ] Verify config panel renders paths with brackets without error


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in model names, file paths, configuration values, and preset names to prevent unintended text formatting interpretation in display output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->