### PR TITLE
refactor: clean up i18n discovery and CLI help

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -36,6 +36,7 @@ try:
     from .llm_inference import LLMHandler
     from .dataset_handler import DatasetHandler
     from .ui.gradio import create_gradio_interface
+    from acestep.ui.gradio.i18n import get_i18n, available_languages_info
     from .gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB, is_mps_platform
     from .model_downloader import ensure_lm_model
 except ImportError:
@@ -47,6 +48,7 @@ except ImportError:
     from acestep.llm_inference import LLMHandler
     from acestep.dataset_handler import DatasetHandler
     from acestep.ui.gradio import create_gradio_interface
+    from acestep.ui.gradio.i18n import get_i18n, available_languages_info
     from acestep.gpu_config import get_gpu_config, get_gpu_memory_gb, print_gpu_config_info, set_global_gpu_config, VRAM_16GB_MIN_GB, VRAM_AUTO_OFFLOAD_THRESHOLD_GB, is_mps_platform
     from acestep.model_downloader import ensure_lm_model
 
@@ -133,26 +135,28 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
     print(f"Output directory: {output_dir}")
 
-    parser = argparse.ArgumentParser(description="Gradio Demo for ACE-Step V1.5")
+    # Initialize i18n with default language (en)
+    get_i18n()
+
+    parser = argparse.ArgumentParser(
+        description="Gradio Demo for ACE-Step V1.5",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
     parser.add_argument("--port", type=int, default=7860, help="Port to run the gradio server on")
     parser.add_argument("--share", action="store_true", help="Create a public link")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     parser.add_argument("--server-name", type=str, default="127.0.0.1", help="Server name (default: 127.0.0.1, use 0.0.0.0 for all interfaces)")
         
-    # UI language argument
-    available_ui_language_codes = []
-    i18n_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ui", "gradio", "i18n")
-    if os.path.exists(i18n_dir):
-        for filename in os.listdir(i18n_dir):
-            if filename.endswith(".json"):
-                available_ui_language_codes.append(filename[:-5]) # Remove .json extension and append language code to list
+    # language argument
+    available_languages = available_languages_info()
     parser.add_argument(
         "--language", 
         type=str, 
         default="en", 
-        choices=available_ui_language_codes, 
-        help="UI language: " + ", ".join(available_ui_language_codes)
+        choices=[language[0] for language in available_languages],
+        help="UI language:\n  " + "\n  ".join((code + f" ({native_name}" + (f"/{name})" if name != native_name else ")") for code, name, native_name in available_languages))
     )
+    del available_languages
     
     parser.add_argument(
         "--allowed-path",

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -49,7 +49,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
     Returns:
         Gradio Blocks instance
     """
-    # Initialize i18n with selected language
+    # Update i18n with selected language
     i18n = get_i18n(language)
     
     # Check if running in service mode (hide training tab)


### PR DESCRIPTION
# Refactor: Clean Up i18n Discovery and Improve CLI Help

## Summary

This refactor consolidates i18n language discovery logic and improves
the formatting of the `--language` CLI argument help output.

## Changes

- Initialize i18n earlier in `acestep_v15_pipeline.py` `main()` function
  - Eliminates redundant JSON scanning of the `i18n` directory
  - Removes duplicate dynamic discovery logic previously used for the `--language` argument
- Switched argparse formatter to `RawTextHelpFormatter`
  - Enables proper hanging indent formatting
  - Allows `\n` to render correctly in help strings
- Improved dynamic `--language` argument help output formatting

### Before

```
--language {en,he,ja,zh}
                    UI language: en, he, ja, zh
```

### After

```
--language {en,he,ja,zh}
                    UI language:
                      en (English)
                      he (עברית/Hebrew)
                      ja (日本語/Japanese)
                      zh (中文/Chinese)
```

## Benefits

- Removes redundant filesystem operations
- Consolidates language discovery into a single source of truth
- Improves CLI readability and scalability
- Keeps future language additions fully dynamic

This change does not modify functionality — it improves structure,
clarity, and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved help text formatting for better readability

* **Refactor**
  * Enhanced language selection and initialization mechanism for the application's multi-language support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->