### PR TITLE
fix: guard torch.mps.empty_cache() with backends.mps.is_available()

### DIFF
--- a/acestep/ui/gradio/events/results/_batch_management_test_support.py
+++ b/acestep/ui/gradio/events/results/_batch_management_test_support.py
@@ -116,6 +116,9 @@ def load_batch_management_module(
     fake_torch = types.ModuleType("torch")
     fake_torch.cuda = fake_cuda
 
+    fake_backends_mps = types.SimpleNamespace(is_available=lambda: mps_available)
+    fake_torch.backends = types.SimpleNamespace(mps=fake_backends_mps)
+
     if mps_available:
         def _mps_empty_cache():
             state["mps_empty_cache_calls"] += 1

--- a/acestep/ui/gradio/events/results/batch_management_background.py
+++ b/acestep/ui/gradio/events/results/batch_management_background.py
@@ -54,7 +54,9 @@ def generate_next_batch_background(
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-        if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+        if (hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache")
+                and hasattr(torch.backends, "mps")
+                and torch.backends.mps.is_available()):
             torch.mps.empty_cache()
 
         generator = generate_with_progress(

--- a/acestep/ui/gradio/events/results/batch_management_wrapper.py
+++ b/acestep/ui/gradio/events/results/batch_management_wrapper.py
@@ -60,7 +60,8 @@ def generate_with_batch_management(
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-    if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+    if (hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache")
+            and hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         torch.mps.empty_cache()
     generator = generate_with_progress(
         dit_handler, llm_handler,
@@ -98,7 +99,8 @@ def generate_with_batch_management(
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-    if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+    if (hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache")
+            and hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         torch.mps.empty_cache()
 
     result = final_result_from_inner


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: Cannot execute emptyCache() without MPS backend.` crash on non-MPS platforms (Windows/Linux CUDA) after recent `git pull`
- Adds `torch.backends.mps.is_available()` guard to all `torch.mps.empty_cache()` call sites in batch management modules, matching the pattern already used in `init_service_memory_basic.py`, `llm_inference.py`, and `lm_score.py`
- Updates test stub to include `torch.backends.mps.is_available` for proper test coverage

## Root Cause

The existing guard `hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache")` is insufficient: on Windows/Linux with recent PyTorch, `torch.mps` exists as a module and `empty_cache` is a real callable, but invoking it raises `RuntimeError` because MPS is only available on macOS with Apple Silicon.

## Files Changed

| File | Change |
|------|--------|
| `batch_management_wrapper.py` | Added `torch.backends.mps.is_available()` to 2 guard locations |
| `batch_management_background.py` | Added `torch.backends.mps.is_available()` to 1 guard location |
| `_batch_management_test_support.py` | Added `torch.backends.mps` to fake torch stub |

## Test plan

- [x] All 65 existing batch management tests pass
- [x] MPS-specific tests (`test_mps_cache_cleared_*`, `test_mps_cache_not_called_*`) pass in both wrapper and background test suites

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Metal Performance Shaders (MPS) backend detection and cache management to ensure operations execute only when the GPU acceleration backend is available and properly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->