### PR TITLE
fix: replace 3 bare excepts with specific exception types

### DIFF
--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -2602,7 +2602,7 @@ class LLMHandler:
                     if current_key == 'bpm':
                         try:
                             metadata['bpm'] = int(value.strip())
-                        except:
+                        except (ValueError, TypeError):
                             metadata['bpm'] = value.strip()
                     elif current_key == 'caption':
                         # Post-process caption to remove YAML multi-line formatting
@@ -2610,7 +2610,7 @@ class LLMHandler:
                     elif current_key == 'duration':
                         try:
                             metadata['duration'] = int(value.strip())
-                        except:
+                        except (ValueError, TypeError):
                             metadata['duration'] = value.strip()
                     elif current_key == 'genres':
                         metadata['genres'] = value.strip()

--- a/scripts/lora_data_prepare/gemini_caption.py
+++ b/scripts/lora_data_prepare/gemini_caption.py
@@ -473,7 +473,7 @@ def analysis_audio_by_gemini(
     )
     try:
         json_result = json.loads(result)
-    except:
+    except (json.JSONDecodeError, ValueError):
         json_result = extract_json_from_text(result)
     if json_result is None:
         raise Exception(f"无法解析json, {result}")


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses with specific exception types.

## Changes

- **`acestep/llm_inference.py`** (2 sites): `except:` → `except (ValueError, TypeError):` for `int()` conversions of `bpm` and `duration` metadata fields
- **`scripts/lora_data_prepare/gemini_caption.py`** (1 site): `except:` → `except (json.JSONDecodeError, ValueError):` for `json.loads()` parsing

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination. Using specific exception types is safer, clearer, and follows Python best practices (PEP 8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved error handling throughout the application for enhanced robustness and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->