### PR TITLE
Automated clean up of issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -18,17 +18,19 @@ jobs:
         with:
           repo-token: ${{ github.token }}
 
-          # "No activity for ~1 month" -> mark stale at 21 days,
+          # "No activity for 28 days" -> mark stale at 21 days,
           # then close 7 days after being marked stale
           days-before-issue-stale: 21
           days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
 
           stale-issue-label: stale
           close-issue-message: >
-            Closing due to 30 days of inactivity. If this is still relevant,
+            Closing due to 28 days of inactivity. If this is still relevant,
             please comment to reopen.
           stale-issue-message: >
-            No activity for 30 days. Closing automatically unless updated.
+            No activity for 28 days. Closing automatically unless updated.
 
           # Prevent closing important issues
           exempt-issue-labels: "keep-open,pinned,security"


### PR DESCRIPTION
This will mark issues with no activity over 3 weeks old as 'stale'.  Then it will close it a week later, allowing a buffer for keeping it open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated stale issue management: inactive issues will be marked stale after 21 days and closed 7 days later. The process runs on a scheduled cadence and can be manually triggered. Exemptions apply for issues labeled "keep-open", "pinned", or "security" and for all milestones. This applies only to issues (no PRs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->