### PR TITLE
Fix Chinese i18n: remove Japanese text + improve translations (#789)

### DIFF
--- a/acestep/ui/gradio/i18n/zh.json
+++ b/acestep/ui/gradio/i18n/zh.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "🎛️ ACE-Step V1.5 演练场💡",
+    "title": "🎛️ ACE-Step V1.5 游乐场💡",
     "subtitle": "推动开源音乐生成的边界"
   },
   "common": {
@@ -52,10 +52,10 @@
     "flash_attention_label": "使用Flash Attention",
     "flash_attention_info_enabled": "启用flash attention以加快推理速度(需要flash_attn包)",
     "flash_attention_info_disabled": "Flash attention不可用(未安装flash_attn包)",
-    "offload_cpu_label": "卸载到CPU",
-    "offload_cpu_info": "不使用时将模型卸载到CPU以节省GPU内存。",
-    "offload_dit_cpu_label": "将DiT卸载到CPU",
-    "offload_dit_cpu_info": "将DiT卸载到CPU(需要启用卸载到CPU)。",
+    "offload_cpu_label": "闲置时转移到 CPU",
+    "offload_cpu_info": "不使用时将模型转移到CPU以节省GPU显存。",
+    "offload_dit_cpu_label": "将DiT转移到CPU",
+    "offload_dit_cpu_info": "将DiT转移到CPU(需要启用闲置时转移到 CPU)。",
     "compile_model_label": "编译模型",
     "compile_model_info": "使用 torch.compile 优化模型（量化必需）。",
     "quantization_label": "INT8 量化",
@@ -181,8 +181,8 @@
     "lm_negative_prompt_label": "LM 负面提示",
     "lm_negative_prompt_placeholder": "输入CFG的负面提示(默认: NO USER INPUT)",
     "lm_negative_prompt_info": "负面提示(当LM CFG比例 > 1.0时使用)。",
-    "cot_metas_label": "CoT メタデータ",
-    "cot_metas_info": "LMを使用してCoTメタデータを生成(チェックを外すとLM CoT生成をスキップ)。",
+    "cot_metas_label": "CoT 元数据",
+    "cot_metas_info": "使用 LM 生成 CoT 元数据(取消勾选则跳过 LM CoT 生成)。",
     "cot_language_label": "CoT 语言",
     "cot_language_info": "在CoT中生成语言(思维链)。",
     "constrained_debug_label": "约束解码调试",
@@ -458,8 +458,8 @@
   "help": {
     "btn_label": "?",
     "close_label": "✕",
-    "getting_started": "## 快速入门\n\n1. 在设置手风琴中**选择模型**（如 `acestep-v15-turbo`）\n2. 如需 Thinking 模式，**选择 5Hz LM**（推荐）\n3. 点击**初始化服务**，等待绿色状态\n4. 选择**生成模式**（建议从 Simple 开始）\n5. 描述你想要的音乐，点击**生成音乐**\n\n> **提示：** Turbo 模型最快。启用 Think 获得更智能的生成。",
-    "service_config": "## 服务配置\n\n### 快速设置\n1. 选择**主模型路径**（推荐 turbo）\n2. 选择 **5Hz LM 模型路径**（按 GPU 自动筛选）\n3. 选择**后端**：`vllm`（快速，NVIDIA ≥8GB）或 `pt`（通用）\n4. 勾选**初始化 5Hz LM** 以启用 Thinking 模式\n5. 点击**初始化服务**\n\n### 性能提示\n- **Flash Attention**：更快推理（需要 flash_attn）\n- **CPU 卸载**：GPU <20GB 时自动启用\n- **INT8 量化**：减少显存，<20GB 时自动启用\n- **编译**：量化必需，默认启用\n\n### LoRA\n- 设置 LoRA 路径 → 加载 → 启用「使用 LoRA」\n- ⚠️ 不能在 INT8 量化下使用 LoRA",
+    "getting_started": "## 快速入门\n\n1. 在设置面板中**选择模型**（如 `acestep-v15-turbo`）\n2. 如需 Thinking 模式，**选择 5Hz LM**（推荐）\n3. 点击**初始化服务**，等待绿色状态\n4. 选择**生成模式**（建议从 Simple 开始）\n5. 描述你想要的音乐，点击**生成音乐**\n\n> **提示：** Turbo 模型最快。启用 Think 获得更智能的生成。",
+    "service_config": "## 服务配置\n\n### 快速设置\n1. 选择**主模型路径**（推荐 turbo）\n2. 选择 **5Hz LM 模型路径**（按 GPU 自动筛选）\n3. 选择**后端**：`vllm`（快速，NVIDIA ≥8GB）或 `pt`（通用）\n4. 勾选**初始化 5Hz LM** 以启用 Thinking 模式\n5. 点击**初始化服务**\n\n### 性能提示\n- **Flash Attention**：更快推理（需要 flash_attn）\n- **闲置时转移到 CPU**：GPU <20GB 时自动启用\n- **INT8 量化**：减少显存，<20GB 时自动启用\n- **编译**：量化必需，默认启用\n\n### LoRA\n- 设置 LoRA 路径 → 加载 → 启用「使用 LoRA」\n- ⚠️ 不能在 INT8 量化下使用 LoRA",
     "generation_simple": "## Simple 模式教程\n\n**适合：** 快速创作音乐，最少操作。\n\n### 步骤\n1. 在生成模式中选择 **Simple**\n2. 输入描述，如 *\"欢快的流行歌曲，带有吉他即兴演奏\"*\n3. （可选）勾选**纯音乐**不要人声\n4. （可选）选择**人声语言**\n5. 点击**创建样本** — AI 生成描述、歌词、元数据\n6. 检查并编辑生成的内容\n7. 点击**生成音乐**\n\n### 提示\n- 点击 🎲 获取随机灵感\n- 描述越具体，结果越好\n- 留空 BPM/调性让 AI 自动决定",
     "generation_custom": "## Custom 模式教程\n\n**适合：** 完全控制每个参数。\n\n### 步骤\n1. 在生成模式中选择 **Custom**\n2. 编写详细的**描述**（风格、流派、乐器、情绪）\n3. 编写带结构标签的**歌词**：`[Verse]`、`[Chorus]`、`[Bridge]`\n4. （可选）上传**参考音频**用于风格引导\n5. 设置 **BPM**、**调性**、**时长**，或留空自动\n6. 点击**格式化**用 LM 增强（可选）\n7. 点击**生成音乐**\n\n### 描述技巧\n- 要具体：*\"梦幻的 shoegaze，带有大量混响的吉他和低语般的人声\"*\n- 包含：流派、乐器、情绪、节奏感、人声风格",
     "generation_remix": "## Remix 模式教程\n\n**适合：** 创建翻唱版本或风格迁移。\n\n### 步骤\n1. 在生成模式中选择 **Remix**\n2. 上传**源音频**（要 remix 的歌曲）\n3. 编写描述目标风格的**描述**\n4. （可选）修改**歌词**\n5. 调整 **Remix 强度**（0.0–1.0）：\n   - 越高 = 越接近原始结构\n   - 越低 = 更多创意自由\n6. 点击**生成音乐**\n\n### 提示\n- 从强度 0.5 开始调整\n- 使用 SFT 模型，翻唱强度 0.1–0.25 以保留旋律",


### PR DESCRIPTION
## Summary

This PR fixes the Chinese localization issues reported in #789:

### Changes Made

1. **Removed Japanese text leak** (lines 184-185)
   - `cot_metas_label`: "CoT メタデータ" → "CoT 元数据"
   - `cot_metas_info`: Japanese sentence → proper Chinese translation

2. **Improved terminology**
   - `app.title`: "演练场" → "游乐场" (Playground - more natural Chinese)
   - `offload_cpu_label`: "卸载到CPU" → "闲置时转移到 CPU" (clearer meaning)
   - `offload_dit_cpu_label`: "将DiT卸载到CPU" → "将DiT转移到CPU" (consistency)
   - Help text: "设置手风琴" → "设置面板" (Settings panel - more appropriate)

3. **Consistency updates**
   - Updated all references to CPU offload terminology throughout the file

### Regarding Language Switcher Issue

The language switcher appearing locked is a separate issue from the translation quality. After investigating the code:
- The UI component is already set to `interactive=True` in `generation_service_config_rows.py`
- The dropdown should be functional, but there may be missing event handlers
- This requires further investigation into the event wiring system

I've focused this PR on fixing the translation quality issues as they are independent of the UI interaction problem.

### Testing

- Verified JSON syntax is valid
- Confirmed all Chinese text is properly encoded
- Checked consistency of terminology throughout the file

Closes #789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Chinese translations to enhance consistency and clarity across UI labels, configuration descriptions, and help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->