### PR TITLE
727: Fix dangerous return in finally block in temporary_llm_model context manager

### DIFF
--- a/acestep/api/runtime_helpers.py
+++ b/acestep/api/runtime_helpers.py
@@ -158,21 +158,20 @@ def temporary_llm_model(
         try:
             yield
         finally:
-            if not ok_switched or not restore_params:
-                return
-            try:
-                llm.initialize(**restore_params)
+            if ok_switched and restore_params:
                 try:
-                    app.state._llm_initialized = True
-                    app.state._llm_init_error = None
-                except Exception:
-                    pass
-            except Exception as exc:
-                try:
-                    app.state._llm_initialized = False
-                    app.state._llm_init_error = str(exc)
-                except Exception:
-                    pass
+                    llm.initialize(**restore_params)
+                    try:
+                        app.state._llm_initialized = True
+                        app.state._llm_init_error = None
+                    except Exception:
+                        pass
+                except Exception as exc:
+                    try:
+                        app.state._llm_initialized = False
+                        app.state._llm_init_error = str(exc)
+                    except Exception:
+                        pass
 
 
 def atomic_write_json(path: str, payload: Dict[str, Any]) -> None:

--- a/acestep/api/runtime_helpers_test.py
+++ b/acestep/api/runtime_helpers_test.py
@@ -127,6 +127,39 @@ class RuntimeHelpersTests(unittest.TestCase):
         self.assertEqual("new-model", first_call["lm_model_path"])
         self.assertEqual(prev_params, second_call)
 
+    def test_temporary_llm_model_does_not_suppress_exception_when_switch_fails(self):
+        """Exceptions inside the context should propagate even if switch/restore is skipped."""
+
+        app = SimpleNamespace(state=SimpleNamespace(_llm_init_lock=threading.Lock()))
+        prev_params = {
+            "checkpoint_dir": "old-checkpoints",
+            "lm_model_path": "old-model",
+            "backend": "vllm",
+            "device": "cuda",
+            "offload_to_cpu": False,
+            "dtype": None,
+        }
+        llm = SimpleNamespace(
+            llm_initialized=True,
+            initialize=mock.Mock(return_value=("failed", False)),
+            last_init_params=prev_params,
+        )
+
+        with mock.patch("acestep.api.runtime_helpers.os.makedirs"):
+            with self.assertRaises(ValueError):
+                with temporary_llm_model(
+                    app=app,
+                    llm=llm,
+                    lm_model_path="new-model",
+                    get_project_root=lambda: "project-root",
+                    get_model_name=lambda _path: "new-model",
+                    ensure_model_downloaded=lambda *_: "",
+                    env_bool=lambda *_: False,
+                ):
+                    raise ValueError("boom")
+
+        self.assertEqual(1, llm.initialize.call_count)
+
     def test_atomic_write_json_replaces_target_on_success(self):
         """Atomic write helper should fsync temp file and replace destination path."""
 


### PR DESCRIPTION
Fix dangerous return in finally block in temporary_llm_model context manager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during model restoration with improved error tracking and state management.

* **Tests**
  * Added test coverage to ensure exceptions propagate correctly when model initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->