### PR TITLE
Chore(workflow): enforce independent PR branches with pre-push guard

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+set -eu
+
+# Prevent cross-polluted PR branches by ensuring the current branch is
+# independently based on upstream/main and does not reuse non-main commits
+# from other remote feature/fix/docs branches.
+
+current_branch="$(git symbolic-ref --quiet --short HEAD || true)"
+[ -z "$current_branch" ] && exit 0
+
+base_ref="${PR_BASE_REF:-upstream/main}"
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  # If upstream/main is unavailable locally, do not block pushes.
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "$base_ref" HEAD; then
+  echo "ERROR: '$current_branch' is not based on '$base_ref'."
+  echo "Create PR branches from upstream/main to keep PRs independent."
+  exit 1
+fi
+
+ahead_commits="$(git rev-list "$base_ref"..HEAD)"
+[ -z "$ahead_commits" ] && exit 0
+
+remote_branches="$(git for-each-ref --format='%(refname:short)' \
+  refs/remotes/origin/feat \
+  refs/remotes/origin/fix \
+  refs/remotes/origin/docs)"
+
+for commit in $ahead_commits; do
+  for remote_branch in $remote_branches; do
+    [ "$remote_branch" = "origin/$current_branch" ] && continue
+    if git merge-base --is-ancestor "$commit" "$remote_branch"; then
+      echo "ERROR: Commit $commit is also present in $remote_branch."
+      echo "This branch appears stacked or cross-polluted."
+      echo "Recreate from '$base_ref' and cherry-pick only intended commits."
+      exit 1
+    fi
+  done
+done
+
+exit 0

--- a/scripts/new_pr_branch.ps1
+++ b/scripts/new_pr_branch.ps1
@@ -1,0 +1,12 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BranchName,
+    [string]$BaseRef = "upstream/main"
+)
+
+$ErrorActionPreference = "Stop"
+
+git fetch upstream
+git checkout -b $BranchName $BaseRef
+
+Write-Host "Created '$BranchName' from '$BaseRef'."


### PR DESCRIPTION
## Summary

Adds an optional local workflow guard to reduce PR cross-pollution (stacked/overlapping feature branches).

### Included changes

- Add `.githooks/pre-push`
  - Blocks push when current branch is not based on `upstream/main`
  - Blocks push when branch commits are already present in other remote `origin/feat*`, `origin/fix*`, or `origin/docs*` branches
  - Allows normal push when branch is independent

- Add `scripts/new_pr_branch.ps1`
  - Helper to create new PR branches from `upstream/main`:
    - `powershell -File scripts/new_pr_branch.ps1 -BranchName "<name>"`

## Why

Prevents occurrences of PR cross-pollution where a new PR accidentally included commits from another open PR.  
This guard makes that failure mode explicit before push.

## Scope / Safety

- Workflow-only change (no runtime/model/UI behaviour changes)
- No production code paths modified

## Validation

- Verified branch creation helper works from `upstream/main`
- Verified push succeeds for independent branch
- Verified guard is active via `core.hooksPath=.githooks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development workflow improvements including automated branch validation to ensure PR isolation and prevent unintended cross-branch commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->