### PR TITLE
fix: add video compression for IM platforms and CJK font fallback for…

### DIFF
--- a/.claude/skills/acestep-simplemv/SKILL.md
+++ b/.claude/skills/acestep-simplemv/SKILL.md
@@ -59,6 +59,8 @@ Options:
   --codec        h264|h265|vp8|vp9 (default: h264)
   --background   Background image file path (if omitted, uses animated gradient)
   --browser      Custom browser executable path (Chrome/Edge/Chromium)
+  --max-size     Max output file size in MB (e.g. 24). Auto-compresses if exceeded.
+                 Use for IM platforms (WhatsApp≤16MB, Discord≤25MB, Telegram≤50MB)
 
 Environment variables:
   BROWSER_EXECUTABLE  Path to browser executable (overrides auto-detection)
@@ -107,6 +109,45 @@ export BROWSER_EXECUTABLE="/path/to/msedge.exe"
 
 # With background image
 ./scripts/render-mv.sh --audio song.mp3 --lyrics song.lrc --title "Song" --background /path/to/cover.jpg
+
+# Compress for Discord upload (max 25MB)
+./scripts/render-mv.sh --audio song.mp3 --lyrics song.lrc --title "Song" --max-size 24
+
+# Compress for WhatsApp (max 16MB)
+./scripts/render-mv.sh --audio song.mp3 --lyrics song.lrc --title "Song" --max-size 15
+```
+
+## IM Platform Upload Limits
+
+When sending MV to chat platforms, use `--max-size` to auto-compress:
+
+| Platform | Limit | Recommended `--max-size` |
+|----------|-------|--------------------------|
+| WhatsApp | 16MB | 15 |
+| Discord (free) | 25MB | 24 |
+| Telegram | 50MB | 48 |
+| Slack (free) | 1GB | - |
+
+The compression uses ffmpeg two-pass encoding to achieve the best quality within the size constraint.
+
+## Container / Docker Font Support
+
+When running in containers (e.g. OpenClaw), CJK fonts may not be pre-installed, causing lyrics to render as □ boxes. The script automatically:
+
+1. **Detects** if CJK fonts are available (via `fc-list`)
+2. **Attempts to install** `fonts-noto-cjk` (Debian/Ubuntu), `font-noto-cjk` (Alpine), or `google-noto-sans-cjk-fonts` (Fedora/RHEL)
+3. **Falls back** with a warning and manual install instructions if auto-install fails
+
+If auto-install doesn't work, manually install fonts before rendering:
+```bash
+# Debian/Ubuntu
+apt-get install -y fonts-noto-cjk
+
+# Alpine
+apk add font-noto-cjk
+
+# Fedora/RHEL
+dnf install -y google-noto-sans-cjk-fonts
 ```
 
 ## File Naming

--- a/.claude/skills/acestep-simplemv/scripts/render-mv.sh
+++ b/.claude/skills/acestep-simplemv/scripts/render-mv.sh
@@ -16,6 +16,8 @@
 #   --codec     h264|h265|vp8|vp9 (default: h264)
 #   --background Background image file path (if omitted, uses animated gradient)
 #   --browser   Custom browser executable path (Chrome/Edge/Chromium)
+#   --max-size  Max output file size in MB (e.g. 24). Compresses video if exceeded.
+#              Use for IM platforms (WhatsApp/Discord/Telegram) with upload limits.
 #
 # Environment variables:
 #   BROWSER_EXECUTABLE  Path to browser executable (overrides auto-detection)
@@ -50,6 +52,7 @@ OUTPUT=""
 CODEC="h264"
 BACKGROUND=""
 BROWSER=""
+MAX_SIZE=""
 
 # Parse args
 while [[ $# -gt 0 ]]; do
@@ -65,6 +68,7 @@ while [[ $# -gt 0 ]]; do
     --codec)       CODEC="$2"; shift 2 ;;
     --background)  BACKGROUND="$2"; shift 2 ;;
     --browser)     BROWSER="$2"; shift 2 ;;
+    --max-size)    MAX_SIZE="$2"; shift 2 ;;
     -h|--help)
       head -20 "$0" | tail -18
       exit 0
@@ -118,6 +122,66 @@ if [[ -n "$BACKGROUND" ]]; then
 fi
 [[ -n "$BROWSER" ]] && NODE_ARGS+=(--browser "$BROWSER")
 
+# --- Font check for container environments ---
+check_and_install_cjk_fonts() {
+  # Only run on Linux (containers are typically Linux)
+  [[ "$(uname -s)" != "Linux" ]] && return 0
+
+  # Check if any CJK font is available via fc-list
+  if command -v fc-list &>/dev/null; then
+    if fc-list :lang=zh 2>/dev/null | head -1 | grep -q .; then
+      return 0  # CJK fonts found
+    fi
+    if fc-list :lang=ja 2>/dev/null | head -1 | grep -q .; then
+      return 0  # Japanese fonts found
+    fi
+  fi
+
+  echo "⚠️  No CJK fonts detected. Non-ASCII lyrics may render as □ boxes."
+
+  # Attempt to install fonts-noto-cjk (works on Debian/Ubuntu containers)
+  if command -v apt-get &>/dev/null; then
+    echo "   Attempting to install fonts-noto-cjk..."
+    if apt-get update -qq &>/dev/null && apt-get install -y -qq fonts-noto-cjk &>/dev/null; then
+      # Refresh font cache
+      command -v fc-cache &>/dev/null && fc-cache -f &>/dev/null
+      echo "   ✅ CJK fonts installed successfully."
+      return 0
+    else
+      echo "   ⚠️  Failed to install fonts (may need root/sudo). Trying sudo..."
+      if sudo apt-get update -qq &>/dev/null && sudo apt-get install -y -qq fonts-noto-cjk &>/dev/null; then
+        command -v fc-cache &>/dev/null && fc-cache -f &>/dev/null
+        echo "   ✅ CJK fonts installed successfully."
+        return 0
+      fi
+    fi
+  elif command -v apk &>/dev/null; then
+    # Alpine Linux containers
+    echo "   Attempting to install font-noto-cjk (Alpine)..."
+    if apk add --no-cache font-noto-cjk &>/dev/null; then
+      command -v fc-cache &>/dev/null && fc-cache -f &>/dev/null
+      echo "   ✅ CJK fonts installed successfully."
+      return 0
+    fi
+  elif command -v dnf &>/dev/null; then
+    echo "   Attempting to install google-noto-sans-cjk-fonts (dnf)..."
+    if dnf install -y -q google-noto-sans-cjk-fonts &>/dev/null; then
+      command -v fc-cache &>/dev/null && fc-cache -f &>/dev/null
+      echo "   ✅ CJK fonts installed successfully."
+      return 0
+    fi
+  fi
+
+  echo "   ⚠️  Could not auto-install CJK fonts. Please install manually:"
+  echo "      Debian/Ubuntu: apt-get install fonts-noto-cjk"
+  echo "      Alpine: apk add font-noto-cjk"
+  echo "      Fedora/RHEL: dnf install google-noto-sans-cjk-fonts"
+  return 1
+}
+
+check_and_install_cjk_fonts
+
+# --- Render ---
 echo "Rendering MV..."
 echo "  Audio: $(basename "$AUDIO")"
 echo "  Title: $TITLE"
@@ -125,6 +189,66 @@ echo "  Output: $OUTPUT"
 
 cd "$RENDER_DIR"
 node "${NODE_ARGS[@]}"
+
+# --- Post-render: compress if --max-size is set ---
+if [[ -n "$MAX_SIZE" && -f "$OUTPUT" ]]; then
+  FILE_SIZE_BYTES=$(stat -f%z "$OUTPUT" 2>/dev/null || stat -c%s "$OUTPUT" 2>/dev/null || echo 0)
+  MAX_SIZE_BYTES=$((MAX_SIZE * 1024 * 1024))
+
+  if [[ "$FILE_SIZE_BYTES" -gt "$MAX_SIZE_BYTES" ]]; then
+    echo ""
+    echo "Video size $(( FILE_SIZE_BYTES / 1024 / 1024 ))MB exceeds ${MAX_SIZE}MB limit. Compressing..."
+
+    COMPRESSED="${OUTPUT%.mp4}_compressed.mp4"
+
+    # Calculate target total bitrate (bits/s) from max size and duration
+    DURATION=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$OUTPUT" 2>/dev/null)
+    if [[ -z "$DURATION" || "$DURATION" == "N/A" ]]; then
+      echo "Error: Cannot determine video duration for compression." >&2
+      exit 1
+    fi
+
+    # Target bitrate = (max_size_bytes * 8) / duration * 0.95 safety margin
+    # Use bc for floating point, fallback to awk
+    TARGET_BITRATE=$(awk "BEGIN { printf \"%d\", ($MAX_SIZE_BYTES * 8 / $DURATION) * 0.95 }")
+    AUDIO_BITRATE=96000  # 96k audio
+    VIDEO_BITRATE=$((TARGET_BITRATE - AUDIO_BITRATE))
+
+    if [[ "$VIDEO_BITRATE" -lt 100000 ]]; then
+      echo "Error: Target size too small for this video duration." >&2
+      exit 1
+    fi
+
+    echo "  Target video bitrate: $((VIDEO_BITRATE / 1000))kbps"
+
+    # Two-pass encoding for best quality at target size
+    ffmpeg -y -i "$OUTPUT" \
+      -c:v libx264 -b:v "${VIDEO_BITRATE}" -pass 1 \
+      -preset medium -an -f null /dev/null 2>/dev/null
+
+    ffmpeg -y -i "$OUTPUT" \
+      -c:v libx264 -b:v "${VIDEO_BITRATE}" -pass 2 \
+      -preset medium -c:a aac -b:a 96k \
+      -movflags +faststart \
+      "$COMPRESSED" 2>/dev/null
+
+    # Clean up two-pass log files
+    rm -f ffmpeg2pass-0.log ffmpeg2pass-0.log.mbtree
+
+    if [[ -f "$COMPRESSED" ]]; then
+      COMP_SIZE=$(stat -f%z "$COMPRESSED" 2>/dev/null || stat -c%s "$COMPRESSED" 2>/dev/null || echo 0)
+      echo "  Compressed: $(( COMP_SIZE / 1024 / 1024 ))MB (was $(( FILE_SIZE_BYTES / 1024 / 1024 ))MB)"
+
+      # Replace original with compressed
+      mv "$COMPRESSED" "$OUTPUT"
+      echo "  ✅ Compressed video saved to: $OUTPUT"
+    else
+      echo "  ⚠️  Compression failed, keeping original file."
+    fi
+  else
+    echo "Video size $(( FILE_SIZE_BYTES / 1024 / 1024 ))MB is within ${MAX_SIZE}MB limit. No compression needed."
+  fi
+fi
 
 echo ""
 echo "Output: $OUTPUT"

--- a/.claude/skills/acestep-simplemv/scripts/src/AudioVisualization.tsx
+++ b/.claude/skills/acestep-simplemv/scripts/src/AudioVisualization.tsx
@@ -261,7 +261,7 @@ export const AudioVisualization: React.FC<MVInputProps> = ({
               opacity: titleOpacity,
               transform: `translateY(${titleY}px)`,
               textShadow: `0 0 40px hsla(${hue}, 100%, 70%, 0.8), 0 4px 20px rgba(0,0,0,0.5)`,
-              fontFamily: '"Noto Sans CJK JP", "Noto Sans CJK SC", Arial, sans-serif',
+              fontFamily: '"Noto Sans CJK SC", "Noto Sans CJK JP", "Noto Sans CJK TC", "Noto Sans CJK KR", "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "Droid Sans Fallback", "Source Han Sans SC", "Microsoft YaHei", "SimHei", "Hiragino Sans GB", Arial, Helvetica, sans-serif',
               marginBottom: 10,
             }}
           >
@@ -275,7 +275,7 @@ export const AudioVisualization: React.FC<MVInputProps> = ({
               opacity: titleOpacity,
               transform: `translateY(${titleY}px)`,
               textShadow: `0 0 30px hsla(${hue + 60}, 100%, 70%, 0.6), 0 2px 10px rgba(0,0,0,0.5)`,
-              fontFamily: '"Noto Sans CJK JP", "Noto Sans CJK SC", Arial, sans-serif',
+              fontFamily: '"Noto Sans CJK SC", "Noto Sans CJK JP", "Noto Sans CJK TC", "Noto Sans CJK KR", "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "Droid Sans Fallback", "Source Han Sans SC", "Microsoft YaHei", "SimHei", "Hiragino Sans GB", Arial, Helvetica, sans-serif',
               letterSpacing: '4px',
             }}
           >
@@ -303,7 +303,7 @@ export const AudioVisualization: React.FC<MVInputProps> = ({
               opacity: lyricProgress,
               transform: `translateY(${(1 - lyricProgress) * 30}px)`,
               textShadow: `0 0 40px hsla(${hue}, 100%, 70%, 0.8), 0 4px 30px rgba(0,0,0,0.9)`,
-              fontFamily: '"Noto Sans CJK JP", "Noto Sans CJK SC", Arial, sans-serif',
+              fontFamily: '"Noto Sans CJK SC", "Noto Sans CJK JP", "Noto Sans CJK TC", "Noto Sans CJK KR", "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "Droid Sans Fallback", "Source Han Sans SC", "Microsoft YaHei", "SimHei", "Hiragino Sans GB", Arial, Helvetica, sans-serif',
               lineHeight: 1.5,
               padding: '25px 50px',
               background: `linear-gradient(135deg, rgba(0,0,0,0.4), rgba(0,0,0,0.2))`,
@@ -334,7 +334,7 @@ export const AudioVisualization: React.FC<MVInputProps> = ({
             opacity: 0.8,
             textAlign: 'center',
             textShadow: `0 0 20px hsla(${hue}, 100%, 70%, 0.6), 0 2px 10px rgba(0,0,0,0.7)`,
-            fontFamily: '"Noto Sans CJK JP", "Noto Sans CJK SC", Arial, sans-serif',
+            fontFamily: '"Noto Sans CJK SC", "Noto Sans CJK JP", "Noto Sans CJK TC", "Noto Sans CJK KR", "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "Droid Sans Fallback", "Source Han Sans SC", "Microsoft YaHei", "SimHei", "Hiragino Sans GB", Arial, Helvetica, sans-serif',
           }}
         >
           {creditText}

--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,9 @@ test_lora_scale_fix.py
 lokr_output/
 .claude/skills/acestep/scripts/config.json
 .claude/skills/acestep/scripts/.first_gen_done
+.claude/skills/acestep-simplemv/scripts/public/
+config.json
+
 acestep_output/
 # macOS
 .DS_Store


### PR DESCRIPTION

This pull request adds major improvements to the `acestep-simplemv` skill, focusing on better support for instant messaging (IM) platform upload limits and improved handling of CJK (Chinese, Japanese, Korean) fonts in containerized environments. It introduces a new `--max-size` option for automatic video compression and enhances font detection, installation, and fallback to ensure proper lyric rendering. Documentation and UI font stacks are also updated for clarity and robustness.

**Key changes:**

### IM Platform Upload Support

* Added a `--max-size` option to `render-mv.sh` and documented its use, enabling automatic video compression to fit IM platform file size limits (e.g., WhatsApp, Discord, Telegram). The script now uses ffmpeg two-pass encoding to compress videos post-render if they exceed the specified size. [[1]](diffhunk://#diff-fb7bfab57b15d928ac7af1310fedbf0a311447e56127e92bceff95f0744c9f6eR19-R20) [[2]](diffhunk://#diff-fb7bfab57b15d928ac7af1310fedbf0a311447e56127e92bceff95f0744c9f6eR55) [[3]](diffhunk://#diff-fb7bfab57b15d928ac7af1310fedbf0a311447e56127e92bceff95f0744c9f6eR71) [[4]](diffhunk://#diff-fb7bfab57b15d928ac7af1310fedbf0a311447e56127e92bceff95f0744c9f6eR193-R252) [[5]](diffhunk://#diff-e548f6a83e98218764d3aa90fce345b3f17692e79308fb6d7db11612778a96aeR62-R63) [[6]](diffhunk://#diff-e548f6a83e98218764d3aa90fce345b3f17692e79308fb6d7db11612778a96aeR112-R150)

### Containerized Font Handling

* Implemented automatic detection and installation of CJK fonts in Linux container environments within `render-mv.sh`. The script checks for available CJK fonts, attempts installation via package managers (apt, apk, dnf), and provides clear manual installation instructions if needed. [[1]](diffhunk://#diff-fb7bfab57b15d928ac7af1310fedbf0a311447e56127e92bceff95f0744c9f6eR125-R184) [[2]](diffhunk://#diff-e548f6a83e98218764d3aa90fce345b3f17692e79308fb6d7db11612778a96aeR112-R150)

### Font Stack Improvements

* Updated font-family stacks in `AudioVisualization.tsx` to include a broader set of CJK and fallback fonts, improving lyric and title rendering across different platforms and environments. [[1]](diffhunk://#diff-4b852ead4f12688ccbd5465b968a940e11579ba24342114dc9cb6dd3e5f5330eL264-R264) [[2]](diffhunk://#diff-4b852ead4f12688ccbd5465b968a940e11579ba24342114dc9cb6dd3e5f5330eL278-R278) [[3]](diffhunk://#diff-4b852ead4f12688ccbd5465b968a940e11579ba24342114dc9cb6dd3e5f5330eL306-R306) [[4]](diffhunk://#diff-4b852ead4f12688ccbd5465b968a940e11579ba24342114dc9cb6dd3e5f5330eL337-R337)

### Documentation Enhancements

* Expanded documentation in `SKILL.md` to explain the new `--max-size` option, provide IM platform upload limits, and give detailed instructions for font installation in containers. [[1]](diffhunk://#diff-e548f6a83e98218764d3aa90fce345b3f17692e79308fb6d7db11612778a96aeR62-R63) [[2]](diffhunk://#diff-e548f6a83e98218764d3aa90fce345b3f17692e79308fb6d7db11612778a96aeR112-R150)

These changes make the skill more robust and user-friendly, especially for users sharing videos on chat platforms or running in containerized environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-size` CLI option to automatically compress videos to meet upload limits for messaging platforms like Discord and WhatsApp.
  * Implemented automatic CJK font detection and installation for container environments with fallback instructions.

* **Documentation**
  * Added IM platform upload limit guidance with recommended compression settings.
  * Expanded font support documentation with platform-specific installation instructions.
  * Added file naming best practices.

* **Improvements**
  * Enhanced font family compatibility across platforms for better text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->