### PR TITLE
feat: add supported_task_types to model inventory and expand cover strength aliases

### DIFF
--- a/acestep/api/http/model_service_routes.py
+++ b/acestep/api/http/model_service_routes.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import Depends, FastAPI
 from pydantic import BaseModel, Field
 
 from acestep.api.http.model_init_service import initialize_models_for_request
+from acestep.constants import TASK_TYPES_BASE, TASK_TYPES_TURBO
 
 
 class InitModelRequest(BaseModel):
@@ -18,6 +20,22 @@ class InitModelRequest(BaseModel):
     model: Optional[str] = Field(default=None, description="DiT model name to initialize (e.g., 'acestep-v15-base')")
     init_llm: bool = Field(default=False, description="Whether to initialize LLM as part of this request")
     lm_model_path: Optional[str] = Field(default=None, description="LLM model path/name (e.g., 'acestep-5Hz-lm-1.7B')")
+
+
+def _read_model_supported_tasks(checkpoint_dir: str, model_name: str) -> List[str]:
+    """Read config.json for a model and return its supported task types."""
+    config_path = os.path.join(checkpoint_dir, model_name, "config.json")
+    if not os.path.isfile(config_path):
+        return list(TASK_TYPES_BASE)
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        is_turbo = config.get("is_turbo", False)
+        if is_turbo:
+            return list(TASK_TYPES_TURBO)
+        return list(TASK_TYPES_BASE)
+    except Exception:
+        return list(TASK_TYPES_BASE)
 
 
 def _collect_model_inventory(
@@ -78,6 +96,7 @@ def _collect_model_inventory(
             "name": name,
             "is_default": bool(name == primary_model and primary_model),
             "is_loaded": name in loaded_dit_models,
+            "supported_task_types": _read_model_supported_tasks(checkpoint_dir, name),
         }
         for name in sorted(available_dit_models)
     ]

--- a/acestep/api/http/release_task_param_parser.py
+++ b/acestep/api/http/release_task_param_parser.py
@@ -26,7 +26,7 @@ PARAM_ALIASES: Dict[str, list[str]] = {
     "guidance_scale": ["guidance_scale", "guidanceScale"],
     "use_random_seed": ["use_random_seed", "useRandomSeed"],
     "seed": ["seed"],
-    "audio_cover_strength": ["audio_cover_strength", "audioCoverStrength"],
+    "audio_cover_strength": ["audio_cover_strength", "audioCoverStrength", "cover_strength", "coverStrength"],
     "cover_noise_strength": ["cover_noise_strength", "coverNoiseStrength"],
     "audio_code_string": ["audio_code_string", "audioCodeString", "audio_codes"],
     "reference_audio_path": ["reference_audio_path", "ref_audio_path", "referenceAudioPath", "refAudioPath"],


### PR DESCRIPTION
## Summary
- Read `config.json` for each model to determine supported task types (base vs turbo) and include `supported_task_types` in the model inventory API response
- Add `cover_strength` / `coverStrength` as parameter aliases for `audio_cover_strength` to improve API compatibility

## Changes
- **`acestep/api/http/model_service_routes.py`**: Added `_read_model_supported_tasks()` helper that reads each model's `config.json` to determine if it's a turbo model, and returns the appropriate task type list. Added `supported_task_types` field to the model inventory response.
- **`acestep/api/http/release_task_param_parser.py`**: Extended `PARAM_ALIASES` for `audio_cover_strength` to also accept `cover_strength` and `coverStrength`.

## Test plan
- [ ] Verify `/models` endpoint returns `supported_task_types` for each model
- [ ] Verify turbo models return turbo task types, base models return base task types
- [ ] Verify `cover_strength` and `coverStrength` are accepted as valid parameter names in release task requests

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model inventory endpoints now expose per-model supported task capabilities based on model configuration.

* **Improvements**
  * Enhanced API parameter flexibility by accepting additional naming conventions for audio cover strength control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->