### PR TITLE
fix: skip LLM for extract tasks and fix track_name fallback

### DIFF
--- a/acestep/api/job_generation_setup.py
+++ b/acestep/api/job_generation_setup.py
@@ -43,8 +43,14 @@ def _resolve_instruction(
                 instruction_to_use = raw_instruction.format(TRACK_CLASSES=classes_str)
             else:
                 instruction_to_use = task_instructions.get("complete_default", raw_instruction)
-        elif "{TRACK_NAME}" in raw_instruction and req.track_name:
-            instruction_to_use = raw_instruction.format(TRACK_NAME=req.track_name.upper())
+        elif "{TRACK_NAME}" in raw_instruction:
+            if req.track_name:
+                instruction_to_use = raw_instruction.format(TRACK_NAME=req.track_name.upper())
+            else:
+                # Fall back to default instruction when track_name is missing
+                # to avoid sending literal {TRACK_NAME} placeholder to the model
+                default_key = f"{req.task_type}_default"
+                instruction_to_use = task_instructions.get(default_key, raw_instruction)
         else:
             instruction_to_use = raw_instruction
 

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -392,9 +392,11 @@ def generate_music(
         actual_seed_list, _ = dit_handler.prepare_seeds(actual_batch_size, seed_for_generation, config.use_random_seed)
 
         # LM-based Chain-of-Thought reasoning
-        # Skip LM for cover/repaint tasks - these tasks use reference/src audio directly
-        # and don't need LM to generate audio codes
-        skip_lm_tasks = {"cover", "repaint"}
+        # Skip LM for cover/repaint/extract tasks - these tasks use reference/src audio directly
+        # and don't need LM to generate audio codes or metadata.
+        # For extract tasks, LLM-generated captions can conflict with the extract instruction
+        # and cause the DiT model to reconstruct input audio instead of extracting stems.
+        skip_lm_tasks = {"cover", "repaint", "extract"}
         
         # Determine if we should use LLM
         # LLM is needed for:
@@ -577,11 +579,11 @@ def generate_music(
             if params.use_cot_language:
                 dit_input_vocal_language = lm_generated_metadata.get("vocal_language", dit_input_vocal_language)
 
-        # Repaint/cover: no LM run, so conditioning must come from params (caption + lyrics from GUI).
-        if params.task_type in ("repaint", "cover"):
+        # Repaint/cover/extract: no LM run, so conditioning must come from params (caption + lyrics from GUI).
+        if params.task_type in ("repaint", "cover", "extract"):
             dit_input_caption = params.caption or dit_input_caption
             dit_input_lyrics = params.lyrics if params.lyrics is not None else dit_input_lyrics
-            logger.info(f"[generate_music] Repaint/Cover task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")
+            logger.info(f"[generate_music] {params.task_type} task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")
             logger.info(f"[generate_music] Final inputs: dit_input_caption='{dit_input_caption}', dit_input_lyrics='{dit_input_lyrics}'")
 
         # Phase 2: DiT music generation


### PR DESCRIPTION
## Summary
Fixes #871 — Extract tasks via API returned audio identical to the input.

**Root cause:** Extract was missing from `skip_lm_tasks` in `inference.py`. When the LLM ran for extract tasks, it generated an unrelated caption that overwrote the DiT input, causing the model to reconstruct the original audio instead of extracting stems.

**Changes:**
- Add `"extract"` to `skip_lm_tasks` to prevent LLM from running and overwriting the caption
- Add `"extract"` to the params caption pass-through path (alongside repaint/cover)
- Fix `_resolve_instruction` to fall back to `extract_default` instruction when `track_name` is missing, instead of sending the literal `{TRACK_NAME}` placeholder to the model

## Test plan
- [ ] Run extract task via API with `task_type=extract` and `track_name=vocal` — verify extracted audio differs from input
- [ ] Run extract task without `track_name` — verify fallback instruction is used
- [ ] Run existing cover/repaint tasks — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)