### PR TITLE
(fix):Resolve Windows CUDA Flash Attention prebuilt wheels

### DIFF
--- a/acestep/third_parts/nano-vllm/pyproject.toml
+++ b/acestep/third_parts/nano-vllm/pyproject.toml
@@ -12,14 +12,10 @@ description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "torch>=2.4.0",
-    # Triton and Flash Attention are optional on ROCm (Python 3.12) - SDPA fallback used instead
-    "triton-windows>=3.0.0,<3.4; sys_platform == 'win32' and python_version == '3.11'",
-    "triton>=3.0.0; sys_platform == 'linux' and python_version == '3.11'",
+    "triton>=3.0.0; sys_platform == 'linux'",
+    "triton-windows>=3.0.0,<3.4; sys_platform == 'win32'",
     "transformers>=4.51.0",
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.13/flash_attn-2.8.3+cu128torch2.10-cp311-cp311-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.11' and platform_machine == 'AMD64'",
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.13/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.12' and platform_machine == 'AMD64'",
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.8.3+cu128torch2.10-cp311-cp311-linux_x86_64.whl ; sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'x86_64'",
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl ; sys_platform == 'linux' and python_version == '3.12' and platform_machine == 'x86_64'",
+    "flash-attn",
     "xxhash",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     # Local third-party packages
     # nano-vllm source is configured in [tool.uv.sources]
     "nano-vllm; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    # flash-attn prebuilt wheels configured in [tool.uv.sources]
+    "flash-attn; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "modelscope",
     "tensorboard>=2.20.0",
     "typer-slim>=0.21.1",
@@ -77,6 +79,12 @@ required-environments = [
 
 [tool.uv.sources]
 nano-vllm = { path = "acestep/third_parts/nano-vllm" }
+flash-attn = [
+    { url = "https://huggingface.co/Wildminder/AI-windows-whl/resolve/main/flash_attn-2.8.3%2Bcu128torch2.10.0cxx11abiTRUE-cp313-cp313-win_amd64.whl", marker = "sys_platform == 'win32' and python_full_version >= '3.13'" },
+    { url = "https://huggingface.co/Wildminder/AI-windows-whl/resolve/main/flash_attn-2.8.3%2Bd20260121.cu130torch2.10.0cxx11abiTRUE-cp312-cp312-win_amd64.whl", marker = "sys_platform == 'win32' and python_full_version >= '3.12' and python_full_version < '3.13'" },
+    { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64' and python_full_version >= '3.12' and python_full_version < '3.13'" },
+    { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64' and python_full_version >= '3.11' and python_full_version < '3.12'" },
+]
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform == 'win32' or (sys_platform == 'linux' and platform_machine == 'x86_64')" },
     { index = "pytorch-cu130", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,10 +51,7 @@ mlx-lm>=0.20.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # nano-vllm dependencies
 triton-windows>=3.0.0,<3.4; sys_platform == 'win32'
 triton>=3.0.0; sys_platform == 'linux'
-flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.13/flash_attn-2.8.3+cu128torch2.10-cp311-cp311-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.11' and platform_machine == 'AMD64'
-flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.13/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.12' and platform_machine == 'AMD64'
-flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.8.3+cu128torch2.10-cp311-cp311-linux_x86_64.whl ; sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'x86_64'
-flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl ; sys_platform == 'linux' and python_version == '3.12' and platform_machine == 'x86_64'
+flash-attn
 xxhash
 
 # Local package - install with: pip install -e acestep/third_parts/nano-vllm


### PR DESCRIPTION
## Summary

Fix two dependency bugs affecting Windows CUDA users, introduced/exposed by the DGX Spark PR (#575):

1. **Windows `uv run` fails with "unsatisfiable" torch resolution** — Adding `win32/AMD64` to `required-environments` forced `uv lock` to cross-resolve all four platforms simultaneously. Since `uv.lock` is gitignored, Windows users had no lockfile and the implicit `uv lock` failed resolving `torch==2.7.1+cu128` from the explicit PyTorch index. Fix: remove `win32/AMD64` from `required-environments` (restoring pre-#575 local resolution behavior) and upgrade Windows torch to `2.10.0+cu128` to align with Linux x86_64.

2. **flash-attn unavailable on Python 3.12** — The only Windows flash-attn wheel (sdbds, `cp311` built against torch 2.7.1) excluded Python 3.12 users entirely. Fix: switch to [mjun0812/flash-attention-prebuild-wheels](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.7.12) which provides `cp311` and `cp312` wheels built against torch 2.10 for both Windows (`cu126`, backward-compatible with `cu128` runtime) and Linux (`cu128`).

## Scope

**Files changed:**
- `pyproject.toml` — Upgrade Windows torch/torchvision/torchaudio from 2.7.1 to 2.10.0+cu128, add `platform_machine == 'AMD64'` marker, remove `win32` from `required-environments`
- `acestep/third_parts/nano-vllm/pyproject.toml` — Replace sdbds flash-attn wheel with mjun0812 wheels (cp311 + cp312) for Windows; add cp312 wheel for Linux
- `requirements.txt` — Mirror the same torch upgrade and flash-attn wheel changes for pip users

**Explicitly out of scope:**
- Linux x86_64 torch (unchanged at 2.10.0+cu128)
- Linux aarch64 / DGX Spark torch (unchanged at 2.10.0+cu130)
- macOS arm64 torch (unchanged at >=2.9.1)
- triton / triton-windows dependencies (unchanged)
- All application code (zero Python source changes)

## Risk and Compatibility

| Platform | torch | flash-attn | Status |
|---|---|---|---|
| Windows AMD64 | 2.7.1+cu128 → **2.10.0+cu128** | sdbds cp311 → **mjun0812 cp311+cp312** | **Changed** |
| Linux x86_64 | 2.10.0+cu128 | added cp312 wheel | Additive only |
| Linux aarch64 (DGX Spark) | 2.10.0+cu130 | N/A (SDPA fallback) | Unchanged |
| macOS arm64 | >=2.9.1 | N/A (SDPA fallback) | Unchanged |

- Windows torch upgrade: all `2.10.0+cu128` wheels verified to exist on the PyTorch index for cp311, cp312, cp313 (`win_amd64`)
- Windows flash-attn `cu126` wheels are backward-compatible with `cu128` CUDA runtime (CUDA minor versions are forward-compatible within the same major version)
- `required-environments` removal for Windows: restores the exact behavior that worked before #575 — uv resolves locally at sync time instead of requiring cross-platform lockfile resolution

## Regression Checks

- [x] `uv lock` succeeds (resolves 172 packages)
- [x] `uv sync --dry-run` succeeds
- [x] Lockfile contains correct Windows torch 2.10.0+cu128 wheels (cp311 + cp312)
- [x] Lockfile contains correct flash-attn entries for all four platform/python combos
- [x] DGX Spark (aarch64) resolution unchanged in lockfile
- [x] macOS arm64 resolution unchanged in lockfile
- [ ] Windows end-to-end: `uv run acestep` (needs Windows tester)
- [ ] Linux end-to-end: flash-attn import on Python 3.12 (needs Linux tester)

## Reviewer Notes

- **`uv.lock` is gitignored** (`.gitignore` line 112) — this is the root cause of Bug 1. Users never receive a lockfile, so `uv run` triggers `uv lock` on their machine. Committing `uv.lock` to version control would be a stronger fix but is a separate discussion.
- **No cp312 flash-attn for Windows + torch 2.7.1 exists anywhere** — the sdbds repo only builds cp311, and mjun0812 only builds against torch 2.10. Upgrading Windows torch to 2.10.0 was necessary to unlock cp312 flash-attn support.
- **Follow-up:** Consider un-gitignoring `uv.lock` so users get reproducible installs without needing to resolve dependencies themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PyTorch, torchvision, and torchaudio to 2.10.0+cu128 for Windows (AMD64) and aligned Linux x86_64 builds to 2.10.0+cu128.
  * Added/explicitly declared macOS ARM64 (Apple Silicon) CPU/MPS wheel entries and preserved Linux aarch64 configurations.
  * Introduced a platform-generic flash-attn dependency and added curated prebuilt wheel sources for Windows and Linux to broaden compatibility.
  * Simplified platform/Python gating for several native-accelerator wheels to reduce overly specific version constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->