### PR TITLE
fix: resolve API crash, generation corruption, and locale parsing (#797, #854, #779)

### DIFF
--- a/acestep/api/job_generation_setup.py
+++ b/acestep/api/job_generation_setup.py
@@ -7,6 +7,11 @@ from typing import Any, Callable, Optional
 
 from acestep.inference import GenerationConfig, GenerationParams
 
+# Sensible fallback when the API receives a null/missing audio_duration.
+# This prevents -1.0/None from propagating into the LLM and DiT, which
+# can cause unconstrained code generation and downstream tensor mismatches.
+_API_DEFAULT_DURATION_SECONDS: float = 120.0
+
 
 @dataclass
 class GenerationSetup:
@@ -155,7 +160,7 @@ def build_generation_setup(
         bpm=bpm,
         keyscale=key_scale,
         timesignature=time_signature,
-        duration=audio_duration if audio_duration else -1.0,
+        duration=audio_duration if audio_duration else _API_DEFAULT_DURATION_SECONDS,
         inference_steps=req.inference_steps,
         seed=req.seed,
         guidance_scale=req.guidance_scale,

--- a/acestep/api/job_generation_setup_test.py
+++ b/acestep/api/job_generation_setup_test.py
@@ -110,7 +110,10 @@ class JobGenerationSetupTests(unittest.TestCase):
         self.assertEqual("Extract VOCALS", setup.params.instruction)
         self.assertFalse(setup.params.use_cot_metas)
         self.assertEqual([0.1, 0.5], setup.params.timesteps)
-        self.assertEqual(-1.0, setup.params.duration)
+        # When audio_duration is None, the API default (120s) is used
+        # instead of -1.0 to prevent unconstrained generation (issue #797).
+        from acestep.api.job_generation_setup import _API_DEFAULT_DURATION_SECONDS
+        self.assertEqual(_API_DEFAULT_DURATION_SECONDS, setup.params.duration)
 
     def test_build_generation_setup_resolves_seed_list_from_string(self) -> None:
         """Seed strings should keep valid values and drop invalid or sentinel values."""

--- a/acestep/core/generation/handler/conditioning_target.py
+++ b/acestep/core/generation/handler/conditioning_target.py
@@ -15,6 +15,23 @@ class ConditioningTargetMixin:
       ``is_silence``, ``_encode_audio_to_latents``, ``_decode_audio_codes_to_latents``.
     """
 
+    def _get_silence_latent_slice(self, length: int) -> torch.Tensor:
+        """Return a silence-latent slice of exactly ``length`` frames.
+
+        When the pre-computed ``silence_latent`` tensor is shorter than
+        ``length``, it is tiled (repeated) along the time axis to cover
+        the needed span.  This prevents a silent shape mismatch that
+        previously occurred when ``audio_duration`` was null and the
+        generated code count exceeded the stored silence latent size.
+        """
+        available = self.silence_latent.shape[1]
+        if length <= available:
+            return self.silence_latent[0, :length, :]
+        # Tile to cover the needed length
+        repeats = (length + available - 1) // available  # ceil division
+        tiled = self.silence_latent[0].repeat(repeats, 1)  # (repeats*available, C)
+        return tiled[:length, :]
+
     def _prepare_target_latents_and_wavs(
         self,
         batch_size: int,
@@ -51,7 +68,7 @@ class ConditioningTargetMixin:
                     current_wav = target_wavs_list[i].to(self.device).unsqueeze(0)
                     if self.is_silence(current_wav):
                         expected_latent_length = current_wav.shape[-1] // 1920
-                        target_latent = self.silence_latent[0, :expected_latent_length, :]
+                        target_latent = self._get_silence_latent_slice(expected_latent_length)
                     else:
                         if (
                             _cached_wav_ref is not None
@@ -82,14 +99,14 @@ class ConditioningTargetMixin:
 
             max_latent_length = max(latent.shape[0] for latent in target_latents_list)
             max_latent_length = max(128, max_latent_length)
-            silence_latent_tiled = self.silence_latent[0, :max_latent_length, :]
+            silence_latent_tiled = self._get_silence_latent_slice(max_latent_length)
 
             padded_latents = []
             for latent in target_latents_list:
                 latent_length = latent.shape[0]
                 if latent_length < max_latent_length:
                     pad_length = max_latent_length - latent_length
-                    latent = torch.cat([latent, self.silence_latent[0, :pad_length, :]], dim=0)
+                    latent = torch.cat([latent, self._get_silence_latent_slice(pad_length)], dim=0)
                 padded_latents.append(latent)
 
             target_latents = torch.stack(padded_latents)

--- a/acestep/core/generation/handler/vae_decode_chunks.py
+++ b/acestep/core/generation/handler/vae_decode_chunks.py
@@ -28,9 +28,13 @@ class VaeDecodeChunksMixin:
                 result = result.to(latents.device)
             return result
 
+        min_overlap = 4  # Minimum floor to prevent audio artifacts at chunk boundaries
         effective_overlap = overlap
-        while chunk_size - 2 * effective_overlap <= 0 and effective_overlap > 0:
+        while chunk_size - 2 * effective_overlap <= 0 and effective_overlap > min_overlap:
             effective_overlap = effective_overlap // 2
+        # Enforce minimum overlap floor to avoid near-zero values that cause corruption
+        if effective_overlap < min_overlap and overlap >= min_overlap:
+            effective_overlap = min_overlap
         if effective_overlap != overlap:
             logger.warning(
                 f"[tiled_decode] Reduced overlap from {overlap} to {effective_overlap} for chunk_size={chunk_size}"

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -2,6 +2,7 @@
 5Hz LM (Language Model) Handler
 Handles all LM-related operations including initialization and generation
 """
+import gc
 import os
 import sys
 import traceback
@@ -130,11 +131,7 @@ class LLMHandler:
             self.llm_backend = None
             self._mlx_model = None
             self._mlx_model_path = None
-            try:
-                import gc
-                gc.collect()
-            except Exception:
-                pass
+            gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 torch.cuda.synchronize()
@@ -280,10 +277,17 @@ class LLMHandler:
                 # CoT phase or mixed: add larger buffer for metadata overhead.
                 max_new_tokens = target_codes + 500
         else:
+            # When no target_duration is set, cap the fallback to a safe
+            # upper bound derived from DURATION_MAX so that generation cannot
+            # produce more audio codes than the downstream DiT can handle.
+            duration_cap = DURATION_MAX * 5 + 500  # codes + metadata buffer
             if fallback_max is not None:
-                max_new_tokens = fallback_max
+                max_new_tokens = min(fallback_max, duration_cap)
             else:
-                max_new_tokens = getattr(self, "max_model_len", 4096) - 64
+                max_new_tokens = min(
+                    getattr(self, "max_model_len", 4096) - 64,
+                    duration_cap,
+                )
 
         # Cap at model's max length
         if hasattr(self, "max_model_len"):
@@ -577,6 +581,7 @@ class LLMHandler:
 
             # Proactive CUDA cleanup before LM load to reduce fragmentation on mode/model switch
             if device == "cuda" and torch.cuda.is_available():
+                gc.collect()
                 torch.cuda.empty_cache()
                 torch.cuda.synchronize()
 
@@ -778,6 +783,7 @@ class LLMHandler:
             current_device = torch.cuda.current_device()
             device_name = torch.cuda.get_device_name(current_device)
 
+            gc.collect()
             torch.cuda.empty_cache()
             self._cleanup_torch_distributed_state()
 
@@ -1400,6 +1406,23 @@ class LLMHandler:
             else:
                 logger.info("Phase 1: Using user-provided metadata (skipping generation)")
             metadata = {k: v for k, v in user_metadata.items() if v is not None}
+
+        # When the caller did not supply an explicit target_duration, use the
+        # duration that Phase 1 (CoT) produced so that Phase 2 code generation
+        # is properly constrained.  Without this, a null API duration lets
+        # Phase 2 run unconstrained, potentially producing more audio codes
+        # than the downstream DiT expects and causing a tensor-size mismatch.
+        if (target_duration is None or target_duration <= 0) and metadata.get("duration"):
+            try:
+                cot_duration = float(metadata["duration"])
+                if cot_duration > 0:
+                    target_duration = cot_duration
+                    logger.info(
+                        f"Using CoT-generated duration ({cot_duration}s) as "
+                        f"Phase 2 target_duration (original was None/unset)"
+                    )
+            except (ValueError, TypeError):
+                pass
 
         # If infer_type is 'dit', stop here and return only metadata
         if infer_type == "dit":
@@ -2447,6 +2470,7 @@ class LLMHandler:
                 except Exception:
                     pass  # Ignore errors during cleanup
             # Clear accelerator cache to release any corrupted memory
+            gc.collect()
             self._clear_accelerator_cache()
             return "", f"❌ Error generating from formatted prompt: {type(e).__name__}: {e or error_detail.splitlines()[-1]}"
 
@@ -2540,6 +2564,9 @@ class LLMHandler:
 
         if streamer is not None:
             streamer.end()
+
+        # Explicitly free KV cache to reduce memory fragmentation
+        del past_key_values
 
         return generated_ids
 
@@ -2709,6 +2736,9 @@ class LLMHandler:
 
         if streamer is not None:
             streamer.end()
+
+        # Explicitly free KV cache to reduce memory fragmentation
+        del past_key_values
 
         # Return the full batch (both conditional and unconditional)
         # The caller will extract only the conditional output
@@ -4069,6 +4099,7 @@ class LLMHandler:
             if hasattr(model, "to"):
                 model.to("cpu")
             # Clear accelerator cache after offloading
+            gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
             elif hasattr(torch, 'xpu') and torch.xpu.is_available():

--- a/acestep/null_duration_fixes_test.py
+++ b/acestep/null_duration_fixes_test.py
@@ -1,0 +1,234 @@
+"""Tests for null audio_duration crash fixes (issue #797).
+
+Covers:
+  - Fix 1: CoT-generated duration feeds into Phase 2 target_duration.
+  - Fix 2: _compute_max_new_tokens caps fallback at DURATION_MAX.
+  - Fix 3: silence_latent tiling when length exceeds stored tensor.
+  - Fix 4: API-level default duration replaces -1.0 sentinel.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    import torch
+    from acestep.llm_inference import LLMHandler
+    from acestep.constants import DURATION_MAX
+    from acestep.core.generation.handler.conditioning_target import (
+        ConditioningTargetMixin,
+    )
+    from acestep.api.job_generation_setup import (
+        _API_DEFAULT_DURATION_SECONDS,
+        build_generation_setup,
+    )
+
+    _IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover
+    torch = None  # type: ignore[assignment]
+    LLMHandler = None
+    ConditioningTargetMixin = None
+    DURATION_MAX = None
+    _API_DEFAULT_DURATION_SECONDS = None
+    build_generation_setup = None
+    _IMPORT_ERROR = exc
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: _compute_max_new_tokens caps
+# ---------------------------------------------------------------------------
+
+@unittest.skipIf(LLMHandler is None, f"import unavailable: {_IMPORT_ERROR}")
+class ComputeMaxNewTokensCapTests(unittest.TestCase):
+    """_compute_max_new_tokens must not exceed DURATION_MAX-based cap."""
+
+    def _handler(self, max_model_len: int = 16384) -> "LLMHandler":
+        h = LLMHandler()
+        h.max_model_len = max_model_len
+        return h
+
+    def test_no_duration_caps_at_duration_max(self):
+        """Without target_duration, result must be <= DURATION_MAX*5 + 500."""
+        h = self._handler(max_model_len=100_000)
+        tokens = h._compute_max_new_tokens(target_duration=None, generation_phase="codes")
+        cap = DURATION_MAX * 5 + 500
+        self.assertLessEqual(tokens, cap)
+
+    def test_no_duration_with_fallback_caps(self):
+        """Explicit fallback_max must also be capped at DURATION_MAX bound."""
+        h = self._handler(max_model_len=100_000)
+        huge_fallback = 999_999
+        tokens = h._compute_max_new_tokens(
+            target_duration=None, generation_phase="codes", fallback_max=huge_fallback,
+        )
+        cap = DURATION_MAX * 5 + 500
+        self.assertLessEqual(tokens, cap)
+
+    def test_with_duration_ignores_cap(self):
+        """When target_duration is set, normal calculation should apply."""
+        h = self._handler()
+        tokens = h._compute_max_new_tokens(target_duration=30.0, generation_phase="codes")
+        # 30s * 5 codes/s + 10 buffer = 160
+        self.assertEqual(tokens, 160)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: silence_latent tiling
+# ---------------------------------------------------------------------------
+
+@unittest.skipIf(torch is None, f"import unavailable: {_IMPORT_ERROR}")
+class SilenceLatentTilingTests(unittest.TestCase):
+    """_get_silence_latent_slice must tile when length > stored tensor."""
+
+    def _make_mixin(self, latent_len: int = 64, channels: int = 6):
+        """Build a minimal object that satisfies the mixin's interface."""
+
+        class _Host(ConditioningTargetMixin):
+            pass
+
+        host = _Host()
+        host.silence_latent = torch.ones(1, latent_len, channels)
+        return host, channels
+
+    def test_slice_within_bounds(self):
+        host, C = self._make_mixin(latent_len=128)
+        result = host._get_silence_latent_slice(64)
+        self.assertEqual(result.shape, (64, C))
+
+    def test_slice_exact_bounds(self):
+        host, C = self._make_mixin(latent_len=128)
+        result = host._get_silence_latent_slice(128)
+        self.assertEqual(result.shape, (128, C))
+
+    def test_slice_exceeds_bounds_tiles(self):
+        host, C = self._make_mixin(latent_len=64)
+        result = host._get_silence_latent_slice(200)
+        self.assertEqual(result.shape, (200, C))
+
+    def test_tiled_values_are_correct(self):
+        """Tiled tensor should repeat the original values."""
+        host, C = self._make_mixin(latent_len=3, channels=2)
+        host.silence_latent = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]])
+        result = host._get_silence_latent_slice(7)
+        self.assertEqual(result.shape, (7, 2))
+        # First 3 frames match original
+        self.assertTrue(torch.equal(result[:3], host.silence_latent[0]))
+        # Frames 3-5 repeat
+        self.assertTrue(torch.equal(result[3:6], host.silence_latent[0]))
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: API default duration
+# ---------------------------------------------------------------------------
+
+@unittest.skipIf(build_generation_setup is None, f"import unavailable: {_IMPORT_ERROR}")
+class ApiDefaultDurationTests(unittest.TestCase):
+    """build_generation_setup must use a sensible default when duration is null."""
+
+    def _base_req(self):
+        return SimpleNamespace(
+            task_type="text2music",
+            instruction="default instruction",
+            reference_audio_path="",
+            src_audio_path="",
+            vocal_language="en",
+            inference_steps=25,
+            seed=None,
+            guidance_scale=4.5,
+            use_adg=False,
+            cfg_interval_start=0.0,
+            cfg_interval_end=1.0,
+            shift=0.0,
+            infer_method="euler",
+            timesteps="",
+            repainting_start=0.0,
+            repainting_end=-1,
+            audio_cover_strength=0.0,
+            cover_noise_strength=0.0,
+            audio_code_string="",
+            lm_temperature=0.85,
+            lm_cfg_scale=2.5,
+            lm_negative_prompt="",
+            batch_size=None,
+            allow_lm_batch=False,
+            use_random_seed=True,
+            audio_format="wav",
+            constrained_decoding_debug=False,
+            track_classes=None,
+            track_name="",
+        )
+
+    def test_null_duration_gets_default(self):
+        """When audio_duration is None, params.duration should be the API default."""
+        setup = build_generation_setup(
+            req=self._base_req(),
+            caption="cap",
+            lyrics="lyr",
+            bpm=None,
+            key_scale="",
+            time_signature="",
+            audio_duration=None,
+            thinking=False,
+            sample_mode=False,
+            format_has_duration=False,
+            use_cot_caption=False,
+            use_cot_language=False,
+            lm_top_k=0,
+            lm_top_p=0.9,
+            parse_timesteps=lambda _: None,
+            is_instrumental=lambda _: False,
+            default_dit_instruction="default instruction",
+            task_instructions={},
+        )
+        self.assertEqual(setup.params.duration, _API_DEFAULT_DURATION_SECONDS)
+
+    def test_zero_duration_gets_default(self):
+        """Zero duration is falsy and should also get the default."""
+        setup = build_generation_setup(
+            req=self._base_req(),
+            caption="cap",
+            lyrics="lyr",
+            bpm=None,
+            key_scale="",
+            time_signature="",
+            audio_duration=0,
+            thinking=False,
+            sample_mode=False,
+            format_has_duration=False,
+            use_cot_caption=False,
+            use_cot_language=False,
+            lm_top_k=0,
+            lm_top_p=0.9,
+            parse_timesteps=lambda _: None,
+            is_instrumental=lambda _: False,
+            default_dit_instruction="default instruction",
+            task_instructions={},
+        )
+        self.assertEqual(setup.params.duration, _API_DEFAULT_DURATION_SECONDS)
+
+    def test_explicit_duration_preserved(self):
+        """When audio_duration is explicitly set, it should be preserved."""
+        setup = build_generation_setup(
+            req=self._base_req(),
+            caption="cap",
+            lyrics="lyr",
+            bpm=None,
+            key_scale="",
+            time_signature="",
+            audio_duration=60.0,
+            thinking=False,
+            sample_mode=False,
+            format_has_duration=False,
+            use_cot_caption=False,
+            use_cot_language=False,
+            lm_top_k=0,
+            lm_top_p=0.9,
+            parse_timesteps=lambda _: None,
+            is_instrumental=lambda _: False,
+            default_dit_instruction="default instruction",
+            task_instructions={},
+        )
+        self.assertEqual(setup.params.duration, 60.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/third_parts/nano-vllm/nanovllm/engine/block_manager.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/engine/block_manager.py
@@ -49,6 +49,16 @@ class BlockManager:
         h.update(np.array(token_ids).tobytes())
         return h.intdigest()
 
+    def reset(self):
+        """Reset all blocks and clear the prefix cache to prevent unbounded growth."""
+        for block_id in list(self.used_block_ids):
+            self.blocks[block_id].ref_count = 0
+            self.blocks[block_id].hash = -1
+            self.blocks[block_id].token_ids = []
+        self.free_block_ids = deque(range(len(self.blocks)))
+        self.used_block_ids.clear()
+        self.hash_to_block_id.clear()
+
     def _allocate_block(self, block_id: int) -> Block:
         block = self.blocks[block_id]
         assert block.ref_count == 0

--- a/acestep/third_parts/nano-vllm/nanovllm/engine/llm_engine.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/engine/llm_engine.py
@@ -105,12 +105,15 @@ class LLMEngine:
             seq = self.scheduler.running.popleft()
             if seq.block_table:  # Only deallocate if blocks are allocated
                 self.scheduler.block_manager.deallocate(seq)
-        
+
         # Deallocate all waiting sequences (they might have blocks from preemption)
         while self.scheduler.waiting:
             seq = self.scheduler.waiting.popleft()
             if seq.block_table:
                 self.scheduler.block_manager.deallocate(seq)
+
+        # Clear prefix cache to prevent unbounded hash_to_block_id growth
+        self.scheduler.block_manager.reset()
 
     def generate(
         self,

--- a/start_gradio_ui.sh
+++ b/start_gradio_ui.sh
@@ -79,6 +79,11 @@ _load_env_file
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 

--- a/start_gradio_ui_macos.sh
+++ b/start_gradio_ui_macos.sh
@@ -88,6 +88,11 @@ export TOKENIZERS_PARALLELISM="false"
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 

--- a/start_gradio_ui_macos_manual.sh
+++ b/start_gradio_ui_macos_manual.sh
@@ -209,6 +209,11 @@ export TOKENIZERS_PARALLELISM="false"
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 

--- a/start_gradio_ui_manual.sh
+++ b/start_gradio_ui_manual.sh
@@ -200,6 +200,11 @@ _load_manual
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 

--- a/start_gradio_ui_rocm.sh
+++ b/start_gradio_ui_rocm.sh
@@ -93,6 +93,11 @@ export TOKENIZERS_PARALLELISM="false"
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 

--- a/start_gradio_ui_rocm_manual.sh
+++ b/start_gradio_ui_rocm_manual.sh
@@ -214,6 +214,11 @@ export TOKENIZERS_PARALLELISM="false"
 SHARE="${SHARE:-}"
 # SHARE="--share"
 
+# Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
+case "$LANGUAGE" in
+    en|zh|he|ja) ;;
+    *) unset LANGUAGE ;;
+esac
 # UI language: en, zh, he, ja
 : "${LANGUAGE:=en}"
 


### PR DESCRIPTION
## Summary

Fixes three open bugs:

- **#797** — API crash when `audio_duration` is null causes tensor size mismatch (`[15230, 64]` vs `[20160, 64]`)
- **#854** — Audio corruption after 5-10 generations with 1.7B LM + base DiT
- **#779** — Shell launcher scripts pass system locale (e.g., `en_CA:en`) as `--language`, rejected by argparse

## Changes

### Fix #797: API crash on null duration (4 defense layers)
- **Feed CoT duration into Phase 2**: After LLM Phase 1 generates metadata with duration, use that duration to constrain Phase 2 code generation when the original `target_duration` was null
- **Cap `max_new_tokens` fallback**: When duration is null, cap at `DURATION_MAX * 5 + 500` instead of unconstrained `max_model_len - 64`
- **Tile silence_latent**: New `_get_silence_latent_slice()` helper tiles the silence latent when requested length exceeds its size, preventing truncation mismatches
- **API default duration**: Set `audio_duration` to 120s when null/None in the API layer instead of passing `-1.0`

### Fix #854: Generation corruption (4 fixes)
- **GC before cache clear**: Add `gc.collect()` before all 5 `torch.cuda.empty_cache()` calls in LLM inference to release circular references first
- **Clear prefix cache**: Add `reset()` to nano-vllm `BlockManager` that clears `hash_to_block_id` to prevent unbounded growth
- **Delete KV cache**: Explicitly `del past_key_values` after PT generation loops in both `_generate_with_constrained_decoding` and `_generate_with_cfg_custom`
- **Min overlap floor**: Set `min_overlap = 4` in VAE tiled decode to prevent overlap from being reduced to near-zero (which causes boundary artifacts)

### Fix #779: Language parameter parsing
- Add `case` validation in all 6 shell launcher scripts to reset `LANGUAGE` if it's not a valid UI code (`en`/`zh`/`he`/`ja`)

## Test plan

- [x] 10 new tests in `null_duration_fixes_test.py` covering max_new_tokens cap, silence_latent tiling, and API default duration
- [x] Updated existing `job_generation_setup_test.py` for new default
- [x] Shell script syntax validation (`bash -n`) passes for all 6 scripts
- [x] `llm_inference.py` imports successfully
- [x] All fix locations verified programmatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio generation when duration is missing (now defaults to 120s) and preserved explicit durations.
  * Improved silence padding/tiling to prevent audio artifacts.
  * Added minimum overlap protection to prevent chunk-boundary corruption.
  * Prevented unbounded block/prefix state growth across resets.

* **Performance & Stability**
  * More aggressive memory cleanup and cache clearing; added safety caps on token generation.

* **Tests**
  * Added tests validating null-duration behavior, tiling, and token-cap logic.

* **Chores**
  * Restrict UI language to supported values (en, zh, he, ja).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->