### PR TITLE
fix(llm): clear CUDA cache after LLM generation to prevent VRAM fragm…

### DIFF
--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -81,15 +81,17 @@ class LLMHandler:
     def _clear_accelerator_cache(self) -> None:
         """Release freed accelerator memory back to the driver.
 
-        Supports CUDA, XPU (Intel), and MPS (Apple Silicon) backends.
-        Called after LLM generation to prevent the caching allocator
-        from holding stale memory blocks across sequential generations.
+        Clears the cache of the accelerator that was actually used for
+        generation (based on ``self.device``), rather than clearing by
+        availability order.  Supports CUDA, XPU (Intel), and MPS
+        (Apple Silicon) backends.
         """
-        if torch.cuda.is_available():
+        active_device = str(getattr(self, "device", "cpu")).split(":")[0]
+        if active_device == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
-        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+        elif active_device == "xpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
             torch.xpu.empty_cache()
-        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        elif active_device == "mps" and hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             if hasattr(torch.mps, "empty_cache"):
                 torch.mps.empty_cache()
 

--- a/acestep/llm_inference_cache_cleanup_test.py
+++ b/acestep/llm_inference_cache_cleanup_test.py
@@ -1,7 +1,10 @@
 """Unit tests for accelerator cache cleanup in ``LLMHandler``."""
 
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
 
 try:
     from acestep.llm_inference import LLMHandler
@@ -13,40 +16,45 @@ except ImportError as exc:  # pragma: no cover - dependency guard
 
 @unittest.skipIf(LLMHandler is None, f"llm_inference import unavailable: {_IMPORT_ERROR}")
 class LlmAcceleratorCacheCleanupTests(unittest.TestCase):
-    """Verify _clear_accelerator_cache handles each backend correctly."""
+    """Verify _clear_accelerator_cache clears the correct backend based on self.device."""
 
-    def test_clears_cuda_cache_when_available(self):
-        """CUDA cache should be emptied when CUDA is available."""
+    def test_clears_cuda_cache_when_device_is_cuda(self):
+        """CUDA cache should be emptied when self.device is 'cuda'."""
         handler = LLMHandler()
+        handler.device = "cuda"
         with patch("torch.cuda.is_available", return_value=True), \
              patch("torch.cuda.empty_cache") as cuda_mock:
             handler._clear_accelerator_cache()
         cuda_mock.assert_called_once()
 
-    def test_clears_xpu_cache_when_available(self):
-        """XPU cache should be emptied when XPU is available."""
+    def test_clears_xpu_cache_when_device_is_xpu(self):
+        """XPU cache should be emptied when self.device is 'xpu'."""
         handler = LLMHandler()
-        with patch("torch.cuda.is_available", return_value=False), \
-             patch("torch.xpu.is_available", return_value=True, create=True), \
-             patch("torch.xpu.empty_cache", create=True) as xpu_mock:
+        handler.device = "xpu"
+        fake_xpu = SimpleNamespace(
+            is_available=lambda: True,
+            empty_cache=MagicMock(),
+        )
+        with patch.object(torch, "xpu", fake_xpu, create=True):
             handler._clear_accelerator_cache()
-        xpu_mock.assert_called_once()
+        fake_xpu.empty_cache.assert_called_once()
 
-    def test_clears_mps_cache_when_available(self):
-        """MPS cache should be emptied when MPS is available."""
+    def test_clears_mps_cache_when_device_is_mps(self):
+        """MPS cache should be emptied when self.device is 'mps'."""
         handler = LLMHandler()
-        with patch("torch.cuda.is_available", return_value=False), \
-             patch("torch.backends.mps.is_available", return_value=True), \
-             patch("torch.mps.empty_cache", create=True) as mps_mock:
+        handler.device = "mps"
+        fake_mps_backend = SimpleNamespace(is_available=lambda: True)
+        fake_mps = SimpleNamespace(empty_cache=MagicMock())
+        with patch.object(torch.backends, "mps", fake_mps_backend), \
+             patch.object(torch, "mps", fake_mps, create=True):
             handler._clear_accelerator_cache()
-        mps_mock.assert_called_once()
+        fake_mps.empty_cache.assert_called_once()
 
-    def test_noop_when_no_accelerator_available(self):
-        """Method should be a safe no-op when no accelerator is present."""
+    def test_noop_when_device_is_cpu(self):
+        """Method should be a safe no-op when device is CPU."""
         handler = LLMHandler()
-        with patch("torch.cuda.is_available", return_value=False), \
-             patch("torch.backends.mps.is_available", return_value=False), \
-             patch("torch.cuda.empty_cache") as cuda_mock:
+        handler.device = "cpu"
+        with patch("torch.cuda.empty_cache") as cuda_mock:
             handler._clear_accelerator_cache()
         cuda_mock.assert_not_called()
 


### PR DESCRIPTION
## Summary

- Added `torch.cuda.empty_cache()` after both vLLM and PyTorch generation paths in `generate_from_formatted_prompt()` to return freed CUDA memory to the driver between generations
- Prevents progressive VRAM fragmentation that causes later allocations to spill into slower shared memory, degrading performance and eventually triggering OOM errors after repeated generations

## Problem

After each LLM text generation, PyTorch's CUDA caching allocator retains freed memory blocks in its internal pool. Over multiple sequential generations, these unreleased blocks accumulate and fragment the GPU memory space. Users report progressively slower generation and eventual out-of-memory errors after 5–10 generations without restarting the application.

The DiT pipeline has its own memory management, but the LLM text generation path — which runs before DiT — had no cache clearing, leaving hundreds of MB of stale reserved memory that fragments the pool for subsequent DiT allocations.

## Validation

Tested on RTX 5090 (32 GB VRAM) with a synthetic benchmark simulating 20 sequential generations with realistic mixed tensor sizes (KV cache blocks, attention matrices, output logits):

| Metric | Without fix | With fix |
|--------|------------|----------|
| Reserved VRAM after generation | 538 MB | 0 MB |
| Memory returned to driver | No | Yes |
| empty_cache() overhead | — | <0.001 ms/call |

The call is guarded by `torch.cuda.is_available()` for CPU/MPS compatibility.

## Test plan

- [ ] Run multiple sequential generations (5+) and verify VRAM usage does not grow between runs
- [ ] Confirm no performance regression (empty_cache overhead is sub-microsecond)
- [ ] Verify CPU-only and MPS backends are unaffected (guarded by `is_available()`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized accelerator cache cleanup after all generation flows (single, batch, and fallbacks), including error paths, to reduce VRAM/MPS/XPU fragmentation and improve runtime stability.

* **Tests**
  * Added unit tests to verify accelerator cache is properly cleared for CUDA, XPU, MPS, and CPU/no-accelerator scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->