### PR TITLE
fix: clear stale UI state on mode switch to prevent remix noise bug

### DIFF
--- a/acestep/ui/gradio/events/__init__.py
+++ b/acestep/ui/gradio/events/__init__.py
@@ -466,6 +466,9 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
             generation_section["timesig_auto"],
             generation_section["vocal_lang_auto"],
             generation_section["duration_auto"],
+            # State-leakage fix: clear stale values on mode switch (indices 42-43)
+            generation_section["text2music_audio_code_string"],
+            generation_section["src_audio"],
         ]
     )
     
@@ -732,6 +735,9 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
         generation_section["timesig_auto"],
         generation_section["vocal_lang_auto"],
         generation_section["duration_auto"],
+        # State-leakage fix: clear stale values on mode switch (indices 42-43)
+        generation_section["text2music_audio_code_string"],
+        generation_section["src_audio"],
     ]
     for btn_idx in range(1, 9):
         results_section[f"send_to_remix_btn_{btn_idx}"].click(

--- a/acestep/ui/gradio/events/generation/mode_ui_test.py
+++ b/acestep/ui/gradio/events/generation/mode_ui_test.py
@@ -1,0 +1,104 @@
+"""Unit tests for mode_ui state-clearing behavior on mode switch.
+
+Verifies that compute_mode_ui_updates correctly clears stale
+text2music_audio_code_string and src_audio values when switching
+between modes, preventing the state-leakage noise bug.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    from acestep.ui.gradio.events.generation.mode_ui import compute_mode_ui_updates
+    _IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - environment dependency guard
+    compute_mode_ui_updates = None
+    _IMPORT_ERROR = exc
+
+# Output indices for the two new state-clearing outputs
+_IDX_AUDIO_CODES = 42
+_IDX_SRC_AUDIO = 43
+_EXPECTED_TUPLE_LENGTH = 44
+
+
+@unittest.skipIf(compute_mode_ui_updates is None,
+                 f"compute_mode_ui_updates import unavailable: {_IMPORT_ERROR}")
+class ModeUiStateClearingTests(unittest.TestCase):
+    """Tests that mode switches clear stale UI state to prevent noise."""
+
+    def test_tuple_length(self):
+        """compute_mode_ui_updates should return exactly 44 elements."""
+        result = compute_mode_ui_updates("Custom")
+        self.assertEqual(len(result), _EXPECTED_TUPLE_LENGTH)
+
+    def test_custom_mode_preserves_audio_codes(self):
+        """In Custom mode, audio_codes textbox should be visible but not cleared."""
+        result = compute_mode_ui_updates("Custom")
+        codes_update = result[_IDX_AUDIO_CODES]
+        # Should only set visibility, not clear the value
+        self.assertTrue(codes_update.get("visible"))
+        self.assertNotIn("value", codes_update)
+
+    def test_remix_mode_clears_audio_codes(self):
+        """Switching to Remix should clear the audio_codes textbox value."""
+        result = compute_mode_ui_updates("Remix", previous_mode="Custom")
+        codes_update = result[_IDX_AUDIO_CODES]
+        self.assertEqual(codes_update.get("value"), "")
+        self.assertFalse(codes_update.get("visible"))
+
+    def test_simple_mode_clears_audio_codes(self):
+        """Switching to Simple should clear the audio_codes textbox value."""
+        result = compute_mode_ui_updates("Simple", previous_mode="Custom")
+        codes_update = result[_IDX_AUDIO_CODES]
+        self.assertEqual(codes_update.get("value"), "")
+
+    def test_repaint_mode_clears_audio_codes(self):
+        """Switching to Repaint should clear the audio_codes textbox value."""
+        result = compute_mode_ui_updates("Repaint", previous_mode="Custom")
+        codes_update = result[_IDX_AUDIO_CODES]
+        self.assertEqual(codes_update.get("value"), "")
+
+    def test_custom_mode_clears_src_audio(self):
+        """Switching to Custom should clear src_audio (no source audio needed)."""
+        result = compute_mode_ui_updates("Custom", previous_mode="Remix")
+        src_update = result[_IDX_SRC_AUDIO]
+        self.assertIsNone(src_update.get("value"))
+
+    def test_simple_mode_clears_src_audio(self):
+        """Switching to Simple should clear src_audio."""
+        result = compute_mode_ui_updates("Simple", previous_mode="Remix")
+        src_update = result[_IDX_SRC_AUDIO]
+        self.assertIsNone(src_update.get("value"))
+
+    def test_remix_mode_preserves_src_audio(self):
+        """In Remix mode, src_audio should not be cleared (it's needed)."""
+        result = compute_mode_ui_updates("Remix")
+        src_update = result[_IDX_SRC_AUDIO]
+        # Should be a no-op update (no value key)
+        self.assertNotIn("value", src_update)
+
+    def test_repaint_mode_preserves_src_audio(self):
+        """In Repaint mode, src_audio should not be cleared (it's needed)."""
+        result = compute_mode_ui_updates("Repaint")
+        src_update = result[_IDX_SRC_AUDIO]
+        self.assertNotIn("value", src_update)
+
+    def test_round_trip_remix_to_custom_clears_both(self):
+        """Switching Remix -> Custom should clear both codes and src_audio."""
+        result = compute_mode_ui_updates("Custom", previous_mode="Remix")
+        codes_update = result[_IDX_AUDIO_CODES]
+        src_update = result[_IDX_SRC_AUDIO]
+        # Custom mode should not clear codes (it uses them)
+        self.assertTrue(codes_update.get("visible"))
+        # But src_audio should be cleared
+        self.assertIsNone(src_update.get("value"))
+
+    def test_round_trip_custom_to_remix_clears_codes(self):
+        """Switching Custom -> Remix should clear stale audio codes."""
+        result = compute_mode_ui_updates("Remix", previous_mode="Custom")
+        codes_update = result[_IDX_AUDIO_CODES]
+        self.assertEqual(codes_update.get("value"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/ui/gradio/events/results/audio_transfer.py
+++ b/acestep/ui/gradio/events/results/audio_transfer.py
@@ -73,9 +73,9 @@ def send_audio_to_remix(audio_file, lm_metadata, current_lyrics, current_caption
         llm_handler: Optional LLM handler.
 
     Returns:
-        46-tuple of Gradio updates (4 data + 42 mode-UI).
+        48-tuple of Gradio updates (4 data + 44 mode-UI).
     """
-    n_outputs = 46
+    n_outputs = 48
     if audio_file is None:
         return (gr.skip(),) * n_outputs
 
@@ -103,9 +103,9 @@ def send_audio_to_repaint(audio_file, lm_metadata, current_lyrics, current_capti
         llm_handler: Optional LLM handler.
 
     Returns:
-        46-tuple of Gradio updates (4 data + 42 mode-UI).
+        48-tuple of Gradio updates (4 data + 44 mode-UI).
     """
-    n_outputs = 46
+    n_outputs = 48
     if audio_file is None:
         return (gr.skip(),) * n_outputs
 

--- a/acestep/ui/gradio/events/results/generation_progress.py
+++ b/acestep/ui/gradio/events/results/generation_progress.py
@@ -93,6 +93,12 @@ def generate_with_progress(
     if task_type == "text2music":
         src_audio = None
 
+    # Defensive guard: cover/repaint/extract/lego tasks should never use
+    # stale audio codes from the text2music_audio_code_string textbox.
+    # Only text2music (Custom mode) with thinking disabled should pass codes.
+    if task_type != "text2music":
+        text2music_audio_code_string = ""
+
     gen_params = GenerationParams(
         task_type=task_type,
         instruction=instruction_display_gen,


### PR DESCRIPTION
When switching between Remix and Custom modes, stale values in text2music_audio_code_string and src_audio leaked across mode boundaries, causing the diffusion pipeline to incorrectly activate the cover path and produce noise output.

Root cause: compute_mode_ui_updates only toggled visibility of these components but never cleared their values on mode switch.

Changes:
- mode_ui.py: extend output tuple to 44 elements; clear audio codes when leaving Custom mode, clear src_audio when entering modes that don't use it (Custom, Simple)
- events/__init__.py: add the two new outputs to both the generation_mode.change() and _mode_ui_outputs output lists
- audio_transfer.py: update send_audio_to_remix/repaint to match the new 44-element tuple (48 total with 4 data outputs)
- generation_progress.py: add defensive guard to force-clear text2music_audio_code_string for non-text2music task types
- mode_ui_test.py: add 11 unit tests covering state-clearing behavior