### PR TITLE
docs: add Awesome ACE-Step link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
     <a href="https://modelscope.cn/models/ACE-Step/Ace-Step1.5">ModelScope</a> |
     <a href="https://huggingface.co/spaces/ACE-Step/Ace-Step-v1.5">Space Demo</a> |
     <a href="https://discord.gg/PeWDxrkdj7">Discord</a> |
-    <a href="https://arxiv.org/abs/2602.00744">Technical Report</a>
+    <a href="https://arxiv.org/abs/2602.00744">Technical Report</a> |
+    <a href="https://github.com/ace-step/awesome-ace-step">Awesome ACE-Step</a>
 </p>
 
 <p align="center">
@@ -263,6 +264,10 @@ The only official website for the ACE-Step project is our GitHub Pages site.
 🚫 Fake domains include but are not limited to:
 ac\*\*p.com, a\*\*p.org, a\*\*\*c.org  
 ⚠️ Please be cautious. Do not visit, trust, or make payments on any of those sites.
+
+## 🌐 Community & Ecosystem
+
+Check out **[Awesome ACE-Step](https://github.com/ace-step/awesome-ace-step)** — a curated list of community projects, alternative UIs, ComfyUI nodes, cloud deployments, training tools, and more built around ACE-Step.
 
 ## 🙏 Acknowledgements
 


### PR DESCRIPTION
## Summary

- Add a link to the curated [awesome-ace-step](https://github.com/ace-step/awesome-ace-step) community resource list in the README.
- The link appears in two places:
  1. **Top navigation bar** — alongside Project, Hugging Face, ModelScope, Space Demo, Discord, and Technical Report.
  2. **New "Community & Ecosystem" section** — before Acknowledgements, with a brief description of the awesome list.

The [awesome-ace-step](https://github.com/ace-step/awesome-ace-step) repository is a curated collection of community projects, alternative UIs (Tadpole Studio, ace-step-ui), ComfyUI nodes, C++/GGML port, training tools (Side-Step), cloud deployment options (Replicate, fal.ai, Modal, Vast.ai), and more.

## Test plan

- [ ] Verify both links render correctly in the GitHub README preview.
- [ ] Confirm the awesome-ace-step URL resolves to the live repository.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Community & Ecosystem section highlighting the Awesome ACE-Step repository.
  * Introduced new external links to community resources throughout the documentation.
  * Enhanced visibility of ecosystem contributions and community projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->