### PR TITLE
feat: Add DeepWiki AI Assistant reminder to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+> **📚 Before submitting:** Have you tried [DeepWiki AI Assistant](https://deepwiki.com/ace-step/ACE-Step-1.5)?
+> DeepWiki can instantly help with installation, troubleshooting, and common issues!
+> See pinned issue #791 for more info.
+
+**Did you check DeepWiki?**
+- [ ] Yes, I checked DeepWiki but couldn't find a solution
+- [ ] No, this is a new bug not covered in the docs
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+> **📚 Quick tip:** Check if this feature already exists!
+> Ask [DeepWiki AI Assistant](https://deepwiki.com/ace-step/ACE-Step-1.5) first - it knows all current features.
+> See pinned issue #791 for more info.
+
+**Did you check existing features?**
+- [ ] Yes, I checked DeepWiki and this feature doesn't exist
+- [ ] This is a new feature idea
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
## Summary

This PR promotes DeepWiki AI Assistant in the issue templates to help users get faster support and reduce duplicate issues.

## Changes

### Bug Report Template
- Added DeepWiki link and reminder at the top
- Added checkbox to confirm user checked DeepWiki first
- References pinned issue #791

### Feature Request Template  
- Added DeepWiki link to check existing features
- Added checkbox to confirm feature doesnt already exist
- References pinned issue #791

## Benefits

✅ Users get instant help from DeepWiki 24/7
✅ Reduces duplicate issues
✅ Faster resolution for common problems
✅ Maintainers spend less time on support
✅ Better user experience

## Related

- Created pinned issue #791 to promote DeepWiki
- Based on discussion #236

## Preview

**Bug Report Template:**
> 📚 Before submitting: Have you tried DeepWiki AI Assistant?
> DeepWiki can instantly help with installation, troubleshooting, and common issues!
> See pinned issue #791 for more info.

**Feature Request Template:**
> 📚 Quick tip: Check if this feature already exists!
> Ask DeepWiki AI Assistant first - it knows all current features.
> See pinned issue #791 for more info.

---

**DeepWiki URL:** https://deepwiki.com/ace-step/ACE-Step-1.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Bug report template now includes pre-submission guidance and a checklist to encourage users to review existing resources and documentation before submitting issues.
  * Feature request template enhanced with quick-start tips and a feature-check list to help prevent duplicate feature requests and streamline the submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->