### PR TITLE
Fix Gradio audio volume persistence and playback reset

### DIFF
--- a/acestep/ui/gradio/events/results/audio_playback_updates.py
+++ b/acestep/ui/gradio/events/results/audio_playback_updates.py
@@ -1,0 +1,36 @@
+"""Audio playback update helpers for Gradio result players.
+
+These helpers standardize audio update payloads so playback always rewinds to
+the start of the track when a new value is assigned.
+"""
+
+from typing import Any, Optional
+
+
+def build_audio_slot_update(
+    gr_module: Any,
+    audio_path: Optional[str],
+    *,
+    label: Optional[str] = None,
+    interactive: Optional[bool] = None,
+) -> Any:
+    """Build an audio slot update that always rewinds playback to 0.
+
+    Args:
+        gr_module: Module/object exposing ``update(**kwargs)``.
+        audio_path: Filepath for the audio component, or ``None`` to clear.
+        label: Optional component label override.
+        interactive: Optional component interactivity override.
+
+    Returns:
+        The framework-specific update object returned by ``gr_module.update``.
+    """
+    update_kwargs = {
+        "value": audio_path,
+        "playback_position": 0,
+    }
+    if label is not None:
+        update_kwargs["label"] = label
+    if interactive is not None:
+        update_kwargs["interactive"] = interactive
+    return gr_module.update(**update_kwargs)

--- a/acestep/ui/gradio/events/results/audio_playback_updates_test.py
+++ b/acestep/ui/gradio/events/results/audio_playback_updates_test.py
@@ -1,0 +1,62 @@
+"""Unit tests for audio_playback_updates helpers."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+def _load_module():
+    """Load the target module directly by file path for isolated testing."""
+    module_path = Path(__file__).with_name("audio_playback_updates.py")
+    spec = importlib.util.spec_from_file_location("audio_playback_updates", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_MODULE = _load_module()
+build_audio_slot_update = _MODULE.build_audio_slot_update
+
+
+class _FakeGr:
+    """Minimal Gradio-like stub exposing ``update``."""
+
+    @staticmethod
+    def update(**kwargs):
+        """Return kwargs for direct assertion in tests."""
+        return kwargs
+
+
+class AudioPlaybackUpdatesTests(unittest.TestCase):
+    """Behavior tests for audio playback update builders."""
+
+    def test_build_audio_slot_update_sets_value_and_rewinds(self):
+        """Success path: slot update should carry path and playback reset."""
+        result = build_audio_slot_update(
+            _FakeGr,
+            "/tmp/sample.flac",
+            label="Sample 1 (Ready)",
+            interactive=False,
+        )
+        self.assertEqual(result["value"], "/tmp/sample.flac")
+        self.assertEqual(result["playback_position"], 0)
+        self.assertEqual(result["label"], "Sample 1 (Ready)")
+        self.assertFalse(result["interactive"])
+
+    def test_build_audio_slot_update_clear_path_rewinds(self):
+        """Regression path: clearing a slot should still force playback to start."""
+        result = build_audio_slot_update(_FakeGr, None)
+        self.assertEqual(result["value"], None)
+        self.assertEqual(result["playback_position"], 0)
+
+    def test_build_audio_slot_update_without_optional_flags_preserves_defaults(self):
+        """Non-target behavior: no label/interactivity overrides unless explicitly passed."""
+        result = build_audio_slot_update(_FakeGr, "/tmp/sample.flac")
+        self.assertEqual(result["value"], "/tmp/sample.flac")
+        self.assertEqual(result["playback_position"], 0)
+        self.assertNotIn("label", result)
+        self.assertNotIn("interactive", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/ui/gradio/events/results/batch_navigation.py
+++ b/acestep/ui/gradio/events/results/batch_navigation.py
@@ -12,6 +12,9 @@ import time as time_module
 import gradio as gr
 
 from acestep.ui.gradio.i18n import t
+from acestep.ui.gradio.events.results.audio_playback_updates import (
+    build_audio_slot_update,
+)
 from acestep.ui.gradio.events.results.batch_queue import (
     update_batch_indicator,
     update_navigation_buttons,
@@ -41,8 +44,9 @@ def navigate_to_previous_batch(current_batch_index, batch_queue):
 
     real_audio_paths = [p for p in audio_paths if not p.lower().endswith('.json')]
     audio_updates = [
-        gr.update(value=real_audio_paths[i].replace("\\", "/")) if i < len(real_audio_paths)
-        else gr.update(value=None)
+        build_audio_slot_update(gr, real_audio_paths[i].replace("\\", "/"))
+        if i < len(real_audio_paths)
+        else build_audio_slot_update(gr, None)
         for i in range(8)
     ]
 
@@ -108,8 +112,9 @@ def navigate_to_next_batch(autogen_enabled, current_batch_index, total_batches, 
 
     real_audio_paths = [p for p in audio_paths if not p.lower().endswith('.json')]
     audio_updates = [
-        gr.update(value=real_audio_paths[i].replace("\\", "/")) if i < len(real_audio_paths)
-        else gr.update(value=None)
+        build_audio_slot_update(gr, real_audio_paths[i].replace("\\", "/"))
+        if i < len(real_audio_paths)
+        else build_audio_slot_update(gr, None)
         for i in range(8)
     ]
 

--- a/acestep/ui/gradio/events/results/generation_info.py
+++ b/acestep/ui/gradio/events/results/generation_info.py
@@ -23,8 +23,20 @@ os.makedirs(DEFAULT_RESULTS_DIR, exist_ok=True)
 
 
 def clear_audio_outputs_for_new_generation():
-    """Return None for all 9 audio outputs so Gradio clears them and stops playback."""
-    return (None,) * 9
+    """Return pre-generation output updates without remounting audio players.
+
+    In Gradio runtime, keep the 8 audio components unchanged via ``gr.skip()``
+    and only clear the batch-download file list (9th output). This avoids
+    replacing player DOM nodes while generation is in progress, which can
+    reset browser-side volume state.
+
+    In non-Gradio test environments, gracefully fall back to 9 ``None`` values.
+    """
+    try:
+        import gradio as gr  # local import keeps headless tests dependency-free
+    except Exception:
+        return (None,) * 9
+    return (gr.skip(),) * 8 + (None,)
 
 
 def _build_generation_info(

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -28,6 +28,9 @@ from acestep.ui.gradio.interfaces.generation import (
     create_advanced_settings_section,
     create_generation_tab_section,
 )
+from acestep.ui.gradio.interfaces.audio_player_preferences import (
+    get_audio_player_preferences_head,
+)
 from acestep.ui.gradio.interfaces.result import create_results_section
 from acestep.ui.gradio.interfaces.training import create_training_section
 from acestep.ui.gradio.events import setup_event_handlers, setup_training_event_handlers
@@ -58,6 +61,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
     with gr.Blocks(
         title=t("app.title"),
         theme=gr.themes.Soft(),
+        head=get_audio_player_preferences_head(),
         css="""
         .main-header {
             text-align: center;

--- a/acestep/ui/gradio/interfaces/audio_player_preferences.py
+++ b/acestep/ui/gradio/interfaces/audio_player_preferences.py
@@ -1,0 +1,328 @@
+"""Frontend audio-player preference helpers for the Gradio UI."""
+
+
+def get_audio_player_preferences_head() -> str:
+    """Return head script that persists and syncs HTML audio volume.
+
+    The script keeps a shared preferred volume for Gradio audio players
+    (native ``audio`` elements and waveform volume sliders), stores it in
+    ``localStorage``, and reapplies it when components are re-rendered.
+    """
+    return """
+<script>
+(() => {
+    const STORAGE_KEY = "acestep.ui.audio.volume";
+    const EPSILON = 0.001;
+    const STARTUP_RESYNC_WINDOW_MS = 3000;
+    const STARTUP_RESYNC_INTERVAL_MS = 120;
+    const seenPlayers = new WeakSet();
+    const seenVolumeSliders = new WeakSet();
+    const sliderSyncSuppressedUntil = new WeakMap();
+    const observedRoots = new WeakSet();
+    const knownRoots = [];
+    const readyForPersistence = new WeakMap();
+    const wasReadyBeforeLoad = new WeakMap();
+    let scanScheduled = false;
+    let preferredVolume = null;
+    let startupResyncTimer = null;
+
+    const clampVolume = (value) => {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+            return null;
+        }
+        if (parsed < 0) {
+            return 0;
+        }
+        if (parsed > 1) {
+            return 1;
+        }
+        return parsed;
+    };
+
+    const loadPreferredVolume = () => {
+        try {
+            return clampVolume(window.localStorage.getItem(STORAGE_KEY));
+        } catch (_error) {
+            return null;
+        }
+    };
+
+    const storePreferredVolume = (value) => {
+        const clamped = clampVolume(value);
+        if (clamped === null) {
+            return;
+        }
+        preferredVolume = clamped;
+        try {
+            window.localStorage.setItem(STORAGE_KEY, String(clamped));
+        } catch (_error) {
+            // Ignore storage failures (private mode / blocked storage).
+        }
+    };
+
+    const isTrustedUserEvent = (event) => Boolean(event && event.isTrusted);
+
+    const applyPreferredVolume = (player) => {
+        if (!player || preferredVolume === null) {
+            return;
+        }
+        if (Math.abs(player.volume - preferredVolume) <= EPSILON) {
+            return;
+        }
+        player.volume = preferredVolume;
+    };
+
+    const forEachAudioPlayer = (callback) => {
+        for (let i = 0; i < knownRoots.length; i += 1) {
+            const root = knownRoots[i];
+            if (!root || !root.querySelectorAll) {
+                continue;
+            }
+            root.querySelectorAll("audio").forEach((player) => callback(player));
+        }
+    };
+
+    const forEachVolumeSlider = (callback) => {
+        for (let i = 0; i < knownRoots.length; i += 1) {
+            const root = knownRoots[i];
+            if (!root || !root.querySelectorAll) {
+                continue;
+            }
+            root.querySelectorAll("input.volume-slider[type='range'], input#volume[type='range']").forEach(
+                (slider) => callback(slider)
+            );
+        }
+    };
+
+    const applyPreferredVolumeToSlider = (slider) => {
+        if (!slider || preferredVolume === null) {
+            return;
+        }
+        const current = clampVolume(slider.value);
+        if (current !== null && Math.abs(current - preferredVolume) <= EPSILON) {
+            return;
+        }
+        sliderSyncSuppressedUntil.set(slider, Date.now() + 250);
+        slider.value = String(preferredVolume);
+        slider.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    const syncAllVolumeControlsToPreferred = (sourcePlayer = null, sourceSlider = null) => {
+        if (preferredVolume === null) {
+            return;
+        }
+        forEachAudioPlayer((player) => {
+            if (!player) {
+                return;
+            }
+            if (sourcePlayer && player !== sourcePlayer) {
+                if (Math.abs(player.volume - preferredVolume) > EPSILON) {
+                    player.volume = preferredVolume;
+                }
+                return;
+            }
+            applyPreferredVolume(player);
+        });
+        forEachVolumeSlider((slider) => {
+            if (!slider || slider === sourceSlider) {
+                return;
+            }
+            applyPreferredVolumeToSlider(slider);
+        });
+    };
+
+    const stopStartupResync = () => {
+        if (startupResyncTimer === null) {
+            return;
+        }
+        window.clearInterval(startupResyncTimer);
+        startupResyncTimer = null;
+    };
+
+    const beginStartupResync = () => {
+        stopStartupResync();
+        if (preferredVolume === null) {
+            return;
+        }
+
+        const startedAt = Date.now();
+        startupResyncTimer = window.setInterval(() => {
+            scanPlayers();
+            syncAllVolumeControlsToPreferred();
+            if (Date.now() - startedAt >= STARTUP_RESYNC_WINDOW_MS) {
+                stopStartupResync();
+            }
+        }, STARTUP_RESYNC_INTERVAL_MS);
+    };
+
+    const observeRoot = (root) => {
+        if (!root || observedRoots.has(root)) {
+            return;
+        }
+        observedRoots.add(root);
+        knownRoots.push(root);
+
+        const observeTarget = root === document ? document.documentElement : root;
+        if (!observeTarget) {
+            return;
+        }
+
+        new MutationObserver(() => {
+            scheduleScan();
+        }).observe(observeTarget, { childList: true, subtree: true });
+    };
+
+    const scheduleScan = () => {
+        if (scanScheduled) {
+            return;
+        }
+        scanScheduled = true;
+        requestAnimationFrame(() => {
+            scanScheduled = false;
+            scanPlayers();
+        });
+    };
+
+    const discoverRoots = () => {
+        const queue = [document];
+        const visited = new WeakSet();
+
+        while (queue.length > 0) {
+            const root = queue.pop();
+            if (!root || visited.has(root)) {
+                continue;
+            }
+            visited.add(root);
+            observeRoot(root);
+
+            if (!root.querySelectorAll) {
+                continue;
+            }
+            root.querySelectorAll("*").forEach((node) => {
+                if (node && node.shadowRoot) {
+                    queue.push(node.shadowRoot);
+                }
+            });
+        }
+    };
+
+    const registerPlayer = (player) => {
+        if (!player || seenPlayers.has(player)) {
+            return;
+        }
+        seenPlayers.add(player);
+        readyForPersistence.set(player, player.readyState > 0);
+        wasReadyBeforeLoad.set(player, false);
+        applyPreferredVolume(player);
+
+        player.addEventListener("volumechange", (event) => {
+            const next = clampVolume(player.volume);
+            if (next === null) {
+                return;
+            }
+
+            if (!isTrustedUserEvent(event)) {
+                applyPreferredVolume(player);
+                return;
+            }
+
+            if (preferredVolume !== null && Math.abs(next - preferredVolume) <= EPSILON) {
+                return;
+            }
+
+            if (
+                readyForPersistence.get(player) !== true
+                && wasReadyBeforeLoad.get(player) !== true
+            ) {
+                // Ignore mount/load reset events before media metadata is ready.
+                applyPreferredVolume(player);
+                return;
+            }
+
+            storePreferredVolume(next);
+            syncAllVolumeControlsToPreferred(player, null);
+        }, { passive: true });
+
+        const markReadyForPersistence = () => {
+            readyForPersistence.set(player, true);
+            wasReadyBeforeLoad.set(player, false);
+            applyPreferredVolume(player);
+            if (player.currentTime > 0) {
+                player.currentTime = 0;
+            }
+        };
+
+        player.addEventListener("loadedmetadata", () => {
+            markReadyForPersistence();
+        }, { passive: true });
+
+        player.addEventListener("loadstart", () => {
+            wasReadyBeforeLoad.set(player, readyForPersistence.get(player) === true);
+            readyForPersistence.set(player, false);
+            applyPreferredVolume(player);
+            if (player.currentTime > 0) {
+                player.currentTime = 0;
+            }
+        }, { passive: true });
+
+        if (player.readyState > 0) {
+            markReadyForPersistence();
+        }
+    };
+
+    const registerVolumeSlider = (slider) => {
+        if (!slider || seenVolumeSliders.has(slider)) {
+            return;
+        }
+        seenVolumeSliders.add(slider);
+        applyPreferredVolumeToSlider(slider);
+
+        const onSliderInput = (event) => {
+            const suppressedUntil = sliderSyncSuppressedUntil.get(slider) || 0;
+            if (Date.now() <= suppressedUntil) {
+                return;
+            }
+
+            if (!isTrustedUserEvent(event)) {
+                applyPreferredVolumeToSlider(slider);
+                return;
+            }
+
+            const next = clampVolume(slider.value);
+            if (next === null) {
+                return;
+            }
+            if (preferredVolume !== null && Math.abs(next - preferredVolume) <= EPSILON) {
+                return;
+            }
+            storePreferredVolume(next);
+            syncAllVolumeControlsToPreferred(null, slider);
+        };
+
+        slider.addEventListener("input", onSliderInput, { passive: true });
+        slider.addEventListener("change", onSliderInput, { passive: true });
+    };
+
+    const scanPlayers = () => {
+        discoverRoots();
+        forEachAudioPlayer(registerPlayer);
+        forEachVolumeSlider(registerVolumeSlider);
+        syncAllVolumeControlsToPreferred();
+    };
+
+    const start = () => {
+        preferredVolume = loadPreferredVolume();
+        scanPlayers();
+        beginStartupResync();
+        window.addEventListener("beforeunload", stopStartupResync, { once: true });
+    };
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start, { once: true });
+    } else {
+        start();
+    }
+})();
+</script>
+""".strip()

--- a/acestep/ui/gradio/interfaces/audio_player_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/audio_player_preferences_test.py
@@ -1,0 +1,56 @@
+"""Unit tests for audio player preference head-script generation."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+def _load_module():
+    """Load the target module directly by file path for isolated testing."""
+    module_path = Path(__file__).with_name("audio_player_preferences.py")
+    spec = importlib.util.spec_from_file_location("audio_player_preferences", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_MODULE = _load_module()
+get_audio_player_preferences_head = _MODULE.get_audio_player_preferences_head
+
+
+class AudioPlayerPreferencesHeadTests(unittest.TestCase):
+    """Tests for browser script generation used by Gradio ``Blocks(head=...)``."""
+
+    def test_script_contains_volume_persistence_and_sync_hooks(self):
+        """Success path: script should include storage and volume-change handling."""
+        script = get_audio_player_preferences_head()
+        self.assertIn("<script>", script)
+        self.assertIn("localStorage", script)
+        self.assertIn("volumechange", script)
+        self.assertIn("MutationObserver", script)
+        self.assertIn("shadowRoot", script)
+        self.assertIn("syncAllVolumeControlsToPreferred", script)
+        self.assertIn("volume-slider", script)
+        self.assertIn("readyForPersistence", script)
+        self.assertIn("wasReadyBeforeLoad", script)
+        self.assertIn("markReadyForPersistence", script)
+        self.assertIn("isTrustedUserEvent", script)
+        self.assertIn("STARTUP_RESYNC_WINDOW_MS", script)
+        self.assertIn("setInterval", script)
+
+    def test_script_resets_audio_position_on_updates(self):
+        """Regression path: script should force playback to track start on reloads."""
+        script = get_audio_player_preferences_head()
+        self.assertIn("currentTime = 0", script)
+        self.assertIn("loadstart", script)
+        self.assertIn("loadedmetadata", script)
+
+    def test_script_generation_is_stable(self):
+        """Non-target behavior: function should be deterministic for repeated calls."""
+        script_1 = get_audio_player_preferences_head()
+        script_2 = get_audio_player_preferences_head()
+        self.assertEqual(script_1, script_2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/studio.html
+++ b/ui/studio.html
@@ -439,6 +439,10 @@
     let wsRegions = null;
     let activeRegion = null;
     let uploadedFile = null;
+    const AUDIO_VOLUME_STORAGE_KEY = "acestep.studio.audio.volume";
+    const AUDIO_EPSILON = 0.001;
+    const managedAudioElements = new WeakSet();
+    let preferredAudioVolume = null;
 
     // --- SMART PROGRESS CONFIGURATION (Ported from Hitster) ---
     // This allows the bar to move smoothly even when server is thinking
@@ -471,6 +475,99 @@
         speedMod: 1.0, 
         timerId: null 
     };
+
+    function clampVolume(value) {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) return null;
+        if (parsed < 0) return 0;
+        if (parsed > 1) return 1;
+        return parsed;
+    }
+
+    function isTrustedUserEvent(event) {
+        return Boolean(event && event.isTrusted);
+    }
+
+    function loadPreferredAudioVolume() {
+        try {
+            return clampVolume(window.localStorage.getItem(AUDIO_VOLUME_STORAGE_KEY));
+        } catch (_error) {
+            return null;
+        }
+    }
+
+    function savePreferredAudioVolume(value) {
+        const clamped = clampVolume(value);
+        if (clamped === null) return;
+        preferredAudioVolume = clamped;
+        try {
+            window.localStorage.setItem(AUDIO_VOLUME_STORAGE_KEY, String(clamped));
+        } catch (_error) {
+            // Ignore storage failures (private mode / blocked storage).
+        }
+        if (wavesurfer && typeof wavesurfer.setVolume === 'function') {
+            wavesurfer.setVolume(clamped);
+        }
+    }
+
+    function applyPreferredVolumeToAudio(audioEl) {
+        if (!audioEl || preferredAudioVolume === null) return;
+        if (Math.abs(audioEl.volume - preferredAudioVolume) <= AUDIO_EPSILON) return;
+        audioEl.volume = preferredAudioVolume;
+    }
+
+    function syncAllAudioVolumes(sourceAudio = null) {
+        if (preferredAudioVolume === null) return;
+        document.querySelectorAll('audio').forEach((audioEl) => {
+            if (!audioEl) return;
+            if (sourceAudio && audioEl === sourceAudio) {
+                applyPreferredVolumeToAudio(audioEl);
+                return;
+            }
+            if (Math.abs(audioEl.volume - preferredAudioVolume) > AUDIO_EPSILON) {
+                audioEl.volume = preferredAudioVolume;
+            }
+        });
+        if (wavesurfer && typeof wavesurfer.setVolume === 'function') {
+            wavesurfer.setVolume(preferredAudioVolume);
+        }
+    }
+
+    function registerAudioElement(audioEl) {
+        if (!audioEl || managedAudioElements.has(audioEl)) return;
+        managedAudioElements.add(audioEl);
+        applyPreferredVolumeToAudio(audioEl);
+
+        audioEl.addEventListener('volumechange', (event) => {
+            if (!isTrustedUserEvent(event)) {
+                applyPreferredVolumeToAudio(audioEl);
+                return;
+            }
+            const next = clampVolume(audioEl.volume);
+            if (next === null) return;
+            if (preferredAudioVolume !== null && Math.abs(next - preferredAudioVolume) <= AUDIO_EPSILON) return;
+            savePreferredAudioVolume(next);
+            syncAllAudioVolumes(audioEl);
+        }, { passive: true });
+
+        audioEl.addEventListener('loadedmetadata', () => {
+            applyPreferredVolumeToAudio(audioEl);
+            if (audioEl.currentTime > 0) audioEl.currentTime = 0;
+        }, { passive: true });
+
+        audioEl.addEventListener('loadstart', () => {
+            applyPreferredVolumeToAudio(audioEl);
+            if (audioEl.currentTime > 0) audioEl.currentTime = 0;
+        }, { passive: true });
+    }
+
+    function scanAndRegisterAudioPlayers() {
+        document.querySelectorAll('audio').forEach(registerAudioElement);
+        syncAllAudioVolumes();
+    }
+
+    preferredAudioVolume = loadPreferredAudioVolume();
+    scanAndRegisterAudioPlayers();
 
     // --- UI Listeners ---
     elements.strength.addEventListener('input', (e) => {
@@ -508,6 +605,9 @@
         wavesurfer.on('ready', () => {
             const dur = wavesurfer.getDuration();
             elements.wsTimeDisplay.innerText = `0:00 / ${formatTime(dur)}`;
+            if (preferredAudioVolume !== null && typeof wavesurfer.setVolume === 'function') {
+                wavesurfer.setVolume(preferredAudioVolume);
+            }
         });
 
         wavesurfer.on('audioprocess', (time) => {
@@ -812,6 +912,7 @@
             `;
 
             elements.resultsGrid.prepend(card);
+            scanAndRegisterAudioPlayers();
         } catch (e) {
             log("Parsing error: " + e.message, "log-error");
         }

--- a/ui/studio_html_test.py
+++ b/ui/studio_html_test.py
@@ -1,0 +1,28 @@
+"""Unit tests for studio HTML audio volume persistence guards."""
+
+from pathlib import Path
+import unittest
+
+
+class StudioHtmlVolumeGuardTests(unittest.TestCase):
+    """Tests for trusted-event gating in studio volume persistence logic."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Load studio HTML content once for all assertions."""
+        cls._html = Path(__file__).with_name("studio.html").read_text(encoding="utf-8")
+
+    def test_contains_trusted_event_helper(self):
+        """Success path: trusted-event helper should exist."""
+        self.assertIn("function isTrustedUserEvent(event)", self._html)
+        self.assertIn("event && event.isTrusted", self._html)
+
+    def test_volumechange_listener_guards_non_trusted_events(self):
+        """Regression path: listener should reject non-user volumechange events."""
+        self.assertIn("audioEl.addEventListener('volumechange', (event) => {", self._html)
+        self.assertIn("if (!isTrustedUserEvent(event)) {", self._html)
+        self.assertIn("applyPreferredVolumeToAudio(audioEl);", self._html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes a long-running Gradio audio UX bug where volume repeatedly snapped back to 100% and playback position handling was inconsistent after generation updates/re-renders.

Yes, this one was a *fun* chase: browser media defaults, Gradio waveform internals, remount behavior, and event timing all teamed up to hide the real root cause.

Major bug fix, my marriage is no longer at risk now I can safely audition my generations without accidentally waking my wife at 1 am with 1200w of awesome heavy metal.

Fixes #675 #156 

## Problem Statement

Users reported:
- volume resets to maximum after generation,
- multiple volume controls not staying in sync,
- volume not persisting across page reloads/sessions,
- playback marker expected to reset to track start when new audio is assigned.

## Root Causes

1. Gradio waveform mode uses its own `volume-slider` control path, not just native `<audio>` volume events.
2. Some UI updates replaced/remounted audio components, allowing browser defaults (`volume=1`) to leak back in.
3. Programmatic/non-user `volumechange` events could overwrite persisted settings if not filtered.
4. Load-cycle timing (`loadstart`/`loadedmetadata`) required guardrails to avoid persisting transient initialization state.

## Review Findings Incorporated

From review feedback, this PR addresses both critical findings:

1. **Missing trusted-event check in `ui/studio.html`**
- Added `isTrustedUserEvent(event)` and guarded `volumechange` persistence.
- Non-user/programmatic events now re-apply preferred volume instead of persisting browser defaults.

2. **`readyForPersistence` load-cycle race in Gradio head script**
- Added `wasReadyBeforeLoad` guard state.
- During load cycles, trusted volume changes are only persisted if the player was previously ready.
- Prevents transient init/reset states from contaminating stored preference.

## What Changed

### Gradio result/update behavior
- Added shared helper to enforce playback rewind on slot assignment:
  - `acestep/ui/gradio/events/results/audio_playback_updates.py`
- Applied helper in generation flow + batch navigation:
  - `acestep/ui/gradio/events/results/generation_progress.py`
  - `acestep/ui/gradio/events/results/batch_navigation.py`
- Kept players mounted during generation prep by using `gr.skip()`:
  - `acestep/ui/gradio/events/results/generation_info.py`

### Gradio volume persistence + sync
- Added browser-side head script injection:
  - `acestep/ui/gradio/interfaces/audio_player_preferences.py`
  - wired via `acestep/ui/gradio/interfaces/__init__.py`
- Supports both:
  - native audio elements,
  - Gradio waveform slider controls (`input.volume-slider` / `input#volume`).
- Uses `localStorage` for persisted preferred volume.
- Syncs all controls to a single source of truth.
- Adds startup resync window to handle late-mount controls.
- Filters persistence to trusted user events.
- Adds load-cycle race guard (`wasReadyBeforeLoad`).

### Studio page parity
- Added persisted audio volume behavior and sync in:
  - `ui/studio.html`
- Added trusted-event guard to avoid persisting programmatic resets.

## Tests Added/Updated

- `acestep/ui/gradio/events/results/audio_playback_updates_test.py`
- `acestep/ui/gradio/interfaces/audio_player_preferences_test.py`
- `acestep/ui/gradio/events/results/generation_info_test.py` (updated)
- `ui/studio_html_test.py`

### Automated test commands run

- `python3 acestep/ui/gradio/events/results/audio_playback_updates_test.py`
- `python3 acestep/ui/gradio/interfaces/audio_player_preferences_test.py`
- `python3 acestep/ui/gradio/events/results/generation_info_test.py`
- `python3 ui/studio_html_test.py`
- `python3 -m py_compile acestep/ui/gradio/events/results/batch_navigation.py acestep/ui/gradio/events/results/generation_info.py acestep/ui/gradio/events/results/generation_progress.py acestep/ui/gradio/events/results/audio_playback_updates.py acestep/ui/gradio/interfaces/__init__.py acestep/ui/gradio/interfaces/audio_player_preferences.py ui/studio_html_test.py`

## Manual UI Validation

Manual iterative validation was performed in the Gradio interface on **Brave (Chromium)** while reproducing the originally reported issue:

1. Set playback volume below 100%.
2. Start generation and observe in-progress UI updates.
3. Verify volume does not snap to max during generation progress.
4. On generated output assignment, verify playback position resets to start.
5. Interact with available volume controls and confirm they remain synchronized.
6. Reload the page and verify prior volume preference is restored.
7. Repeat generation cycle to confirm behavior remains stable.

## Scope / Risk

- Scope is limited to audio playback/volume UX in Gradio result paths and studio page.
- No model/inference logic changes.
- Primary risk area is browser event ordering; mitigated with trusted-event gating, load-cycle guards, and focused regression tests.
