### PR TITLE
fix(ui): add missing overflow class to Initialize 5Hz LM checkbox

### DIFF
--- a/acestep/ui/gradio/interfaces/generation_service_config_toggles.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_toggles.py
@@ -53,6 +53,7 @@ def build_service_toggles(
             label=t("service.init_llm_label"),
             value=params.get("init_llm", init_lm_default) if service_pre_initialized else init_lm_default,
             info=lm_info_text,
+            elem_classes=["has-info-container"],
         )
 
         flash_attn_available = dit_handler.is_flash_attention_available(device_value)


### PR DESCRIPTION
## Summary

- Added missing `elem_classes=["has-info-container"]` to the Initialize 5Hz LM checkbox

## Problem

The `init_llm_checkbox` in `build_service_toggles()` was the only checkbox missing the `has-info-container` CSS class. This caused a visible scrollbar on the checkbox container because the `info` text overflows the default Gradio container height. All six other checkboxes in the same function already use this class.

## Test plan

- [ ] Verify no scrollbar appears on the Initialize 5Hz LM checkbox in Settings > Service Configuration
- [ ] Confirm all other checkboxes in the same row still render correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for a configuration checkbox to better display accompanying information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->