### PR TITLE
fix(lrc): always return intermediate tensors so LRC generation works for all task types

### DIFF
--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -195,6 +195,6 @@ class GenerateMusicRequestMixin:
             "repainting_end_batch": repainting_end_batch,
             "target_wavs_tensor": target_wavs_tensor,
             "audio_code_hints_batch": audio_code_hints_batch,
-            "should_return_intermediate": task_type == "text2music",
+            "should_return_intermediate": True,
         }
 

--- a/acestep/core/generation/handler/generate_music_request_test.py
+++ b/acestep/core/generation/handler/generate_music_request_test.py
@@ -112,5 +112,31 @@ class GenerateMusicRequestMixinTests(unittest.TestCase):
         self.assertEqual(error["error"], "Invalid source audio")
 
 
+    def test_should_return_intermediate_always_true(self):
+        """Intermediate tensors must always be returned for LRC generation support."""
+        host = _Host()
+        for task in ("text2music", "cover", "repaint"):
+            inputs = host._prepare_generate_music_service_inputs(
+                actual_batch_size=1,
+                processed_src_audio=None,
+                audio_duration=60.0,
+                captions="test",
+                lyrics="test",
+                vocal_language="en",
+                instruction="inst",
+                bpm=120,
+                key_scale="C major",
+                time_signature="4/4",
+                task_type=task,
+                audio_code_string="",
+                repainting_start=0.0,
+                repainting_end=1.0,
+            )
+            self.assertTrue(
+                inputs["should_return_intermediate"],
+                f"should_return_intermediate must be True for task_type={task!r}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/acestep/ui/gradio/events/results/batch_management_wrapper.py
+++ b/acestep/ui/gradio/events/results/batch_management_wrapper.py
@@ -153,10 +153,17 @@ def generate_with_batch_management(
     can_prev, can_next = update_navigation_buttons(current_batch_index, total_batches)
     next_batch_status_text = t("messages.autogen_enabled") if autogen_checkbox else ""
 
-    ui_core = _extract_ui_core_outputs(result)
-    logger.info(f"[generate_with_batch_management] Final yield: {len(ui_core)} core + 9 state")
+    ui_core_list = list(_extract_ui_core_outputs(result))
 
-    yield tuple(ui_core) + (
+    if auto_lrc and isinstance(extra_outputs_from_result, dict):
+        lrcs = extra_outputs_from_result.get("lrcs", [""] * 8)
+        for i in range(min(8, len(lrcs))):
+            if lrcs[i]:
+                ui_core_list[36 + i] = gr.update(value=lrcs[i], visible=True)
+
+    logger.info(f"[generate_with_batch_management] Final yield: {len(ui_core_list)} core + 9 state")
+
+    yield tuple(ui_core_list) + (
         current_batch_index, total_batches, batch_queue, next_params,
         batch_indicator_text,
         gr.update(interactive=can_prev),


### PR DESCRIPTION
## Summary

- **Root cause**: When audio codes are present (e.g. from LLM thinking mode or user input), `_resolve_generate_music_task` silently switches `task_type` from `"text2music"` to `"cover"`. The old guard `task_type == "text2music"` then set `should_return_intermediate=False`, causing `_attach_service_generate_outputs` to skip the encoder/context/lyric tensors that both `_run_auto_lrc` (auto LRC) and `generate_lrc_handler` (manual LRC button) require.
- **Fix**: Set `should_return_intermediate=True` unconditionally so intermediate tensors are always available for downstream LRC generation regardless of resolved task type. The overhead is minimal (a few extra tensor `.detach().cpu()` copies).
- **Robustness**: Harden the batch-management wrapper's final yield to explicitly set LRC display values via `gr.update(value=...)`, ensuring the UI textboxes update even if streaming yields were missed.

## Changed files

| File | Change |
|------|--------|
| `acestep/core/generation/handler/generate_music_request.py` | `should_return_intermediate: True` (was `task_type == "text2music"`) |
| `acestep/core/generation/handler/generate_music_request_test.py` | New test: `test_should_return_intermediate_always_true` |
| `acestep/ui/gradio/events/results/batch_management_wrapper.py` | Explicit `gr.update(value=lrc)` in final yield when auto_lrc is on |
| `acestep/ui/gradio/events/results/batch_management_test.py` | New tests: `test_auto_lrc_sets_lrc_display_in_final_yield`, `test_auto_lrc_disabled_preserves_passthrough_values` |

## Test plan

- [x] `uv run python -m unittest acestep.core.generation.handler.generate_music_request_test` — 6 tests pass
- [x] Batch management tests (8 tests pass) — run from `acestep/ui/gradio/events/results/`
- [x] All 158 handler tests pass (`uv run python -m unittest discover -s acestep/core/generation/handler -p "*_test.py"`)
- [ ] Manual regression: Custom mode + Auto LRC checked → LRC textbox should populate after generation
- [ ] Manual regression: Custom mode + manual "Generate LRC" button → should no longer show "Missing required tensors"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LRC (lyrics) display integration to music generation results. When enabled, lyrics are automatically displayed alongside your music generation results.

* **Tests**
  * Added comprehensive test coverage for the new LRC display functionality, ensuring correct behavior when the feature is enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->