### PR TITLE
fix(generation): skip VRAM pre-flight when CPU offload is active — fixes #747

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -51,6 +51,13 @@ class GenerateMusicMixin:
         if not torch.cuda.is_available():
             return None
 
+        if getattr(self, "offload_to_cpu", False):
+            logger.debug(
+                "[generate_music] VRAM pre-flight: skipping check "
+                "(offload_to_cpu=True, models loaded one-at-a-time)"
+            )
+            return None
+
         duration_s = audio_duration or 60.0
         # CFG doubles forward-pass memory: two DiT evaluations per step.
         dit_key = "base" if guidance_scale > 1.0 else "turbo"

--- a/acestep/core/generation/handler/generate_music_test.py
+++ b/acestep/core/generation/handler/generate_music_test.py
@@ -11,6 +11,7 @@ import types
 import unittest
 from pathlib import Path
 from typing import Any, Dict
+from unittest.mock import patch
 
 import torch
 
@@ -63,12 +64,13 @@ class _Host(GenerateMusicMixin):
     payloads so tests can assert orchestration sequencing and return behavior.
     """
 
-    def __init__(self):
+    def __init__(self, offload_to_cpu: bool = False):
         """Initialize deterministic state and stub payloads for orchestration tests."""
         self.model = object()
         self.vae = object()
         self.text_tokenizer = object()
         self.text_encoder = object()
+        self.offload_to_cpu = offload_to_cpu
         self.calls: Dict[str, Any] = {}
         self._final_payload = {"audios": [{"tensor": torch.zeros(1, 4), "sample_rate": 48000}], "success": True}
         self._readiness_error = {
@@ -191,6 +193,68 @@ class GenerateMusicMixinTests(unittest.TestCase):
         self.assertFalse(out["success"])
         self.assertEqual(out["error"], "boom")
         self.assertIn("Error: boom", out["status_message"])
+
+
+class VramPreflightCheckTests(unittest.TestCase):
+    """Verify ``_vram_preflight_check`` respects CPU offload mode."""
+
+    _GM_MOD = GENERATE_MUSIC_MODULE
+
+    @patch.object(_GM_MOD, "torch")
+    def test_preflight_skips_when_offload_to_cpu_enabled(self, mock_torch):
+        """It returns None (pass) when offload_to_cpu is True, regardless of free VRAM."""
+        mock_torch.cuda.is_available.return_value = True
+        host = _Host(offload_to_cpu=True)
+        result = host._vram_preflight_check(
+            actual_batch_size=2,
+            audio_duration=246.0,
+            guidance_scale=7.0,
+        )
+        self.assertIsNone(result)
+
+    @patch.object(_GM_MOD, "get_effective_free_vram_gb", return_value=3.4)
+    @patch.object(_GM_MOD, "torch")
+    def test_preflight_blocks_when_offload_disabled_and_vram_low(
+        self, mock_torch, _mock_free_vram
+    ):
+        """It returns error payload when offload is off and free VRAM is insufficient."""
+        mock_torch.cuda.is_available.return_value = True
+        host = _Host(offload_to_cpu=False)
+        result = host._vram_preflight_check(
+            actual_batch_size=2,
+            audio_duration=246.0,
+            guidance_scale=7.0,
+        )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertIn("Insufficient free VRAM", result["error"])
+
+    @patch.object(_GM_MOD, "get_effective_free_vram_gb", return_value=24.0)
+    @patch.object(_GM_MOD, "torch")
+    def test_preflight_passes_when_offload_disabled_and_vram_sufficient(
+        self, mock_torch, _mock_free_vram
+    ):
+        """It returns None when offload is off but free VRAM exceeds estimate."""
+        mock_torch.cuda.is_available.return_value = True
+        host = _Host(offload_to_cpu=False)
+        result = host._vram_preflight_check(
+            actual_batch_size=2,
+            audio_duration=246.0,
+            guidance_scale=7.0,
+        )
+        self.assertIsNone(result)
+
+    @patch.object(_GM_MOD, "torch")
+    def test_preflight_passes_on_non_cuda_device(self, mock_torch):
+        """It returns None when CUDA is not available (CPU/MPS/XPU)."""
+        mock_torch.cuda.is_available.return_value = False
+        host = _Host(offload_to_cpu=False)
+        result = host._vram_preflight_check(
+            actual_batch_size=2,
+            audio_duration=246.0,
+            guidance_scale=7.0,
+        )
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Fixes #747**: VRAM pre-flight check (added in 2934e63 for #146) falsely rejects generation on 8 GB GPUs (e.g. RTX 3070) when `offload_to_cpu=True`. The check estimates aggregate VRAM as if all models are GPU-resident simultaneously, but the `_load_model_context` offload mechanism loads/offloads models one at a time, keeping peak VRAM well below the estimate.
- Skip the hard VRAM block when `offload_to_cpu` is enabled, consistent with `_vram_guard_reduce_batch` which already trusts tier-based limits in offload mode. The preflight check remains active for non-offload setups (>= 20 GB GPUs).
- Added 4 unit tests covering the preflight check behavior: offload skip, low-VRAM block, sufficient-VRAM pass, and non-CUDA pass-through.

## Root Cause

The preflight formula `needed_gb = per_batch_gb * batch * duration_factor + margin` yields ~5.4 GB for batch=2 / duration=246s, but only 3.4 GB is free after LM initialization. In offload mode, the DiT model is loaded to GPU, runs, then offloaded back to CPU before the VAE is loaded — so peak usage per phase is much lower than the aggregate. The tiled VAE decode and automatic CPU VAE fallback provide additional safety.

## Test plan

- [x] `test_preflight_skips_when_offload_to_cpu_enabled` — verifies `None` return with offload active
- [x] `test_preflight_blocks_when_offload_disabled_and_vram_low` — verifies error payload without offload
- [x] `test_preflight_passes_when_offload_disabled_and_vram_sufficient` — verifies pass with enough VRAM
- [x] `test_preflight_passes_on_non_cuda_device` — verifies no-op on CPU/MPS/XPU
- [x] All 3 existing `GenerateMusicMixinTests` continue to pass
- [x] All 162 handler tests pass (1 pre-existing unrelated failure in `io_audio_test`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional VRAM validation that automatically bypasses checks when models are offloaded to CPU.

* **Tests**
  * Expanded test coverage for VRAM preflight checks, validating behavior across CPU offload settings, CUDA device availability, and various memory conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->