### PR TITLE
refactor(api): extract lifespan runtime and worker orchestration

### DIFF
--- a/acestep/api/lifespan_runtime.py
+++ b/acestep/api/lifespan_runtime.py
@@ -1,0 +1,147 @@
+"""Lifespan bootstrap helpers for API server runtime state initialization."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Callable
+
+
+@dataclass
+class LifespanRuntime:
+    """Runtime objects returned after lifespan state initialization."""
+
+    cache_root: str
+    tmp_root: str
+    handler: Any
+    llm_handler: Any
+    handler2: Any
+    handler3: Any
+    config_path2: str
+    config_path3: str
+    executor: ThreadPoolExecutor
+
+
+def _initialize_local_cache(app: Any, cache_root: str) -> None:
+    """Initialize local cache store when optional dependency is available."""
+
+    try:
+        from acestep.local_cache import get_local_cache
+
+        local_cache_dir = os.path.join(cache_root, "local_redis")
+        app.state.local_cache = get_local_cache(local_cache_dir)
+    except ImportError:
+        app.state.local_cache = None
+
+
+def initialize_lifespan_runtime(
+    *,
+    app: Any,
+    store: Any,
+    queue_maxsize: int,
+    avg_window: int,
+    initial_avg_job_seconds: float,
+    get_project_root: Callable[[], str],
+    initialize_training_state_fn: Callable[[Any], None],
+    ace_handler_cls: Callable[[], Any],
+    llm_handler_cls: Callable[[], Any],
+) -> LifespanRuntime:
+    """Initialize process environment, model handlers, and app.state runtime fields."""
+
+    for proxy_var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"]:
+        os.environ.pop(proxy_var, None)
+
+    project_root = get_project_root()
+    cache_root = os.path.join(project_root, ".cache", "acestep")
+    tmp_root = (os.getenv("ACESTEP_TMPDIR") or os.path.join(cache_root, "tmp")).strip()
+    triton_cache_root = (os.getenv("TRITON_CACHE_DIR") or os.path.join(cache_root, "triton")).strip()
+    inductor_cache_root = (
+        (os.getenv("TORCHINDUCTOR_CACHE_DIR") or os.path.join(cache_root, "torchinductor")).strip()
+    )
+
+    for path in [cache_root, tmp_root, triton_cache_root, inductor_cache_root]:
+        try:
+            os.makedirs(path, exist_ok=True)
+        except Exception:
+            pass
+
+    if os.getenv("ACESTEP_TMPDIR"):
+        os.environ["TMPDIR"] = tmp_root
+        os.environ["TEMP"] = tmp_root
+        os.environ["TMP"] = tmp_root
+    else:
+        os.environ.setdefault("TMPDIR", tmp_root)
+        os.environ.setdefault("TEMP", tmp_root)
+        os.environ.setdefault("TMP", tmp_root)
+
+    os.environ.setdefault("TRITON_CACHE_DIR", triton_cache_root)
+    os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", inductor_cache_root)
+
+    handler = ace_handler_cls()
+    llm_handler = llm_handler_cls()
+    init_lock = asyncio.Lock()
+    app.state._initialized = False
+    app.state._init_error = None
+    app.state._init_lock = init_lock
+
+    app.state.llm_handler = llm_handler
+    app.state._llm_initialized = False
+    app.state._llm_init_error = None
+    app.state._llm_init_lock = Lock()
+    app.state._llm_lazy_load_disabled = False
+
+    handler2 = None
+    handler3 = None
+    config_path2 = os.getenv("ACESTEP_CONFIG_PATH2", "").strip()
+    config_path3 = os.getenv("ACESTEP_CONFIG_PATH3", "").strip()
+    if config_path2:
+        handler2 = ace_handler_cls()
+    if config_path3:
+        handler3 = ace_handler_cls()
+
+    app.state.handler2 = handler2
+    app.state.handler3 = handler3
+    app.state._initialized2 = False
+    app.state._initialized3 = False
+    app.state._config_path = os.getenv("ACESTEP_CONFIG_PATH", "acestep-v15-turbo")
+    app.state._config_path2 = config_path2
+    app.state._config_path3 = config_path3
+
+    max_workers = int(os.getenv("ACESTEP_API_WORKERS", "1"))
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    app.state.job_queue = asyncio.Queue(maxsize=queue_maxsize)
+    app.state.pending_ids = deque()
+    app.state.pending_lock = asyncio.Lock()
+    app.state.job_temp_files = {}
+    app.state.job_temp_files_lock = asyncio.Lock()
+    app.state.stats_lock = asyncio.Lock()
+    app.state.recent_durations = deque(maxlen=avg_window)
+    app.state.avg_job_seconds = initial_avg_job_seconds
+
+    app.state.handler = handler
+    app.state.executor = executor
+    app.state.job_store = store
+    app.state._python_executable = sys.executable
+    initialize_training_state_fn(app)
+
+    app.state.temp_audio_dir = os.path.join(tmp_root, "api_audio")
+    os.makedirs(app.state.temp_audio_dir, exist_ok=True)
+    _initialize_local_cache(app, cache_root)
+
+    return LifespanRuntime(
+        cache_root=cache_root,
+        tmp_root=tmp_root,
+        handler=handler,
+        llm_handler=llm_handler,
+        handler2=handler2,
+        handler3=handler3,
+        config_path2=config_path2,
+        config_path3=config_path3,
+        executor=executor,
+    )

--- a/acestep/api/lifespan_runtime_test.py
+++ b/acestep/api/lifespan_runtime_test.py
@@ -1,0 +1,106 @@
+"""Unit tests for lifespan runtime bootstrap helper."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from acestep.api.lifespan_runtime import initialize_lifespan_runtime
+
+
+class LifespanRuntimeTests(unittest.TestCase):
+    """Behavior tests for API lifespan runtime/state initialization."""
+
+    @patch("acestep.api.lifespan_runtime._initialize_local_cache")
+    @patch("acestep.api.lifespan_runtime.os.makedirs")
+    def test_initialize_lifespan_runtime_sets_expected_default_state(
+        self,
+        mock_makedirs: MagicMock,
+        mock_initialize_local_cache: MagicMock,
+    ) -> None:
+        """Bootstrap helper should initialize default app.state runtime fields."""
+
+        app = SimpleNamespace(state=SimpleNamespace())
+        store = object()
+        training_state_init = MagicMock()
+        handler = MagicMock(name="handler")
+        ace_handler_cls = MagicMock(return_value=handler)
+        llm_handler = MagicMock(name="llm_handler")
+        llm_handler_cls = MagicMock(return_value=llm_handler)
+
+        with patch.dict(os.environ, {}, clear=True):
+            runtime = initialize_lifespan_runtime(
+                app=app,
+                store=store,
+                queue_maxsize=200,
+                avg_window=50,
+                initial_avg_job_seconds=5.0,
+                get_project_root=MagicMock(return_value="k:/repo"),
+                initialize_training_state_fn=training_state_init,
+                ace_handler_cls=ace_handler_cls,
+                llm_handler_cls=llm_handler_cls,
+            )
+
+        self.assertEqual(200, app.state.job_queue.maxsize)
+        self.assertEqual(5.0, app.state.avg_job_seconds)
+        self.assertEqual("acestep-v15-turbo", app.state._config_path)
+        self.assertIs(app.state.handler, handler)
+        self.assertIs(app.state.llm_handler, llm_handler)
+        self.assertIsNone(runtime.handler2)
+        self.assertIsNone(runtime.handler3)
+        training_state_init.assert_called_once_with(app)
+        mock_initialize_local_cache.assert_called_once_with(app, runtime.cache_root)
+        self.assertTrue(mock_makedirs.called)
+
+    @patch("acestep.api.lifespan_runtime._initialize_local_cache")
+    @patch("acestep.api.lifespan_runtime.os.makedirs")
+    def test_initialize_lifespan_runtime_supports_secondary_and_third_model_handlers(
+        self,
+        _mock_makedirs: MagicMock,
+        _mock_initialize_local_cache: MagicMock,
+    ) -> None:
+        """Bootstrap helper should create extra handlers when secondary config paths exist."""
+
+        app = SimpleNamespace(state=SimpleNamespace())
+        store = object()
+        training_state_init = MagicMock()
+        handler_values = [MagicMock(), MagicMock(), MagicMock()]
+        ace_handler_cls = MagicMock(side_effect=handler_values)
+        llm_handler_cls = MagicMock(return_value=MagicMock())
+
+        with patch.dict(
+            os.environ,
+            {
+                "ACESTEP_TMPDIR": "k:/tmp/acestep",
+                "ACESTEP_CONFIG_PATH2": "acestep-v15-second",
+                "ACESTEP_CONFIG_PATH3": "acestep-v15-third",
+                "ACESTEP_API_WORKERS": "3",
+            },
+            clear=True,
+        ):
+            runtime = initialize_lifespan_runtime(
+                app=app,
+                store=store,
+                queue_maxsize=50,
+                avg_window=20,
+                initial_avg_job_seconds=2.5,
+                get_project_root=MagicMock(return_value="k:/repo"),
+                initialize_training_state_fn=training_state_init,
+                ace_handler_cls=ace_handler_cls,
+                llm_handler_cls=llm_handler_cls,
+            )
+            self.assertEqual("k:/tmp/acestep", os.environ.get("TMPDIR"))
+
+        self.assertIsNotNone(runtime.handler2)
+        self.assertIsNotNone(runtime.handler3)
+        self.assertEqual("acestep-v15-second", runtime.config_path2)
+        self.assertEqual("acestep-v15-third", runtime.config_path3)
+        self.assertEqual("acestep-v15-second", app.state._config_path2)
+        self.assertEqual("acestep-v15-third", app.state._config_path3)
+        self.assertTrue(str(app.state.temp_audio_dir).endswith("api_audio"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/api/worker_runtime.py
+++ b/acestep/api/worker_runtime.py
@@ -1,0 +1,87 @@
+"""Background worker task orchestration helpers for API server."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Awaitable, Callable
+
+from acestep.api.jobs.worker_loops import process_queue_item, run_job_store_cleanup_loop
+
+
+async def _queue_worker_loop(
+    *,
+    app_state: Any,
+    store: Any,
+    run_one_job: Callable[[str, Any], Awaitable[None]],
+    cleanup_job_temp_files: Callable[[str], Awaitable[None]],
+) -> None:
+    """Continuously consume job queue entries and process each item."""
+
+    while True:
+        job_id, req = await app_state.job_queue.get()
+        await process_queue_item(
+            job_id=job_id,
+            req=req,
+            app_state=app_state,
+            store=store,
+            run_one_job=run_one_job,
+            cleanup_job_temp_files=cleanup_job_temp_files,
+        )
+
+
+async def _job_store_cleanup_worker_loop(*, store: Any, cleanup_interval_seconds: int) -> None:
+    """Run periodic completed-job cleanup loop."""
+
+    await run_job_store_cleanup_loop(
+        store=store,
+        cleanup_interval_seconds=cleanup_interval_seconds,
+    )
+
+
+def start_worker_tasks(
+    *,
+    app_state: Any,
+    store: Any,
+    worker_count: int,
+    run_one_job: Callable[[str, Any], Awaitable[None]],
+    cleanup_job_temp_files: Callable[[str], Awaitable[None]],
+    cleanup_interval_seconds: int,
+) -> tuple[list[asyncio.Task], asyncio.Task]:
+    """Start queue workers and cleanup worker; attach task refs to app state."""
+
+    normalized_worker_count = max(1, worker_count)
+    workers = [
+        asyncio.create_task(
+            _queue_worker_loop(
+                app_state=app_state,
+                store=store,
+                run_one_job=run_one_job,
+                cleanup_job_temp_files=cleanup_job_temp_files,
+            )
+        )
+        for _ in range(normalized_worker_count)
+    ]
+    cleanup_task = asyncio.create_task(
+        _job_store_cleanup_worker_loop(
+            store=store,
+            cleanup_interval_seconds=cleanup_interval_seconds,
+        )
+    )
+    app_state.worker_tasks = workers
+    app_state.cleanup_task = cleanup_task
+    return workers, cleanup_task
+
+
+def stop_worker_tasks(
+    *,
+    workers: list[asyncio.Task],
+    cleanup_task: asyncio.Task,
+    executor: ThreadPoolExecutor,
+) -> None:
+    """Cancel running worker tasks and shut down thread pool executor."""
+
+    cleanup_task.cancel()
+    for worker in workers:
+        worker.cancel()
+    executor.shutdown(wait=False, cancel_futures=True)

--- a/acestep/api/worker_runtime_test.py
+++ b/acestep/api/worker_runtime_test.py
@@ -1,0 +1,64 @@
+"""Unit tests for background worker task orchestration helper."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from acestep.api.worker_runtime import start_worker_tasks, stop_worker_tasks
+
+
+class WorkerRuntimeTests(unittest.IsolatedAsyncioTestCase):
+    """Behavior tests for queue worker startup and shutdown helpers."""
+
+    @patch("acestep.api.worker_runtime.run_job_store_cleanup_loop", new_callable=AsyncMock)
+    @patch("acestep.api.worker_runtime.process_queue_item", new_callable=AsyncMock)
+    async def test_start_and_stop_worker_tasks_processes_queue_items(
+        self,
+        mock_process_queue_item: AsyncMock,
+        _mock_run_job_store_cleanup_loop: AsyncMock,
+    ) -> None:
+        """Worker orchestration should start tasks, process queue items, and stop cleanly."""
+
+        processed = asyncio.Event()
+
+        async def _process_queue_item_side_effect(**_kwargs) -> None:
+            processed.set()
+
+        mock_process_queue_item.side_effect = _process_queue_item_side_effect
+        app_state = SimpleNamespace(job_queue=asyncio.Queue())
+        store = MagicMock()
+        run_one_job = AsyncMock()
+        cleanup_job_temp_files = AsyncMock()
+
+        workers, cleanup_task = start_worker_tasks(
+            app_state=app_state,
+            store=store,
+            worker_count=0,
+            run_one_job=run_one_job,
+            cleanup_job_temp_files=cleanup_job_temp_files,
+            cleanup_interval_seconds=300,
+        )
+
+        self.assertEqual(1, len(workers))
+        await app_state.job_queue.put(("job-1", MagicMock()))
+        await asyncio.wait_for(processed.wait(), timeout=1.0)
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        with patch.object(executor, "shutdown") as mock_shutdown:
+            stop_worker_tasks(
+                workers=workers,
+                cleanup_task=cleanup_task,
+                executor=executor,
+            )
+            mock_shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+
+        await asyncio.gather(*workers, cleanup_task, return_exceptions=True)
+        self.assertGreaterEqual(mock_process_queue_item.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -23,10 +23,8 @@ import sys
 import time
 import traceback
 import urllib.parse
-from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from threading import Lock
 from typing import Any, Dict, List, Optional
 import torch
 from loguru import logger
@@ -44,7 +42,9 @@ from acestep.api.jobs.store import _JobStore
 from acestep.api.log_capture import install_log_capture
 from acestep.api.route_setup import configure_api_routes
 from acestep.api.server_cli import run_api_server_main
+from acestep.api.lifespan_runtime import initialize_lifespan_runtime
 from acestep.api.startup_model_init import initialize_models_at_startup
+from acestep.api.worker_runtime import start_worker_tasks, stop_worker_tasks
 from acestep.api.server_utils import (
     env_bool as _env_bool,
     get_model_name as _get_model_name,
@@ -71,10 +71,6 @@ from acestep.api.http.release_task_param_parser import (
 from acestep.api.jobs.local_cache_updates import (
     update_local_cache,
     update_local_cache_progress,
-)
-from acestep.api.jobs.worker_loops import (
-    process_queue_item,
-    run_job_store_cleanup_loop,
 )
 from acestep.api.runtime_helpers import (
     append_jsonl as _runtime_append_jsonl,
@@ -213,104 +209,26 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        # Clear proxy env that may affect downstream libs
-        for proxy_var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"]:
-            os.environ.pop(proxy_var, None)
-
-        # Ensure compilation/temp caches do not fill up small default /tmp.
-        # Triton/Inductor (and the system compiler) can create large temporary files.
-        project_root = _get_project_root()
-        cache_root = os.path.join(project_root, ".cache", "acestep")
-        tmp_root = (os.getenv("ACESTEP_TMPDIR") or os.path.join(cache_root, "tmp")).strip()
-        triton_cache_root = (os.getenv("TRITON_CACHE_DIR") or os.path.join(cache_root, "triton")).strip()
-        inductor_cache_root = (os.getenv("TORCHINDUCTOR_CACHE_DIR") or os.path.join(cache_root, "torchinductor")).strip()
-
-        for p in [cache_root, tmp_root, triton_cache_root, inductor_cache_root]:
-            try:
-                os.makedirs(p, exist_ok=True)
-            except Exception:
-                # Best-effort: do not block startup if directory creation fails.
-                pass
-
-        # Respect explicit user overrides; if ACESTEP_TMPDIR is set, it should win.
-        if os.getenv("ACESTEP_TMPDIR"):
-            os.environ["TMPDIR"] = tmp_root
-            os.environ["TEMP"] = tmp_root
-            os.environ["TMP"] = tmp_root
-        else:
-            os.environ.setdefault("TMPDIR", tmp_root)
-            os.environ.setdefault("TEMP", tmp_root)
-            os.environ.setdefault("TMP", tmp_root)
-
-        os.environ.setdefault("TRITON_CACHE_DIR", triton_cache_root)
-        os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", inductor_cache_root)
-
-        handler = AceStepHandler()
-        llm_handler = LLMHandler()
-        init_lock = asyncio.Lock()
-        app.state._initialized = False
-        app.state._init_error = None
-        app.state._init_lock = init_lock
-
-        app.state.llm_handler = llm_handler
-        app.state._llm_initialized = False
-        app.state._llm_init_error = None
-        app.state._llm_init_lock = Lock()
-        app.state._llm_lazy_load_disabled = False  # Will be set to True if LLM skipped due to GPU config
-
-        # Multi-model support: secondary DiT handlers
-        handler2 = None
-        handler3 = None
-        config_path2 = os.getenv("ACESTEP_CONFIG_PATH2", "").strip()
-        config_path3 = os.getenv("ACESTEP_CONFIG_PATH3", "").strip()
-
-        if config_path2:
-            handler2 = AceStepHandler()
-        if config_path3:
-            handler3 = AceStepHandler()
-
-        app.state.handler2 = handler2
-        app.state.handler3 = handler3
-        app.state._initialized2 = False
-        app.state._initialized3 = False
-        app.state._config_path = os.getenv("ACESTEP_CONFIG_PATH", "acestep-v15-turbo")
-        app.state._config_path2 = config_path2
-        app.state._config_path3 = config_path3
-
-        max_workers = int(os.getenv("ACESTEP_API_WORKERS", "1"))
-        executor = ThreadPoolExecutor(max_workers=max_workers)
-
-        # Queue & observability
-        app.state.job_queue = asyncio.Queue(maxsize=QUEUE_MAXSIZE)  # (job_id, req)
-        app.state.pending_ids = deque()  # queued job_ids
-        app.state.pending_lock = asyncio.Lock()
-
-        # temp files per job (from multipart uploads)
-        app.state.job_temp_files = {}  # job_id -> list[path]
-        app.state.job_temp_files_lock = asyncio.Lock()
-
-        # stats
-        app.state.stats_lock = asyncio.Lock()
-        app.state.recent_durations = deque(maxlen=AVG_WINDOW)
-        app.state.avg_job_seconds = INITIAL_AVG_JOB_SECONDS
-
-        app.state.handler = handler
-        app.state.executor = executor
-        app.state.job_store = store
-        app.state._python_executable = sys.executable
-        initialize_training_state(app)
-
-        # Temporary directory for saving generated audio files
-        app.state.temp_audio_dir = os.path.join(tmp_root, "api_audio")
-        os.makedirs(app.state.temp_audio_dir, exist_ok=True)
-
-        # Initialize local cache
-        try:
-            from acestep.local_cache import get_local_cache
-            local_cache_dir = os.path.join(cache_root, "local_redis")
-            app.state.local_cache = get_local_cache(local_cache_dir)
-        except ImportError:
-            app.state.local_cache = None
+        runtime = initialize_lifespan_runtime(
+            app=app,
+            store=store,
+            queue_maxsize=QUEUE_MAXSIZE,
+            avg_window=AVG_WINDOW,
+            initial_avg_job_seconds=INITIAL_AVG_JOB_SECONDS,
+            get_project_root=_get_project_root,
+            initialize_training_state_fn=initialize_training_state,
+            ace_handler_cls=AceStepHandler,
+            llm_handler_cls=LLMHandler,
+        )
+        cache_root = runtime.cache_root
+        tmp_root = runtime.tmp_root
+        handler = runtime.handler
+        llm_handler = runtime.llm_handler
+        handler2 = runtime.handler2
+        handler3 = runtime.handler3
+        config_path2 = runtime.config_path2
+        config_path3 = runtime.config_path3
+        executor = runtime.executor
 
         async def _ensure_initialized() -> None:
             """Check if models are initialized (they should be loaded at startup)."""
@@ -1015,30 +933,14 @@ def create_app() -> FastAPI:
                     if app.state.recent_durations:
                         app.state.avg_job_seconds = sum(app.state.recent_durations) / len(app.state.recent_durations)
 
-        async def _queue_worker(worker_idx: int) -> None:
-            while True:
-                job_id, req = await app.state.job_queue.get()
-                await process_queue_item(
-                    job_id=job_id,
-                    req=req,
-                    app_state=app.state,
-                    store=store,
-                    run_one_job=_run_one_job,
-                    cleanup_job_temp_files=_cleanup_job_temp_files,
-                )
-
-        async def _job_store_cleanup_worker() -> None:
-            """Background task to periodically clean up old completed jobs."""
-            await run_job_store_cleanup_loop(
-                store=store,
-                cleanup_interval_seconds=JOB_STORE_CLEANUP_INTERVAL,
-            )
-
-        worker_count = max(1, WORKER_COUNT)
-        workers = [asyncio.create_task(_queue_worker(i)) for i in range(worker_count)]
-        cleanup_task = asyncio.create_task(_job_store_cleanup_worker())
-        app.state.worker_tasks = workers
-        app.state.cleanup_task = cleanup_task
+        workers, cleanup_task = start_worker_tasks(
+            app_state=app.state,
+            store=store,
+            worker_count=WORKER_COUNT,
+            run_one_job=_run_one_job,
+            cleanup_job_temp_files=_cleanup_job_temp_files,
+            cleanup_interval_seconds=JOB_STORE_CLEANUP_INTERVAL,
+        )
         initialize_models_at_startup(
             app=app,
             handler=handler,
@@ -1055,10 +957,11 @@ def create_app() -> FastAPI:
         try:
             yield
         finally:
-            cleanup_task.cancel()
-            for t in workers:
-                t.cancel()
-            executor.shutdown(wait=False, cancel_futures=True)
+            stop_worker_tasks(
+                workers=workers,
+                cleanup_task=cleanup_task,
+                executor=executor,
+            )
 
     app = FastAPI(title="ACE-Step API", version="1.0", lifespan=lifespan)
 


### PR DESCRIPTION
## Summary
This PR extracts the remaining low-risk runtime orchestration from `acestep/api_server.py` into focused modules, while preserving existing API behavior.

- `acestep/api_server.py` reduced from 1023 LOC to 881 LOC in this slice.
- Extracted lifespan/bootstrap state setup into `acestep/api/lifespan_runtime.py`.
- Extracted background worker lifecycle orchestration into `acestep/api/worker_runtime.py`.
- Added focused unit tests for both modules.

## Scope
In scope:
- Lifespan runtime/environment/state bootstrap extraction.
- Worker start/stop orchestration extraction.
- Parity-focused tests.

Out of scope:
- Core generation logic in `_run_one_job`/`_blocking_generate`.
- API contract changes.

## What Changed
- Added `acestep/api/lifespan_runtime.py`
- Added `acestep/api/worker_runtime.py`
- Added tests:
  - `acestep/api/lifespan_runtime_test.py`
  - `acestep/api/worker_runtime_test.py`
- Updated `acestep/api_server.py`:
  - delegate lifespan setup to `initialize_lifespan_runtime(...)`
  - delegate worker orchestration to `start_worker_tasks(...)` / `stop_worker_tasks(...)`

## Validation
Executed:
- `uv run python -m py_compile acestep/api_server.py acestep/api/lifespan_runtime.py acestep/api/worker_runtime.py acestep/api/lifespan_runtime_test.py acestep/api/worker_runtime_test.py`
- `uv run python -m unittest -v acestep.api.lifespan_runtime_test acestep.api.worker_runtime_test acestep.api.route_setup_test acestep.api.server_cli_test acestep.api.server_utils_test acestep.api.log_capture_test acestep.api.train_api_service_http_test acestep.api.http.release_task_route_http_test acestep.api.http.query_result_route_http_test acestep.api.startup_model_init_test acestep.api.startup_llm_init_test acestep.api.http.auth_test`

Result:
- 45 tests passed, 0 failures.

## Reviewer Focus
1. Lifespan setup parity (env/cache setup and app.state initialization).
2. Worker orchestration parity (`process_queue_item`, cleanup loop, shutdown behavior).
3. `initialize_models_at_startup(...)` dependency wiring remains equivalent.
4. No route/API behavior drift.

## CodeRabbit Scope Guard
Please mark pre-existing issues from `upstream/main` or legacy behavior outside this FD slice as out-of-scope/non-blocking for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured API server initialization logic into dedicated modules for improved maintainability and code organization.

* **Tests**
  * Added comprehensive unit tests for runtime initialization and background worker orchestration to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->