### PR TITLE
feat: add chunk_mask_mode parameter for explicit vs auto mask control

### DIFF
--- a/acestep/api/http/release_task_models.py
+++ b/acestep/api/http/release_task_models.py
@@ -62,6 +62,7 @@ class GenerateMusicRequest(BaseModel):
         description="User-provided audio semantic codes string for code-control generation. When non-empty, skips LM code generation.",
     )
     task_type: str = "text2music"
+    chunk_mask_mode: Literal["explicit", "auto"] = "auto"
     analysis_only: bool = False
     full_analysis_only: bool = False
 

--- a/acestep/api/http/release_task_request_builder.py
+++ b/acestep/api/http/release_task_request_builder.py
@@ -66,6 +66,7 @@ def build_generate_music_request(
         reference_audio_path=reference_audio,
         src_audio_path=src_audio,
         task_type=parser.str("task_type", "text2music"),
+        chunk_mask_mode=parser.str("chunk_mask_mode", "auto"),
         use_adg=parser.bool("use_adg"),
         cfg_interval_start=parser.float("cfg_interval_start", 0.0),
         cfg_interval_end=parser.float("cfg_interval_end", 1.0),

--- a/acestep/api/job_generation_setup.py
+++ b/acestep/api/job_generation_setup.py
@@ -161,6 +161,7 @@ def build_generation_setup(
         timesteps=parsed_timesteps,
         repainting_start=req.repainting_start,
         repainting_end=req.repainting_end if req.repainting_end else -1,
+        chunk_mask_mode=getattr(req, "chunk_mask_mode", "auto"),
         audio_cover_strength=req.audio_cover_strength,
         cover_noise_strength=req.cover_noise_strength,
         thinking=thinking,

--- a/acestep/core/generation/handler/conditioning_batch.py
+++ b/acestep/core/generation/handler/conditioning_batch.py
@@ -34,6 +34,7 @@ class ConditioningBatchMixin:
         audio_code_hints: Optional[List[Optional[str]]] = None,
         audio_cover_strength: float = 1.0,
         cover_noise_strength: float = 0.0,
+        chunk_mask_modes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Prepare model-ready conditioning batch tensors and metadata.
 
@@ -89,6 +90,7 @@ class ConditioningBatchMixin:
             repainting_start,
             repainting_end,
             silence_latent_tiled,
+            chunk_mask_modes=chunk_mask_modes,
         )
         precomputed_lm_hints_25hz = self._prepare_precomputed_lm_hints(
             batch_size, audio_code_hints, max_latent_length, silence_latent_tiled
@@ -110,6 +112,7 @@ class ConditioningBatchMixin:
             vocal_languages,
             audio_cover_strength,
             global_captions=global_captions,
+            chunk_mask_modes=chunk_mask_modes,
         )
 
         batch = {

--- a/acestep/core/generation/handler/conditioning_masks.py
+++ b/acestep/core/generation/handler/conditioning_masks.py
@@ -27,6 +27,7 @@ class ConditioningMaskMixin:
         repainting_start: Optional[List[float]],
         repainting_end: Optional[List[float]],
         silence_latent_tiled: torch.Tensor,
+        chunk_mask_modes: Optional[List[str]] = None,
     ) -> Tuple[torch.Tensor, List[Tuple[str, int, int]], torch.Tensor, torch.Tensor]:
         """Create chunk masks/spans and corresponding source latents."""
         chunk_masks = []
@@ -67,6 +68,10 @@ class ConditioningMaskMixin:
             is_covers.append(is_cover)
 
         chunk_masks_tensor = torch.stack(chunk_masks)
+        if chunk_mask_modes:
+            for i, mode in enumerate(chunk_mask_modes):
+                if mode == "auto":
+                    chunk_masks_tensor[i] = 2.0
         is_covers_tensor = torch.BoolTensor(is_covers).to(self.device)
 
         src_latents_list = []

--- a/acestep/core/generation/handler/conditioning_text.py
+++ b/acestep/core/generation/handler/conditioning_text.py
@@ -64,6 +64,7 @@ class ConditioningTextMixin:
         vocal_languages: List[str],
         audio_cover_strength: float,
         global_captions: Optional[List[str]] = None,
+        chunk_mask_modes: Optional[List[str]] = None,
     ) -> Tuple[List[str], torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
         """Tokenize caption/lyric prompts and optional non-cover branch prompts."""
         actual_captions, actual_languages = self._extract_caption_and_language(parsed_metas, captions, vocal_languages)
@@ -105,13 +106,12 @@ class ConditioningTextMixin:
                 global_cap = (global_captions[i] if global_captions and i < len(global_captions) else "") or ""
                 instr_lower = instruction.lower()
                 is_chunk_mode = "a segment" in instr_lower
+                chunk_mode_i = (chunk_mask_modes[i] if chunk_mask_modes and i < len(chunk_mask_modes) else "auto")
+                mask_control_str = "Mask Control: false" if chunk_mode_i == "auto" else "Mask Control: true"
                 if is_chunk_mode:
-                    # Chunk mode: Local only, no Global prefix
-                    actual_caption = f"Local: {local_cap}\nMask Control: true"
+                    actual_caption = f"Local: {local_cap}\n{mask_control_str}"
                 else:
-                    # Full mode: always include Global + Local (even when global_cap is empty,
-                    # the model was trained exclusively with this prefix in full-mode prompts)
-                    actual_caption = f"Global: {global_cap}\nLocal: {local_cap}\nMask Control: true"
+                    actual_caption = f"Global: {global_cap}\nLocal: {local_cap}\n{mask_control_str}"
 
             text_prompt = SFT_GEN_PROMPT.format(instruction, actual_caption, parsed_metas[i])
 

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -125,6 +125,7 @@ class GenerateMusicMixin:
         timesteps: Optional[List[float]] = None,
         latent_shift: float = 0.0,
         latent_rescale: float = 1.0,
+        chunk_mask_mode: str = "auto",
         progress=None,
     ) -> Dict[str, Any]:
         """Generate audio from text/reference inputs and return response payload.
@@ -208,6 +209,7 @@ class GenerateMusicMixin:
                 audio_code_string=audio_code_string,
                 repainting_start=repainting_start,
                 repainting_end=repainting_end,
+                chunk_mask_mode=chunk_mask_mode,
             )
             vram_error = self._vram_preflight_check(
                 actual_batch_size=actual_batch_size,

--- a/acestep/core/generation/handler/generate_music_execute.py
+++ b/acestep/core/generation/handler/generate_music_execute.py
@@ -80,6 +80,7 @@ class GenerateMusicExecuteMixin:
                     audio_code_hints=service_inputs["audio_code_hints_batch"],
                     return_intermediate=service_inputs["should_return_intermediate"],
                     timesteps=timesteps,
+                    chunk_mask_modes=service_inputs.get("chunk_mask_modes_batch"),
                 )
             except Exception as exc:
                 _error["exc"] = exc

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -152,6 +152,7 @@ class GenerateMusicRequestMixin:
         audio_code_string: Union[str, List[str]] = "",
         repainting_start: float = 0.0,
         repainting_end: Optional[float] = None,
+        chunk_mask_mode: str = "auto",
     ) -> Dict[str, Any]:
         """Prepare service inputs (batch text, repaint spans, and optional code hints)."""
         captions_batch, instructions_batch, lyrics_batch, vocal_languages_batch, metas_batch = self.prepare_batch_data(
@@ -198,6 +199,7 @@ class GenerateMusicRequestMixin:
             "repainting_end_batch": repainting_end_batch,
             "target_wavs_tensor": target_wavs_tensor,
             "audio_code_hints_batch": audio_code_hints_batch,
+            "chunk_mask_modes_batch": [chunk_mask_mode] * actual_batch_size,
             "should_return_intermediate": True,
         }
 

--- a/acestep/core/generation/handler/service_generate.py
+++ b/acestep/core/generation/handler/service_generate.py
@@ -44,6 +44,7 @@ class ServiceGenerateMixin:
         audio_code_hints: Optional[Union[str, List[str]]] = None,
         infer_method: str = "ode",
         timesteps: Optional[List[float]] = None,
+        chunk_mask_modes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Generate music latents and metadata from text/audio conditioning inputs.
 
@@ -109,6 +110,7 @@ class ServiceGenerateMixin:
             audio_code_hints=normalized["audio_code_hints"],
             audio_cover_strength=audio_cover_strength,
             cover_noise_strength=cover_noise_strength,
+            chunk_mask_modes=chunk_mask_modes,
         )
         payload = self._unpack_service_processed_data(self.preprocess_batch(batch))
         seed_param = self._resolve_service_seed_param(normalized["seed_list"])

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -139,6 +139,7 @@ class GenerationParams:
 
     repainting_start: float = 0.0
     repainting_end: float = -1
+    chunk_mask_mode: str = "auto"  # "explicit" = 0/1 mask from repaint range; "auto" = all 2.0 (model decides)
     audio_cover_strength: float = 1.0
     cover_noise_strength: float = 0.0  # 0=pure noise (no cover), 1=closest to src audio
 
@@ -614,6 +615,7 @@ def generate_music(
             timesteps=params.timesteps,
             latent_shift=params.latent_shift,
             latent_rescale=params.latent_rescale,
+            chunk_mask_mode=getattr(params, "chunk_mask_mode", "auto"),
             progress=progress,
         )
 


### PR DESCRIPTION
Introduce a chunk_mask_mode option ("explicit" | "auto") that flows from the HTTP API through GenerationParams down to the conditioning pipeline.

- "explicit": uses the 0/1 chunk mask derived from the repainting range
  (existing behavior, Mask Control: true in prompt).
- "auto": fills the chunk mask tensor with 2.0 so the model decides
  mask boundaries itself (Mask Control: false in prompt).

Default is "auto" which lets the model handle segmentation autonomously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable chunk masking mode to music generation. Users can now specify masking behavior with 'auto' (default) for automatic masking or 'explicit' mode for explicit control during generation. This enhancement provides greater flexibility and precision in customizing music generation workflows according to specific masking requirements, use cases, and preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->