### PR TITLE
Refactor(handler part 13): vae encode

### DIFF
--- a/acestep/core/generation/handler/__init__.py
+++ b/acestep/core/generation/handler/__init__.py
@@ -24,6 +24,8 @@ from .service_generate_execute import ServiceGenerateExecuteMixin
 from .service_generate_outputs import ServiceGenerateOutputsMixin
 from .service_generate_request import ServiceGenerateRequestMixin
 from .task_utils import TaskUtilsMixin
+from .vae_encode import VaeEncodeMixin
+from .vae_encode_chunks import VaeEncodeChunksMixin
 
 __all__ = [
     "AudioCodesMixin",
@@ -50,4 +52,6 @@ __all__ = [
     "ServiceGenerateOutputsMixin",
     "ServiceGenerateRequestMixin",
     "TaskUtilsMixin",
+    "VaeEncodeMixin",
+    "VaeEncodeChunksMixin",
 ]

--- a/acestep/core/generation/handler/vae_encode.py
+++ b/acestep/core/generation/handler/vae_encode.py
@@ -1,0 +1,82 @@
+"""VAE encode orchestration helpers for tiled audio-to-latent conversion."""
+
+import math
+from typing import Optional
+
+import torch
+from loguru import logger
+
+from acestep.gpu_config import get_gpu_memory_gb
+
+
+class VaeEncodeMixin:
+    """High-level VAE encode entrypoints and runtime chunk policy."""
+
+    def tiled_encode(self, audio, chunk_size=None, overlap=None, offload_latent_to_cpu=True):
+        """Encode audio to latents using overlap-discard tiling.
+
+        Args:
+            audio: Tensor shaped ``[batch, channels, samples]`` or ``[channels, samples]``.
+            chunk_size: Audio chunk size in samples; auto-selected when ``None``.
+            overlap: Overlap in samples; defaults to 2 seconds at 48kHz.
+            offload_latent_to_cpu: Whether to offload chunk outputs to CPU.
+
+        Returns:
+            Latent tensor shaped ``[batch, latent_channels, latent_frames]``.
+        """
+        # ---- MLX fast path (macOS Apple Silicon) ----
+        if self.use_mlx_vae and self.mlx_vae is not None:
+            input_was_2d = audio.dim() == 2
+            if input_was_2d:
+                audio = audio.unsqueeze(0)
+            try:
+                result = self._mlx_vae_encode_sample(audio)
+                if input_was_2d:
+                    result = result.squeeze(0)
+                return result
+            except Exception as exc:
+                logger.warning(
+                    f"[tiled_encode] MLX VAE encode failed ({type(exc).__name__}: {exc}), "
+                    f"falling back to PyTorch VAE..."
+                )
+                if input_was_2d:
+                    audio = audio.squeeze(0)
+
+        # ---- PyTorch path (CUDA / MPS / CPU) ----
+        if chunk_size is None:
+            gpu_memory = get_gpu_memory_gb()
+            if gpu_memory <= 0 and self.device == "mps":
+                mem_gb = self._get_effective_mps_memory_gb()
+                if mem_gb is not None:
+                    gpu_memory = mem_gb
+            chunk_size = 48000 * 15 if gpu_memory <= 8 else 48000 * 30
+        if overlap is None:
+            overlap = 48000 * 2
+
+        input_was_2d = audio.dim() == 2
+        if input_was_2d:
+            audio = audio.unsqueeze(0)
+
+        batch_size, _channels, samples = audio.shape
+
+        if samples <= chunk_size:
+            vae_input = audio.to(self.device).to(self.vae.dtype)
+            with torch.inference_mode():
+                latents = self.vae.encode(vae_input).latent_dist.sample()
+            if input_was_2d:
+                latents = latents.squeeze(0)
+            return latents
+
+        stride = chunk_size - 2 * overlap
+        if stride <= 0:
+            raise ValueError(f"chunk_size {chunk_size} must be > 2 * overlap {overlap}")
+
+        num_steps = math.ceil(samples / stride)
+        if offload_latent_to_cpu:
+            result = self._tiled_encode_offload_cpu(audio, batch_size, samples, stride, overlap, num_steps, chunk_size)
+        else:
+            result = self._tiled_encode_gpu(audio, batch_size, samples, stride, overlap, num_steps, chunk_size)
+
+        if input_was_2d:
+            result = result.squeeze(0)
+        return result

--- a/acestep/core/generation/handler/vae_encode_chunks.py
+++ b/acestep/core/generation/handler/vae_encode_chunks.py
@@ -1,0 +1,98 @@
+"""Chunk-level VAE encode helpers for tiled audio-to-latent conversion."""
+
+import torch
+from tqdm import tqdm
+
+
+class VaeEncodeChunksMixin:
+    """Implement chunked encode strategies for GPU and CPU-offload modes."""
+
+    def _tiled_encode_gpu(self, audio, batch_size, samples, stride, overlap, num_steps, chunk_size):
+        """Standard tiled encode keeping all data on GPU."""
+        _ = batch_size, chunk_size
+        encoded_latent_list = []
+        downsample_factor = None
+
+        for i in tqdm(range(num_steps), desc="Encoding audio chunks", disable=self.disable_tqdm):
+            core_start = i * stride
+            core_end = min(core_start + stride, samples)
+            win_start = max(0, core_start - overlap)
+            win_end = min(samples, core_end + overlap)
+
+            audio_chunk = audio[:, :, win_start:win_end].to(self.device).to(self.vae.dtype)
+            with torch.inference_mode():
+                latent_chunk = self.vae.encode(audio_chunk).latent_dist.sample()
+
+            if downsample_factor is None:
+                downsample_factor = audio_chunk.shape[-1] / latent_chunk.shape[-1]
+
+            added_start = core_start - win_start
+            trim_start = int(round(added_start / downsample_factor))
+            added_end = win_end - core_end
+            trim_end = int(round(added_end / downsample_factor))
+
+            latent_len = latent_chunk.shape[-1]
+            end_idx = latent_len - trim_end if trim_end > 0 else latent_len
+            latent_core = latent_chunk[:, :, trim_start:end_idx]
+            encoded_latent_list.append(latent_core)
+            del audio_chunk
+
+        return torch.cat(encoded_latent_list, dim=-1)
+
+    def _tiled_encode_offload_cpu(self, audio, batch_size, samples, stride, overlap, num_steps, chunk_size):
+        """Tiled encode that offloads latent chunks to CPU immediately."""
+        _ = chunk_size
+        first_core_end = min(stride, samples)
+        first_win_end = min(samples, first_core_end + overlap)
+
+        first_audio_chunk = audio[:, :, 0:first_win_end].to(self.device).to(self.vae.dtype)
+        with torch.inference_mode():
+            first_latent_chunk = self.vae.encode(first_audio_chunk).latent_dist.sample()
+
+        downsample_factor = first_audio_chunk.shape[-1] / first_latent_chunk.shape[-1]
+        latent_channels = first_latent_chunk.shape[1]
+
+        total_latent_length = int(round(samples / downsample_factor))
+        final_latents = torch.zeros(
+            batch_size,
+            latent_channels,
+            total_latent_length,
+            dtype=first_latent_chunk.dtype,
+            device="cpu",
+        )
+
+        first_added_end = first_win_end - first_core_end
+        first_trim_end = int(round(first_added_end / downsample_factor))
+        first_latent_len = first_latent_chunk.shape[-1]
+        first_end_idx = first_latent_len - first_trim_end if first_trim_end > 0 else first_latent_len
+
+        first_latent_core = first_latent_chunk[:, :, :first_end_idx]
+        latent_write_pos = first_latent_core.shape[-1]
+        final_latents[:, :, :latent_write_pos] = first_latent_core.cpu()
+        del first_audio_chunk, first_latent_chunk, first_latent_core
+
+        for i in tqdm(range(1, num_steps), desc="Encoding audio chunks", disable=self.disable_tqdm):
+            core_start = i * stride
+            core_end = min(core_start + stride, samples)
+            win_start = max(0, core_start - overlap)
+            win_end = min(samples, core_end + overlap)
+
+            audio_chunk = audio[:, :, win_start:win_end].to(self.device).to(self.vae.dtype)
+            with torch.inference_mode():
+                latent_chunk = self.vae.encode(audio_chunk).latent_dist.sample()
+
+            added_start = core_start - win_start
+            trim_start = int(round(added_start / downsample_factor))
+            added_end = win_end - core_end
+            trim_end = int(round(added_end / downsample_factor))
+
+            latent_len = latent_chunk.shape[-1]
+            end_idx = latent_len - trim_end if trim_end > 0 else latent_len
+            latent_core = latent_chunk[:, :, trim_start:end_idx]
+
+            core_len = latent_core.shape[-1]
+            final_latents[:, :, latent_write_pos : latent_write_pos + core_len] = latent_core.cpu()
+            latent_write_pos += core_len
+            del audio_chunk, latent_chunk, latent_core
+
+        return final_latents[:, :, :latent_write_pos]

--- a/acestep/core/generation/handler/vae_encode_test.py
+++ b/acestep/core/generation/handler/vae_encode_test.py
@@ -1,0 +1,149 @@
+"""Unit tests for extracted VAE encode mixins."""
+
+import unittest
+
+import torch
+
+from acestep.core.generation.handler.vae_encode import VaeEncodeMixin
+from acestep.core.generation.handler.vae_encode_chunks import VaeEncodeChunksMixin
+
+
+class _Dist:
+    """Minimal distribution wrapper exposing ``sample``."""
+
+    def __init__(self, sample):
+        """Store latent sample tensor."""
+        self._sample = sample
+
+    def sample(self):
+        """Return precomputed latent sample."""
+        return self._sample
+
+
+class _EncOut:
+    """Minimal encode output wrapper exposing ``latent_dist``."""
+
+    def __init__(self, sample):
+        """Store sample wrapper used by tests."""
+        self.latent_dist = _Dist(sample)
+
+
+class _Vae:
+    """Simple VAE stub with deterministic temporal downsample."""
+
+    def __init__(self, fn=None):
+        """Configure optional encode callback."""
+        self.dtype = torch.float32
+        self._fn = fn
+
+    def encode(self, audio_chunk):
+        """Return deterministic latent tensor (2x temporal downsample)."""
+        if self._fn:
+            return _EncOut(self._fn(audio_chunk))
+        bsz, _c, s = audio_chunk.shape
+        return _EncOut(torch.ones(bsz, 4, max(1, s // 2)))
+
+
+class _Host(VaeEncodeMixin, VaeEncodeChunksMixin):
+    """Host combining both encode mixins with minimal dependencies."""
+
+    def __init__(self):
+        """Initialize deterministic state for unit tests."""
+        self.use_mlx_vae = False
+        self.mlx_vae = None
+        self.device = "cpu"
+        self.vae = _Vae()
+        self.disable_tqdm = True
+        self.recorded = {}
+
+    def _get_effective_mps_memory_gb(self):
+        """Return no override by default."""
+        return None
+
+    def _mlx_vae_encode_sample(self, audio):
+        """Return MLX sentinel result for MLX-path tests."""
+        _ = audio
+        return torch.full((1, 4, 6), 3.0)
+
+
+class VaeEncodeMixinTests(unittest.TestCase):
+    """Validate orchestration and chunk path selection for tiled encode."""
+
+    def test_tiled_encode_uses_mlx_path_when_available(self):
+        """MLX path should short-circuit PyTorch path."""
+        host = _Host()
+        host.use_mlx_vae = True
+        host.mlx_vae = object()
+        out = host.tiled_encode(torch.zeros(1, 2, 16), chunk_size=8, overlap=2)
+        self.assertTrue(torch.equal(out, torch.full((1, 4, 6), 3.0)))
+
+    def test_tiled_encode_direct_path_for_short_audio(self):
+        """Short audio should encode directly without chunk helpers."""
+        host = _Host()
+        out = host.tiled_encode(torch.zeros(1, 2, 16), chunk_size=20, overlap=2)
+        self.assertEqual(tuple(out.shape), (1, 4, 8))
+
+    def test_tiled_encode_uses_offload_path(self):
+        """Offload mode should route through CPU-offload chunk helper."""
+        host = _Host()
+
+        def _offload(*args, **kwargs):
+            """Capture invocation and return sentinel latents."""
+            _ = args, kwargs
+            host.recorded["offload"] = True
+            return torch.ones(1, 4, 5)
+
+        host._tiled_encode_offload_cpu = _offload
+        out = host.tiled_encode(torch.zeros(1, 2, 48), chunk_size=16, overlap=2, offload_latent_to_cpu=True)
+        self.assertTrue(host.recorded["offload"])
+        self.assertEqual(tuple(out.shape), (1, 4, 5))
+
+    def test_tiled_encode_rejects_invalid_stride(self):
+        """Stride <= 0 should raise ValueError."""
+        host = _Host()
+        with self.assertRaises(ValueError):
+            host.tiled_encode(torch.zeros(1, 2, 48), chunk_size=10, overlap=5)
+
+    def test_tiled_encode_routes_to_gpu_chunk_path(self):
+        """Non-offload mode should route through GPU chunk helper."""
+        host = _Host()
+
+        def _gpu(*args, **kwargs):
+            """Capture GPU routing and return sentinel latents."""
+            _ = args, kwargs
+            host.recorded["gpu"] = True
+            return torch.ones(1, 4, 7)
+
+        host._tiled_encode_gpu = _gpu
+        out = host.tiled_encode(torch.zeros(1, 2, 64), chunk_size=16, overlap=2, offload_latent_to_cpu=False)
+        self.assertTrue(host.recorded["gpu"])
+        self.assertEqual(tuple(out.shape), (1, 4, 7))
+
+    def test_tiled_encode_gpu_and_offload_outputs_match(self):
+        """GPU and offload chunk methods should agree on deterministic output."""
+        host = _Host()
+        audio = torch.zeros(1, 2, 40)
+        chunk_size = 16
+        overlap = 2
+        stride = chunk_size - 2 * overlap
+        num_steps = 4
+        out_gpu = host._tiled_encode_gpu(audio, 1, 40, stride, overlap, num_steps, chunk_size)
+        out_offload = host._tiled_encode_offload_cpu(audio, 1, 40, stride, overlap, num_steps, chunk_size)
+        self.assertEqual(tuple(out_gpu.shape), (1, 4, 20))
+        self.assertEqual(tuple(out_offload.shape), (1, 4, 20))
+        self.assertTrue(torch.equal(out_gpu.cpu(), out_offload))
+
+    def test_tiled_encode_offload_returns_cpu_tensor(self):
+        """CPU-offload chunk helper should return latents on CPU."""
+        host = _Host()
+        audio = torch.zeros(1, 2, 40)
+        chunk_size = 16
+        overlap = 2
+        stride = chunk_size - 2 * overlap
+        num_steps = 4
+        out = host._tiled_encode_offload_cpu(audio, 1, 40, stride, overlap, num_steps, chunk_size)
+        self.assertEqual(out.device.type, "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extract VAE encode/tiled encode logic from `acestep/handler.py` into focused mixins while preserving runtime behaviour.

This continues the handler FD plan by slimming the facade and moving encode responsibilities into dedicated modules.

## What changed

### Decomposition
- Added `acestep/core/generation/handler/vae_encode.py`
  - `VaeEncodeMixin`
  - `tiled_encode(...)` orchestration and path selection
- Added `acestep/core/generation/handler/vae_encode_chunks.py`
  - `VaeEncodeChunksMixin`
  - `_tiled_encode_gpu(...)`
  - `_tiled_encode_offload_cpu(...)`
- Wired mixins in:
  - `acestep/core/generation/handler/__init__.py`
  - `acestep/handler.py`
- Removed moved VAE encode implementation block from `handler.py` facade section.

### Tests
- Added `acestep/core/generation/handler/vae_encode_test.py`
  - MLX fast-path routing
  - direct encode path
  - offload routing
  - invalid stride validation
  - GPU routing path
  - GPU/offload output parity on deterministic input
  - offload output device assertion

## Behavioral parity notes

- No public API/signature changes intended.
- Preserves:
  - MLX fast path + fallback semantics
  - chunk sizing/overlap defaults and stride validation
  - offload vs GPU encode routing
  - latent trimming/downsample flow in chunk methods

## Validation

- `py_compile` passed on changed files.
- Unit tests are included; environment-level optional deps may constrain full local execution in this runtime.
test_tiled_encode_uses_mlx_path_when_available
test_tiled_encode_direct_path_for_short_audio
test_tiled_encode_uses_offload_path
test_tiled_encode_rejects_invalid_stride
test_tiled_encode_routes_to_gpu_chunk_path
test_tiled_encode_gpu_and_offload_outputs_match
test_tiled_encode_offload_returns_cpu_tensor

## Manual UI testing

Manual UI tests passed for available platform paths:
- basic text2music generate
- tiled encode scenarios
- cover/repaint source-audio encode path
- batch flow

Apple-specific (MPS/MLX) manual tests: **not run** (environment unavailable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced VAE audio encoding with tiled processing and configurable overlap handling
  * Automatic chunk size selection based on available GPU memory
  * Multiple encoding pathways with adaptive fallback support
  * Optional CPU offload capability for improved memory efficiency

* **Tests**
  * Comprehensive test coverage for VAE encoding functionality added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->