### PR TITLE
Refactor(handler part 11): decompose generate_music orchestration and add upl…

### DIFF
--- a/acestep/core/generation/handler/io_audio.py
+++ b/acestep/core/generation/handler/io_audio.py
@@ -108,8 +108,8 @@ class IoAudioMixin:
             back_audio = audio[:, back_start : back_start + segment_frames]
 
             return torch.cat([front_audio, middle_audio, back_audio], dim=-1)
-        except (OSError, RuntimeError, ValueError):
-            logger.exception("[process_reference_audio] Error processing reference audio")
+        except (OSError, RuntimeError, ValueError) as exc:
+            logger.warning(f"[process_reference_audio] Invalid or unsupported reference audio: {exc}")
             return None
 
     def process_src_audio(self, audio_file: Optional[str]) -> Optional[torch.Tensor]:

--- a/acestep/gradio_ui/events/__init__.py
+++ b/acestep/gradio_ui/events/__init__.py
@@ -260,6 +260,13 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
                 generation_section["instruction_display_gen"],
             ]
         )
+
+    # Validate reference audio eagerly so users get immediate feedback on invalid files.
+    generation_section["reference_audio"].change(
+        fn=lambda reference_audio: gen_h.validate_uploaded_audio_file(reference_audio, "reference"),
+        inputs=[generation_section["reference_audio"]],
+        outputs=[generation_section["reference_audio"]],
+    )
     
     # ========== Sample/Transcribe Handlers ==========
     # Load random example from ./examples/text2music directory
@@ -472,6 +479,13 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
         outputs=[generation_section["captions"]],
     )
     
+    # Validate source audio eagerly so users get immediate feedback on invalid files.
+    generation_section["src_audio"].change(
+        fn=lambda src_audio: gen_h.validate_uploaded_audio_file(src_audio, "source"),
+        inputs=[generation_section["src_audio"]],
+        outputs=[generation_section["src_audio"]],
+    )
+
     # ========== Extract/Lego Mode: Auto-fill audio_duration from src_audio ==========
     generation_section["src_audio"].change(
         fn=gen_h.handle_extract_src_audio_change,


### PR DESCRIPTION
## Summary
This PR extracts `generate_music` orchestration from `acestep/handler.py` into focused mixins, keeps `handler.py` as a thin facade, and adds targeted tests.  
It also adds early UI audio-file validation (reference + source) to improve user feedback for invalid/corrupt uploads.

## What changed

### 1. Decompose `generate_music` orchestration
- Added `GenerateMusicRequestMixin`  
  - `acestep/core/generation/handler/generate_music_request.py`
- Added `GenerateMusicInputsMixin`  
  - `acestep/core/generation/handler/generate_music_inputs.py`
- Added `GenerateMusicExecuteMixin`  
  - `acestep/core/generation/handler/generate_music_execute.py`
- Wired mixins in:
  - `acestep/core/generation/handler/__init__.py`
  - `acestep/handler.py`

Behavioral intent is unchanged: same entrypoint/signature, same payload contract, same flow and error schema.

### 2. Add upload-time audio validation in UI (reference + source)
- Added shared validator in:
  - `acestep/gradio_ui/events/generation_handlers.py`
  - `validate_uploaded_audio_file(...)`
- Wired validation hooks in:
  - `acestep/gradio_ui/events/__init__.py`
  - `reference_audio.change(...)`
  - `src_audio.change(...)`

On invalid/unsupported/corrupt files, UI now shows a warning toast and clears the invalid input before generation.

### 3. Reduce noisy expected-error logging for invalid reference files
- Updated:
  - `acestep/core/generation/handler/io_audio.py`
- For invalid/unsupported reference audio decode failures, changed full traceback logging to concise warning logging.

## Why audio validation is implemented this way

Validation uses `soundfile` (`soundfile.info(...)`) in Gradio handlers, which is an existing library already used elsewhere in the project (e.g., audio loading paths), so this avoids introducing new dependencies and keeps validation consistent with current audio stack.

## Tests

# Unit Tests (Added / Updated)

## `generate_music_request_test.py`
- `test_resolve_task_switches_to_cover_when_audio_codes_present`
- `test_prepare_runtime_normalizes_batch_and_duration`
- `test_prepare_runtime_passes_use_random_seed_to_prepare_seeds`
- `test_resolve_generate_music_progress_returns_callback_or_noop`
- `test_validate_generate_music_readiness_for_initialized_and_uninitialized`
- `test_prepare_reference_and_source_audio_returns_error_for_invalid_reference`
- `test_prepare_reference_and_source_audio_ignores_src_audio_for_text2music`
- `test_prepare_reference_and_source_audio_returns_error_for_invalid_source`

## `generate_music_execute_test.py`
- `test_run_service_with_progress_invokes_service_and_stops_estimator`

## `generation_handlers_test.py`
- `test_validate_uploaded_audio_file_returns_none_for_invalid_file`
- `test_validate_uploaded_audio_file_keeps_valid_file`
- `test_validate_uploaded_audio_file_shows_source_role_message`

---

# Automated Validation Run

- `py_compile` passed for changed files.

- `unittest` execution is environment-blocked here:
  - Handler tests import-chain requires `torchaudio`
  - Gradio event tests import-chain requires `gradio`

---

# Manual UI Tests Passed

- Generate flow works after model init.
- Text2music flow works (no `src_audio` usage path).
- Invalid reference upload now shows user warning and clears input.
- Invalid source upload now shows user warning and clears input.
- Existing UI paths otherwise pass (per verification).

## Scope and risk

- Scoped to `generate_music` orchestration decomposition and audio upload validation UX.
- No intentional API changes.
- Error payload structure and output contract preserved.
- Module LOC policy addressed via split:
  - `generate_music_request.py` reduced to focused request/preflight helpers.
  - service-input assembly moved to `generate_music_inputs.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented real-time validation for audio uploads (reference and source audio), with immediate user feedback when files are unsupported or invalid.

* **Bug Fixes**
  * Enhanced error handling and logging for audio processing failures with clearer, more informative error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->