### PR TITLE
chore: ignore local config and output files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ gradio_outputs/
 acestep/third_parts/vllm/
 test_lora_scale_fix.py
 lokr_output/
-
+.claude/skills/acestep/scripts/config.json
+acestep_output/
 # macOS
 .DS_Store


### PR DESCRIPTION
## Summary

- Add `.claude/skills/acestep/scripts/config.json` to `.gitignore` — this file contains local API keys and should never be committed.
- Add `acestep_output/` to `.gitignore` — this directory holds generated audio output files.

## Test plan

- [ ] Verify `.claude/skills/acestep/scripts/config.json` is no longer tracked by git.
- [ ] Verify `acestep_output/` directory is no longer tracked by git.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration files to ignore additional build and configuration artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->