### PR TITLE
Refactor (gradio part1) events wiring contracts

### DIFF
--- a/acestep/ui/gradio/events/wiring/__init__.py
+++ b/acestep/ui/gradio/events/wiring/__init__.py
@@ -1,0 +1,21 @@
+"""Wiring helpers for Gradio event registration.
+
+This package provides shared context and list-builder helpers used by the
+event wiring facade in ``acestep.ui.gradio.events``.
+"""
+
+from .context import (
+    GenerationWiringContext,
+    TrainingWiringContext,
+    build_auto_checkbox_inputs,
+    build_auto_checkbox_outputs,
+    build_mode_ui_outputs,
+)
+
+__all__ = [
+    "GenerationWiringContext",
+    "TrainingWiringContext",
+    "build_auto_checkbox_inputs",
+    "build_auto_checkbox_outputs",
+    "build_mode_ui_outputs",
+]

--- a/acestep/ui/gradio/events/wiring/context.py
+++ b/acestep/ui/gradio/events/wiring/context.py
@@ -1,0 +1,124 @@
+"""Typed wiring context and shared component-list builders.
+
+The event facade contains several long output/input lists that must remain in
+strict order. This module centralizes those list contracts to reduce copy-paste
+risk while keeping handler wiring behavior unchanged.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+ComponentMap = Mapping[str, Any]
+
+_AUTO_CHECKBOX_OUTPUT_KEYS = (
+    "bpm_auto",
+    "key_auto",
+    "timesig_auto",
+    "vocal_lang_auto",
+    "duration_auto",
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+)
+
+_AUTO_CHECKBOX_INPUT_KEYS = (
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+)
+
+_MODE_UI_OUTPUT_KEYS = (
+    "simple_mode_group",
+    "custom_mode_group",
+    "generate_btn",
+    "simple_sample_created",
+    "optional_params_accordion",
+    "task_type",
+    "src_audio_row",
+    "repainting_group",
+    "text2music_audio_codes_group",
+    "track_name",
+    "complete_track_classes",
+    "generate_btn_row",
+    "generation_mode",
+    "results_wrapper",
+    "think_checkbox",
+    "load_file_col",
+    "load_file",
+    "audio_cover_strength",
+    "cover_noise_strength",
+    "captions",
+    "lyrics",
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+    "auto_score",
+    "autogen_checkbox",
+    "auto_lrc",
+    "analyze_btn",
+    "repainting_header_html",
+    "repainting_start",
+    "repainting_end",
+    "previous_generation_mode",
+    "remix_help_group",
+    "extract_help_group",
+    "complete_help_group",
+    "bpm_auto",
+    "key_auto",
+    "timesig_auto",
+    "vocal_lang_auto",
+    "duration_auto",
+    "text2music_audio_code_string",
+    "src_audio",
+)
+
+
+@dataclass(frozen=True)
+class GenerationWiringContext:
+    """Inputs required for generation/results event wiring."""
+
+    demo: Any
+    dit_handler: Any
+    llm_handler: Any
+    dataset_handler: Any
+    dataset_section: ComponentMap
+    generation_section: ComponentMap
+    results_section: ComponentMap
+
+
+@dataclass(frozen=True)
+class TrainingWiringContext:
+    """Inputs required for training event wiring."""
+
+    demo: Any
+    dit_handler: Any
+    llm_handler: Any
+    training_section: ComponentMap
+
+
+def build_auto_checkbox_outputs(context: GenerationWiringContext) -> list[Any]:
+    """Return ordered auto-checkbox outputs for metadata field sync."""
+
+    generation = context.generation_section
+    return [generation[key] for key in _AUTO_CHECKBOX_OUTPUT_KEYS]
+
+
+def build_auto_checkbox_inputs(context: GenerationWiringContext) -> list[Any]:
+    """Return ordered metadata fields used to derive auto-checkbox state."""
+
+    generation = context.generation_section
+    return [generation[key] for key in _AUTO_CHECKBOX_INPUT_KEYS]
+
+
+def build_mode_ui_outputs(context: GenerationWiringContext) -> list[Any]:
+    """Return ordered mode-UI outputs shared across mode/remix/repaint wiring."""
+
+    generation = context.generation_section
+    return [generation[key] for key in _MODE_UI_OUTPUT_KEYS]

--- a/acestep/ui/gradio/events/wiring/context_test.py
+++ b/acestep/ui/gradio/events/wiring/context_test.py
@@ -1,0 +1,142 @@
+"""Unit tests for event-wiring context helpers."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+AUTO_OUTPUT_EXPECTED = [
+    "bpm_auto",
+    "key_auto",
+    "timesig_auto",
+    "vocal_lang_auto",
+    "duration_auto",
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+]
+
+AUTO_INPUT_EXPECTED = [
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+]
+
+MODE_OUTPUT_EXPECTED = [
+    "simple_mode_group",
+    "custom_mode_group",
+    "generate_btn",
+    "simple_sample_created",
+    "optional_params_accordion",
+    "task_type",
+    "src_audio_row",
+    "repainting_group",
+    "text2music_audio_codes_group",
+    "track_name",
+    "complete_track_classes",
+    "generate_btn_row",
+    "generation_mode",
+    "results_wrapper",
+    "think_checkbox",
+    "load_file_col",
+    "load_file",
+    "audio_cover_strength",
+    "cover_noise_strength",
+    "captions",
+    "lyrics",
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+    "auto_score",
+    "autogen_checkbox",
+    "auto_lrc",
+    "analyze_btn",
+    "repainting_header_html",
+    "repainting_start",
+    "repainting_end",
+    "previous_generation_mode",
+    "remix_help_group",
+    "extract_help_group",
+    "complete_help_group",
+    "bpm_auto",
+    "key_auto",
+    "timesig_auto",
+    "vocal_lang_auto",
+    "duration_auto",
+    "text2music_audio_code_string",
+    "src_audio",
+]
+
+
+def _load_context_module():
+    """Load the context module directly from disk without package side effects."""
+    module_path = Path(__file__).with_name("context.py")
+    spec = importlib.util.spec_from_file_location("events_wiring_context", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load spec for {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_MODULE = _load_context_module()
+GenerationWiringContext = _MODULE.GenerationWiringContext
+TrainingWiringContext = _MODULE.TrainingWiringContext
+build_auto_checkbox_inputs = _MODULE.build_auto_checkbox_inputs
+build_auto_checkbox_outputs = _MODULE.build_auto_checkbox_outputs
+build_mode_ui_outputs = _MODULE.build_mode_ui_outputs
+
+
+class GenerationWiringContextTests(unittest.TestCase):
+    """Verify ordered component-list builders used by event wiring."""
+
+    def setUp(self):
+        """Build a minimal context with deterministic component values."""
+        required_keys = set(MODE_OUTPUT_EXPECTED + AUTO_OUTPUT_EXPECTED + AUTO_INPUT_EXPECTED)
+        self.generation_section = {key: key for key in required_keys}
+        self.context = GenerationWiringContext(
+            demo=object(),
+            dit_handler=object(),
+            llm_handler=object(),
+            dataset_handler=object(),
+            dataset_section={},
+            generation_section=self.generation_section,
+            results_section={},
+        )
+
+    def test_build_auto_checkbox_outputs_uses_expected_order(self):
+        """Auto checkbox output order must remain stable across refactors."""
+        self.assertEqual(build_auto_checkbox_outputs(self.context), AUTO_OUTPUT_EXPECTED)
+
+    def test_build_auto_checkbox_inputs_uses_expected_order(self):
+        """Auto checkbox input order must remain stable across refactors."""
+        self.assertEqual(build_auto_checkbox_inputs(self.context), AUTO_INPUT_EXPECTED)
+
+    def test_build_mode_ui_outputs_uses_expected_order(self):
+        """Mode output list must match wiring contract for event handlers."""
+        self.assertEqual(build_mode_ui_outputs(self.context), MODE_OUTPUT_EXPECTED)
+
+
+class TrainingWiringContextTests(unittest.TestCase):
+    """Verify the training context stores expected references."""
+
+    def test_training_context_keeps_training_section_reference(self):
+        """Training context should keep the original section mapping."""
+        training_section = {"training_progress": "training_progress"}
+        context = TrainingWiringContext(
+            demo=object(),
+            dit_handler=object(),
+            llm_handler=object(),
+            training_section=training_section,
+        )
+        self.assertIs(context.training_section, training_section)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Functional decomposition of Gradio event wiring.
- Extracts repeated wiring list contracts into shared helpers without changing public event facade interfaces.
- Keeps behaviour unchanged while reducing copy-paste risk ahead of follow-up splits.

## Scope
- Added Acestep/ui/gradio/events/wiring/context.py with:
  - GenerationWiringContext
  - TrainingWiringContext
  - Build_auto_checkbox_inputs(...)
  - Build_auto_checkbox_outputs(...)
  - Build_mode_ui_outputs(...)
- Added Acestep/ui/gradio/events/wiring/__init__.py re-exports.
- Updated Acestep/ui/gradio/events/__init__.py to consume shared builders for:
  - auto-checkbox input/output lists
  - mode UI output list
- Added Acestep/ui/gradio/events/wiring/context_test.py to lock ordering contracts.


- No handler behaviour changes.
- No interface signature changes for:
  - setup_event_handlers(...)
  - setup_training_event_handlers(...)
- No cross-path runtime/hardware changes.

## Validation
Code review by GLM5 with no issues.

### Unit tests introduced
- Acestep/ui/gradio/events/wiring/context_test.py
  - verifies auto-checkbox output ordering
  - verifies auto-checkbox input ordering
  - verifies mode UI output ordering
  - verifies training context reference integrity

### Unit tests run
- python -m unittest discover -s acestep/ui/gradio/events/wiring -p context_test.py (pass)

### Manual UI tests passed
- Generation and Training tabs load without startup errors.
- Generation mode switching (Custom/Simple/Remix/Repaint/Extract/Complete) keeps UI visibility/labels consistent.
- Auto-checkbox flows remain correct for reset + populated-field uncheck behaviour.
- Send-to-Remix / Send-to-Repaint actions preserve expected mode/field transitions.
- Batch navigation (Prev/Next/Restore Params) behaviour remains intact.
- LRC display change updates subtitles on matching audio component.
- Training tab interaction smoke checks (load/scan/dataset controls) remain wired.

## Risk
- Low. This is a wiring-contract extraction with ordering covered by dedicated tests.
- Residual risk is primarily runtime key presence in component dicts (same behaviour as before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal structure of UI event handling system for better maintainability and code organization.

* **Tests**
  * Added comprehensive test coverage for event wiring context and builder components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->