### PR TITLE
fix(gradio): restore language and optional parameter interactivity

### DIFF
--- a/acestep/ui/gradio/events/wiring/generation_service_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_service_wiring.py
@@ -9,6 +9,7 @@ from typing import Any
 import gradio as gr
 
 from .. import generation_handlers as gen_h
+from ...i18n import get_i18n
 from .context import (
     GenerationWiringContext,
     build_auto_checkbox_inputs,
@@ -39,6 +40,12 @@ def register_generation_service_handlers(
     generation_section["refresh_btn"].click(
         fn=lambda: gen_h.refresh_checkpoints(dit_handler),
         outputs=[generation_section["checkpoint_dropdown"]],
+    )
+
+    generation_section["language_dropdown"].change(
+        fn=lambda language: _apply_runtime_language(language),
+        inputs=[generation_section["language_dropdown"]],
+        outputs=[generation_section["language_dropdown"]],
     )
 
     generation_section["config_path"].change(
@@ -189,3 +196,17 @@ def register_generation_service_handlers(
     )
 
     return auto_checkbox_inputs, auto_checkbox_outputs
+
+
+def _apply_runtime_language(language: str) -> dict[str, Any]:
+    """Update global i18n language for runtime-generated messages.
+
+    Args:
+        language: Selected UI language code from the language dropdown.
+
+    Returns:
+        A ``gr.update`` payload preserving the selected dropdown value.
+    """
+
+    get_i18n(language)
+    return gr.update(value=language)

--- a/acestep/ui/gradio/events/wiring/generation_service_wiring_test.py
+++ b/acestep/ui/gradio/events/wiring/generation_service_wiring_test.py
@@ -1,0 +1,55 @@
+"""Contract tests for generation service wiring."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+_WIRING_PATH = Path(__file__).resolve().parent / "generation_service_wiring.py"
+
+
+class GenerationServiceWiringTests(unittest.TestCase):
+    """Verify key event hooks are present in generation service wiring."""
+
+    def test_registers_language_dropdown_change_handler(self):
+        """Service wiring should attach a change handler for language dropdown."""
+
+        module = ast.parse(_WIRING_PATH.read_text(encoding="utf-8"))
+        register_fn = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.FunctionDef) and node.name == "register_generation_service_handlers"
+        )
+
+        found_language_change = False
+        for node in ast.walk(register_fn):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "change":
+                continue
+            if not isinstance(node.func.value, ast.Subscript):
+                continue
+            target = node.func.value
+            if (
+                isinstance(target.value, ast.Name)
+                and target.value.id == "generation_section"
+                and isinstance(target.slice, ast.Constant)
+                and target.slice.value == "language_dropdown"
+            ):
+                found_language_change = True
+                break
+
+        self.assertTrue(found_language_change, "language_dropdown.change handler was not found")
+
+    def test_language_runtime_helper_exists(self):
+        """Runtime language helper should exist for dropdown change wiring."""
+
+        module = ast.parse(_WIRING_PATH.read_text(encoding="utf-8"))
+        function_names = {
+            node.name for node in module.body if isinstance(node, ast.FunctionDef)
+        }
+        self.assertIn("_apply_runtime_language", function_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -28,6 +28,7 @@ def build_language_selector(current_language: str) -> dict[str, Any]:
             value=current_language,
             label=t("service.language_label"),
             info=t("service.language_info"),
+            interactive=True,
             elem_classes=["has-info-container"],
             scale=1,
         )

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows_test.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows_test.py
@@ -1,0 +1,47 @@
+"""Contract tests for generation service-config row builders."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+_ROWS_PATH = Path(__file__).resolve().parent / "generation_service_config_rows.py"
+
+
+class GenerationServiceConfigRowsTests(unittest.TestCase):
+    """Verify service row builder contracts needed by the UI wiring."""
+
+    def test_language_dropdown_is_explicitly_interactive(self):
+        """Language selector should remain interactive for runtime language selection."""
+
+        module = ast.parse(_ROWS_PATH.read_text(encoding="utf-8"))
+        func = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.FunctionDef) and node.name == "build_language_selector"
+        )
+
+        dropdown_calls = [
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "Dropdown"
+        ]
+        self.assertTrue(dropdown_calls, "Expected a gr.Dropdown call in build_language_selector")
+
+        interactive_kw = next(
+            (
+                kw
+                for kw in dropdown_calls[0].keywords
+                if kw.arg == "interactive"
+            ),
+            None,
+        )
+        self.assertIsNotNone(interactive_kw, "language_dropdown should set interactive explicitly")
+        self.assertIsInstance(interactive_kw.value, ast.Constant)
+        self.assertTrue(interactive_kw.value.value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/ui/gradio/interfaces/generation_tab_optional_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_optional_controls.py
@@ -39,7 +39,7 @@ def build_optional_parameter_controls(
                 step=1,
                 info=t("generation.bpm_info"),
                 elem_classes=["has-info-container"],
-                interactive=False,
+                interactive=not service_mode,
             )
             key_scale = gr.Textbox(
                 label=t("generation.keyscale_label"),
@@ -47,7 +47,7 @@ def build_optional_parameter_controls(
                 value="",
                 info=t("generation.keyscale_info"),
                 elem_classes=["has-info-container"],
-                interactive=False,
+                interactive=not service_mode,
             )
             time_signature = gr.Dropdown(
                 choices=["", "2", "3", "4", "6", "N/A"],
@@ -56,7 +56,7 @@ def build_optional_parameter_controls(
                 allow_custom_value=True,
                 info=t("generation.timesig_info"),
                 elem_classes=["has-info-container"],
-                interactive=False,
+                interactive=not service_mode,
             )
             vocal_language = gr.Dropdown(
                 choices=[(lang if lang != "unknown" else "Instrumental / auto", lang) for lang in VALID_LANGUAGES],
@@ -65,7 +65,7 @@ def build_optional_parameter_controls(
                 info=t("generation.vocal_language_info"),
                 allow_custom_value=True,
                 elem_classes=["has-info-container"],
-                interactive=False,
+                interactive=not service_mode,
             )
         with gr.Row(elem_classes=["auto-toggles-row"]):
             bpm_auto = gr.Checkbox(
@@ -102,7 +102,7 @@ def build_optional_parameter_controls(
                 info=t("generation.duration_info")
                 + f" (Max: {max_duration}s / {max_duration // 60} min)",
                 elem_classes=["has-info-container"],
-                interactive=False,
+                interactive=not service_mode,
             )
             batch_size_input = gr.Number(
                 label=t("generation.batch_size_label"),

--- a/acestep/ui/gradio/interfaces/generation_tab_optional_controls_test.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_optional_controls_test.py
@@ -1,0 +1,55 @@
+"""Contract tests for generation optional-parameter controls."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+_OPTIONAL_PATH = Path(__file__).resolve().parent / "generation_tab_optional_controls.py"
+_EXPECTED_NAMES = {
+    "bpm",
+    "key_scale",
+    "time_signature",
+    "vocal_language",
+    "audio_duration",
+}
+
+
+class GenerationTabOptionalControlsTests(unittest.TestCase):
+    """Verify optional controls stay editable outside service mode."""
+
+    def test_optional_fields_use_service_mode_gated_interactivity(self):
+        """Optional controls should use ``interactive=not service_mode`` consistently."""
+
+        module = ast.parse(_OPTIONAL_PATH.read_text(encoding="utf-8"))
+        func = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.FunctionDef) and node.name == "build_optional_parameter_controls"
+        )
+
+        found: dict[str, ast.AST] = {}
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            target_name = node.targets[0].id
+            if target_name not in _EXPECTED_NAMES:
+                continue
+            if not isinstance(node.value, ast.Call):
+                continue
+            interactive_kw = next((kw for kw in node.value.keywords if kw.arg == "interactive"), None)
+            if interactive_kw is not None:
+                found[target_name] = interactive_kw.value
+
+        self.assertEqual(_EXPECTED_NAMES, set(found.keys()))
+        for field_name, expr in found.items():
+            self.assertIsInstance(expr, ast.UnaryOp, f"{field_name} should use 'not service_mode'")
+            self.assertIsInstance(expr.op, ast.Not, f"{field_name} should negate service_mode")
+            self.assertIsInstance(expr.operand, ast.Name, f"{field_name} should reference service_mode")
+            self.assertEqual("service_mode", expr.operand.id, f"{field_name} should use service_mode")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
Fixes the UI interactivity regression reported in #669:
- language selector in Settings became non-interactive
- Optional Parameters fields (BPM/Key/Time Signature/Vocal Language/Audio Duration) were effectively locked, while Batch Size remained editable

## Root Cause (How Regression Occurred)
This regression was introduced during the generation UI decomposition from a monolithic interface builder into smaller modules.

1. Optional Parameters controls were moved into generation_tab_optional_controls.py with hardcoded interactive=False on metadata inputs. In the decomposed flow this left those controls disabled by default, which made them appear unusable.
2. Language selector moved into generation_service_config_rows.py without an explicit runtime change hook in service wiring, so changing language at runtime did not apply through the event layer.

## What Changed
- Acestep/ui/gradio/interfaces/generation_tab_optional_controls.py
  - Restored input interactivity for optional metadata fields via interactive=not service_mode:
    - Bpm, key_scale, Time_signature, Local_language, Audio_duration
- Acestep/ui/gradio/interfaces/generation_service_config_rows.py
  - Set language_dropdown to interactive=True
- Acestep/ui/gradio/events/wiring/generation_service_wiring.py
  - Added language_dropdown.change(...) wiring and runtime i18n apply helper (_apply_runtime_language) so language changes are propagated through event state

## Tests Added
- Acestep/ui/gradio/interfaces/generation_tab_optional_controls_test.py
- Acestep/ui/gradio/interfaces/generation_service_config_rows_test.py
- Acestep/ui/gradio/events/wiring/generation_service_wiring_test.py

## Validation
- python -m unittest discover -s acestep/ui/gradio/interfaces -p "generation_service_config_rows_test.py"
- python -m unittest discover -s acestep/ui/gradio/interfaces -p "generation_tab_optional_controls_test.py"
- python -m unittest discover -s acestep/ui/gradio/events/wiring -p "generation_service_wiring_test.py"
- python -m unittest discover -s acestep/ui/gradio/interfaces -p "*decomposition*test.py"

Fixes #669
