### PR TITLE
feat: add VST3 preview playback and file handoff

### DIFF
--- a/plugins/acestep_vst3/CMakeLists.txt
+++ b/plugins/acestep_vst3/CMakeLists.txt
@@ -38,7 +38,9 @@ target_sources(
         src/PluginBackendClient.cpp
         src/PluginEditor.cpp
         src/PluginEditorState.cpp
+        src/PluginEditorPreview.cpp
         src/PluginEnums.cpp
+        src/PluginPreview.cpp
         src/PluginProcessor.cpp
         src/PluginState.cpp
 )

--- a/plugins/acestep_vst3/src/PluginBackendClient.cpp
+++ b/plugins/acestep_vst3/src/PluginBackendClient.cpp
@@ -156,6 +156,24 @@ int chooseInferenceSteps(QualityMode qualityMode)
 
     return 8;
 }
+
+juce::String chooseFileExtension(const juce::String& remoteFileUrl)
+{
+    const auto decoded = juce::URL::removeEscapeChars(remoteFileUrl);
+    const auto dotIndex = decoded.lastIndexOfChar('.');
+    if (dotIndex < 0)
+    {
+        return ".wav";
+    }
+
+    const auto extension = decoded.substring(dotIndex);
+    if (extension.length() > 8 || extension.containsAnyOf("/?&"))
+    {
+        return ".wav";
+    }
+
+    return extension;
+}
 }  // namespace
 
 PluginHealthCheckResult PluginBackendClient::checkHealth(const juce::String& baseUrl) const
@@ -336,6 +354,52 @@ PluginGenerationPollResult PluginBackendClient::pollGeneration(const juce::Strin
         slot.label = buildResultLabel(*itemObject, index);
     }
 
+    return result;
+}
+
+PluginPreviewDownloadResult PluginBackendClient::downloadPreviewFile(const juce::String& baseUrl,
+                                                                     const juce::String& remoteFileUrl,
+                                                                     int slotIndex) const
+{
+    PluginPreviewDownloadResult result;
+    result.slotIndex = slotIndex;
+    if (remoteFileUrl.isEmpty())
+    {
+        result.errorMessage = "The backend did not return an audio file URL.";
+        return result;
+    }
+
+    int statusCode = 0;
+    auto stream = buildUrl(baseUrl, remoteFileUrl)
+                      .createInputStream(juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress)
+                                             .withConnectionTimeoutMs(kNetworkTimeoutMs)
+                                             .withStatusCode(&statusCode)
+                                             .withNumRedirectsToFollow(4)
+                                             .withHttpRequestCmd("GET"));
+    if (stream == nullptr || statusCode != 200)
+    {
+        result.errorMessage = "Could not download the generated preview audio.";
+        return result;
+    }
+
+    auto previewFile = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                           .getNonexistentChildFile("acestep-vst3-preview-"
+                                                        + juce::String(slotIndex + 1),
+                                                    chooseFileExtension(remoteFileUrl),
+                                                    false);
+    juce::FileOutputStream output(previewFile);
+    if (!output.openedOk())
+    {
+        result.errorMessage = "Could not create a temporary preview file.";
+        return result;
+    }
+
+    output.writeFromInputStream(*stream, -1);
+    output.flush();
+
+    result.succeeded = true;
+    result.localFilePath = previewFile.getFullPathName();
+    result.displayName = previewFile.getFileName();
     return result;
 }
 }  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PluginBackendClient.h
+++ b/plugins/acestep_vst3/src/PluginBackendClient.h
@@ -36,6 +36,15 @@ struct PluginGenerationPollResult final
     std::array<PluginBackendResultSlot, static_cast<size_t>(kResultSlotCount)> resultSlots;
 };
 
+struct PluginPreviewDownloadResult final
+{
+    int slotIndex = -1;
+    bool succeeded = false;
+    juce::String localFilePath;
+    juce::String displayName;
+    juce::String errorMessage;
+};
+
 class PluginBackendClient final
 {
 public:
@@ -43,5 +52,8 @@ public:
     [[nodiscard]] PluginGenerationStartResult startGeneration(const PluginState& state) const;
     [[nodiscard]] PluginGenerationPollResult pollGeneration(const juce::String& baseUrl,
                                                             const juce::String& taskId) const;
+    [[nodiscard]] PluginPreviewDownloadResult downloadPreviewFile(const juce::String& baseUrl,
+                                                                  const juce::String& remoteFileUrl,
+                                                                  int slotIndex) const;
 };
 }  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PluginEditor.cpp
+++ b/plugins/acestep_vst3/src/PluginEditor.cpp
@@ -7,7 +7,7 @@ namespace acestep::vst3
 namespace
 {
 constexpr int kEditorWidth = 720;
-constexpr int kEditorHeight = 640;
+constexpr int kEditorHeight = 760;
 }  // namespace
 
 ACEStepVST3AudioProcessorEditor::ACEStepVST3AudioProcessorEditor(
@@ -86,6 +86,21 @@ void ACEStepVST3AudioProcessorEditor::resized()
     bounds.removeFromTop(8);
     resultsLabel_.setBounds(bounds.removeFromTop(18));
     resultSlotBox_.setBounds(bounds.removeFromTop(28));
+
+    bounds.removeFromTop(12);
+    previewTitle_.setBounds(bounds.removeFromTop(18));
+    previewValue_.setBounds(bounds.removeFromTop(56));
+    bounds.removeFromTop(8);
+    auto previewButtons = bounds.removeFromTop(30);
+    choosePreviewButton_.setBounds(previewButtons.removeFromLeft(180));
+    previewButtons.removeFromLeft(8);
+    playPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
+    previewButtons.removeFromLeft(8);
+    stopPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
+    previewButtons.removeFromLeft(8);
+    clearPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
+    previewButtons.removeFromLeft(8);
+    revealPreviewButton_.setBounds(previewButtons.removeFromLeft(120));
 }
 
 void ACEStepVST3AudioProcessorEditor::timerCallback()

--- a/plugins/acestep_vst3/src/PluginEditor.h
+++ b/plugins/acestep_vst3/src/PluginEditor.h
@@ -25,6 +25,11 @@ private:
     void persistTextFields();
     void refreshResultSelector();
     void refreshStatusViews();
+    void choosePreviewFile();
+    void playPreviewFile();
+    void stopPreviewFile();
+    void clearPreviewFile();
+    void revealPreviewFile();
 
     ACEStepVST3AudioProcessor& processor_;
     juce::Label titleLabel_;
@@ -43,6 +48,8 @@ private:
     juce::Label errorTitle_;
     juce::Label errorValue_;
     juce::Label resultsLabel_;
+    juce::Label previewTitle_;
+    juce::Label previewValue_;
     juce::TextEditor backendUrlEditor_;
     juce::TextEditor promptEditor_;
     juce::TextEditor lyricsEditor_;
@@ -53,6 +60,12 @@ private:
     juce::ComboBox backendStatusBox_;
     juce::ComboBox resultSlotBox_;
     juce::TextButton generateButton_ {"Generate"};
+    juce::TextButton choosePreviewButton_ {"Load Preview File"};
+    juce::TextButton playPreviewButton_ {"Play"};
+    juce::TextButton stopPreviewButton_ {"Stop"};
+    juce::TextButton clearPreviewButton_ {"Clear"};
+    juce::TextButton revealPreviewButton_ {"Reveal File"};
+    std::unique_ptr<juce::FileChooser> previewChooser_;
     bool isSyncing_ = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ACEStepVST3AudioProcessorEditor)

--- a/plugins/acestep_vst3/src/PluginEditorPreview.cpp
+++ b/plugins/acestep_vst3/src/PluginEditorPreview.cpp
@@ -1,0 +1,51 @@
+#include "PluginEditor.h"
+
+#include "PluginProcessor.h"
+
+namespace acestep::vst3
+{
+void ACEStepVST3AudioProcessorEditor::choosePreviewFile()
+{
+    previewChooser_ = std::make_unique<juce::FileChooser>("Select preview audio file",
+                                                          juce::File(),
+                                                          "*.wav;*.aiff;*.flac;*.ogg;*.mp3");
+    previewChooser_->launchAsync(juce::FileBrowserComponent::openMode
+                                     | juce::FileBrowserComponent::canSelectFiles,
+                                 [this](const juce::FileChooser& chooser) {
+                                     const auto file = chooser.getResult();
+                                     previewChooser_.reset();
+                                     if (file == juce::File())
+                                     {
+                                         return;
+                                     }
+
+                                     processor_.stopPreview();
+                                     [[maybe_unused]] const auto loaded = processor_.loadPreviewFile(file);
+                                     refreshStatusViews();
+                                 });
+}
+
+void ACEStepVST3AudioProcessorEditor::playPreviewFile()
+{
+    processor_.playPreview();
+    refreshStatusViews();
+}
+
+void ACEStepVST3AudioProcessorEditor::stopPreviewFile()
+{
+    processor_.stopPreview();
+    refreshStatusViews();
+}
+
+void ACEStepVST3AudioProcessorEditor::clearPreviewFile()
+{
+    processor_.stopPreview();
+    processor_.clearPreviewFile();
+    refreshStatusViews();
+}
+
+void ACEStepVST3AudioProcessorEditor::revealPreviewFile()
+{
+    processor_.revealPreviewFile();
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PluginEditorState.cpp
+++ b/plugins/acestep_vst3/src/PluginEditorState.cpp
@@ -8,7 +8,7 @@ namespace acestep::vst3
 void ACEStepVST3AudioProcessorEditor::configureLabels()
 {
     titleLabel_.setText("ACE-Step VST3 MVP UI", juce::dontSendNotification);
-    titleLabel_.setFont(juce::Font(20.0f, juce::Font::bold));
+    titleLabel_.setFont(juce::Font(juce::FontOptions(20.0f, juce::Font::bold)));
     subtitleLabel_.setText("State-driven prompt, job, and result workflow shell.",
                            juce::dontSendNotification);
 
@@ -16,7 +16,7 @@ void ACEStepVST3AudioProcessorEditor::configureLabels()
                         &lyricsLabel_, &durationLabel_, &seedLabel_, &modelLabel_,
                         &qualityLabel_, &backendStatusTitle_, &backendStatusValue_,
                         &jobStatusTitle_, &jobStatusValue_, &errorTitle_, &errorValue_,
-                        &resultsLabel_})
+                        &resultsLabel_, &previewTitle_, &previewValue_})
     {
         label->setJustificationType(juce::Justification::centredLeft);
         addAndMakeVisible(*label);
@@ -33,6 +33,7 @@ void ACEStepVST3AudioProcessorEditor::configureLabels()
     jobStatusTitle_.setText("Job status", juce::dontSendNotification);
     errorTitle_.setText("Error state", juce::dontSendNotification);
     resultsLabel_.setText("Result slot selection", juce::dontSendNotification);
+    previewTitle_.setText("Preview and file handoff", juce::dontSendNotification);
     errorValue_.setColour(juce::Label::textColourId, juce::Colours::lightsalmon);
 }
 
@@ -87,13 +88,23 @@ void ACEStepVST3AudioProcessorEditor::configureSelectors()
         processor_.requestGeneration();
         refreshStatusViews();
     };
+    choosePreviewButton_.onClick = [this] { choosePreviewFile(); };
+    playPreviewButton_.onClick = [this] { playPreviewFile(); };
+    stopPreviewButton_.onClick = [this] { stopPreviewFile(); };
+    clearPreviewButton_.onClick = [this] { clearPreviewFile(); };
+    revealPreviewButton_.onClick = [this] { revealPreviewFile(); };
 
     for (auto* component : {static_cast<juce::Component*>(&durationBox_),
                             static_cast<juce::Component*>(&modelBox_),
                             static_cast<juce::Component*>(&qualityBox_),
                             static_cast<juce::Component*>(&backendStatusBox_),
                             static_cast<juce::Component*>(&resultSlotBox_),
-                            static_cast<juce::Component*>(&generateButton_)})
+                            static_cast<juce::Component*>(&generateButton_),
+                            static_cast<juce::Component*>(&choosePreviewButton_),
+                            static_cast<juce::Component*>(&playPreviewButton_),
+                            static_cast<juce::Component*>(&stopPreviewButton_),
+                            static_cast<juce::Component*>(&clearPreviewButton_),
+                            static_cast<juce::Component*>(&revealPreviewButton_)})
     {
         addAndMakeVisible(*component);
     }
@@ -179,6 +190,18 @@ void ACEStepVST3AudioProcessorEditor::refreshStatusViews()
                             juce::dontSendNotification);
     errorValue_.setText(state.errorMessage.isEmpty() ? "No active error." : state.errorMessage,
                         juce::dontSendNotification);
+
+    auto previewText = state.previewDisplayName.isEmpty() ? "No preview file loaded."
+                                                          : state.previewDisplayName;
+    previewText += "\n";
+    previewText += state.previewFilePath.isEmpty() ? "Choose a local audio file to preview or reveal."
+                                                   : state.previewFilePath;
+    if (processor_.isPreviewPlaying())
+    {
+        previewText += "\nPlayback: active";
+    }
+    previewValue_.setText(previewText, juce::dontSendNotification);
+
     const auto isBusy = state.jobStatus == JobStatus::submitting
                         || state.jobStatus == JobStatus::queuedOrRunning;
     generateButton_.setEnabled(!isBusy);

--- a/plugins/acestep_vst3/src/PluginPreview.cpp
+++ b/plugins/acestep_vst3/src/PluginPreview.cpp
@@ -1,0 +1,128 @@
+#include "PluginPreview.h"
+
+namespace acestep::vst3
+{
+PluginPreview::PluginPreview()
+{
+    formatManager_.registerBasicFormats();
+}
+
+PluginPreview::~PluginPreview()
+{
+    clear();
+}
+
+void PluginPreview::prepareToPlay(double sampleRate, int samplesPerBlock)
+{
+    const juce::ScopedLock lock(lock_);
+    sampleRate_ = sampleRate > 0.0 ? sampleRate : 44100.0;
+    transportSource_.prepareToPlay(samplesPerBlock, sampleRate_);
+}
+
+void PluginPreview::releaseResources()
+{
+    const juce::ScopedLock lock(lock_);
+    transportSource_.releaseResources();
+}
+
+void PluginPreview::render(juce::AudioBuffer<float>& buffer)
+{
+    const juce::ScopedTryLock lock(lock_);
+    if (!lock.isLocked() || readerSource_ == nullptr)
+    {
+        return;
+    }
+
+    juce::AudioSourceChannelInfo channelInfo(&buffer, 0, buffer.getNumSamples());
+    transportSource_.getNextAudioBlock(channelInfo);
+}
+
+bool PluginPreview::loadFile(const juce::File& file, juce::String& errorMessage)
+{
+    errorMessage = {};
+    if (!file.existsAsFile())
+    {
+        errorMessage = "Preview file not found.";
+        return false;
+    }
+
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager_.createReaderFor(file));
+    if (reader == nullptr)
+    {
+        errorMessage = "Preview file format is not supported.";
+        return false;
+    }
+
+    const auto readerSampleRate = reader->sampleRate;
+    auto nextReaderSource = std::make_unique<juce::AudioFormatReaderSource>(reader.release(), true);
+
+    const juce::ScopedLock lock(lock_);
+    transportSource_.stop();
+    transportSource_.setSource(nullptr);
+    readerSource_.reset();
+    transportSource_.setSource(nextReaderSource.get(), 0, nullptr, readerSampleRate);
+    readerSource_ = std::move(nextReaderSource);
+    currentFile_ = file;
+    return true;
+}
+
+void PluginPreview::clear()
+{
+    const juce::ScopedLock lock(lock_);
+    transportSource_.stop();
+    transportSource_.setSource(nullptr);
+    readerSource_.reset();
+    currentFile_ = juce::File();
+}
+
+void PluginPreview::play()
+{
+    const juce::ScopedLock lock(lock_);
+    if (readerSource_ == nullptr)
+    {
+        return;
+    }
+
+    transportSource_.setPosition(0.0);
+    transportSource_.start();
+}
+
+void PluginPreview::stop()
+{
+    const juce::ScopedLock lock(lock_);
+    transportSource_.stop();
+}
+
+void PluginPreview::revealToUser() const
+{
+    const juce::ScopedLock lock(lock_);
+    if (currentFile_.existsAsFile())
+    {
+        currentFile_.revealToUser();
+    }
+}
+
+bool PluginPreview::hasLoadedFile() const
+{
+    const juce::ScopedLock lock(lock_);
+    return readerSource_ != nullptr && currentFile_.existsAsFile();
+}
+
+bool PluginPreview::isPlaying() const
+{
+    const juce::ScopedLock lock(lock_);
+    return transportSource_.isPlaying();
+}
+
+juce::String PluginPreview::getDisplayName() const
+{
+    const juce::ScopedLock lock(lock_);
+    return currentFile_.existsAsFile() ? currentFile_.getFileName() : juce::String();
+}
+
+juce::String PluginPreview::getFilePath() const
+{
+    const juce::ScopedLock lock(lock_);
+    return currentFile_.getFullPathName();
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PluginPreview.h
+++ b/plugins/acestep_vst3/src/PluginPreview.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+
+#include <JuceHeader.h>
+
+namespace acestep::vst3
+{
+class PluginPreview final
+{
+public:
+    PluginPreview();
+    ~PluginPreview();
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock);
+    void releaseResources();
+    void render(juce::AudioBuffer<float>& buffer);
+
+    [[nodiscard]] bool loadFile(const juce::File& file, juce::String& errorMessage);
+    void clear();
+    void play();
+    void stop();
+    void revealToUser() const;
+
+    [[nodiscard]] bool hasLoadedFile() const;
+    [[nodiscard]] bool isPlaying() const;
+    [[nodiscard]] juce::String getDisplayName() const;
+    [[nodiscard]] juce::String getFilePath() const;
+
+private:
+    mutable juce::CriticalSection lock_;
+    juce::AudioFormatManager formatManager_;
+    juce::AudioTransportSource transportSource_;
+    std::unique_ptr<juce::AudioFormatReaderSource> readerSource_;
+    juce::File currentFile_;
+    double sampleRate_ = 44100.0;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginPreview)
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PluginProcessor.cpp
+++ b/plugins/acestep_vst3/src/PluginProcessor.cpp
@@ -14,10 +14,13 @@ ACEStepVST3AudioProcessor::~ACEStepVST3AudioProcessor() = default;
 
 void ACEStepVST3AudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
 {
-    juce::ignoreUnused(sampleRate, samplesPerBlock);
+    preview_.prepareToPlay(sampleRate, samplesPerBlock);
 }
 
-void ACEStepVST3AudioProcessor::releaseResources() {}
+void ACEStepVST3AudioProcessor::releaseResources()
+{
+    preview_.releaseResources();
+}
 
 bool ACEStepVST3AudioProcessor::isBusesLayoutSupported(const BusesLayout& layouts) const
 {
@@ -34,6 +37,7 @@ void ACEStepVST3AudioProcessor::processBlock(juce::AudioBuffer<float>& buffer,
 {
     juce::ignoreUnused(midiMessages);
     buffer.clear();
+    preview_.render(buffer);
 }
 
 juce::AudioProcessorEditor* ACEStepVST3AudioProcessor::createEditor()
@@ -118,6 +122,7 @@ void ACEStepVST3AudioProcessor::setStateInformation(const void* data, int sizeIn
         if (auto parsedState = parseStateXml(*xml))
         {
             state_ = *parsedState;
+            syncPreviewFromState();
         }
     }
 }
@@ -132,6 +137,61 @@ PluginState& ACEStepVST3AudioProcessor::getMutableState() noexcept
     return state_;
 }
 
+bool ACEStepVST3AudioProcessor::loadPreviewFile(const juce::File& file)
+{
+    juce::String errorMessage;
+    if (!preview_.loadFile(file, errorMessage))
+    {
+        state_.errorMessage = errorMessage;
+        return false;
+    }
+
+    state_.previewFilePath = file.getFullPathName();
+    state_.previewDisplayName = file.getFileName();
+    state_.errorMessage = {};
+    return true;
+}
+
+void ACEStepVST3AudioProcessor::clearPreviewFile()
+{
+    preview_.clear();
+    state_.previewFilePath = {};
+    state_.previewDisplayName = {};
+    state_.errorMessage = {};
+}
+
+void ACEStepVST3AudioProcessor::playPreview()
+{
+    if (!hasPreviewFile())
+    {
+        state_.errorMessage = "Load a preview file before playing it.";
+        return;
+    }
+
+    state_.errorMessage = {};
+    preview_.play();
+}
+
+void ACEStepVST3AudioProcessor::stopPreview()
+{
+    preview_.stop();
+}
+
+void ACEStepVST3AudioProcessor::revealPreviewFile() const
+{
+    preview_.revealToUser();
+}
+
+bool ACEStepVST3AudioProcessor::hasPreviewFile() const
+{
+    return preview_.hasLoadedFile();
+}
+
+bool ACEStepVST3AudioProcessor::isPreviewPlaying() const
+{
+    return preview_.isPlaying();
+}
+
 void ACEStepVST3AudioProcessor::requestGeneration()
 {
     if (state_.prompt.trim().isEmpty())
@@ -143,6 +203,8 @@ void ACEStepVST3AudioProcessor::requestGeneration()
     }
 
     clearGeneratedResults();
+    stopPreview();
+    clearPreviewFile();
     state_.jobStatus = JobStatus::submitting;
     state_.progressText = "Submitting request...";
     state_.errorMessage = {};
@@ -151,6 +213,11 @@ void ACEStepVST3AudioProcessor::requestGeneration()
 void ACEStepVST3AudioProcessor::selectResultSlot(int index)
 {
     state_.selectedResultSlot = juce::jlimit(0, kResultSlotCount - 1, index);
+    const auto& localPath = state_.resultLocalPaths[static_cast<size_t>(state_.selectedResultSlot)];
+    if (localPath.isNotEmpty())
+    {
+        [[maybe_unused]] const auto loaded = loadPreviewFile(juce::File(localPath));
+    }
 }
 
 void ACEStepVST3AudioProcessor::pumpBackendWorkflow()
@@ -175,6 +242,13 @@ void ACEStepVST3AudioProcessor::pumpBackendWorkflow()
         return;
     }
 
+    if (pendingPreviewDownloadSlot_.has_value())
+    {
+        schedulePreviewDownload(*pendingPreviewDownloadSlot_);
+        pendingPreviewDownloadSlot_.reset();
+        return;
+    }
+
     const auto now = juce::Time::getMillisecondCounter();
     if (state_.jobStatus == JobStatus::submitting)
     {
@@ -192,7 +266,8 @@ void ACEStepVST3AudioProcessor::pumpBackendWorkflow()
     if (state_.jobStatus == JobStatus::idle || state_.jobStatus == JobStatus::failed
         || state_.jobStatus == JobStatus::succeeded)
     {
-        if (lastHealthCheckedBaseUrl_ != state_.backendBaseUrl || now - lastHealthCheckAtMs_ >= 5000)
+        if (lastHealthCheckedBaseUrl_ != state_.backendBaseUrl
+            || now - lastHealthCheckAtMs_ >= 5000)
         {
             scheduleHealthCheck();
         }
@@ -260,6 +335,29 @@ void ACEStepVST3AudioProcessor::scheduleGenerationPoll()
     }));
 }
 
+void ACEStepVST3AudioProcessor::schedulePreviewDownload(int slotIndex)
+{
+    if (backendTaskRunning_.exchange(true))
+    {
+        pendingPreviewDownloadSlot_ = slotIndex;
+        return;
+    }
+
+    const auto baseUrl = state_.backendBaseUrl;
+    const auto remoteFileUrl = state_.resultFileUrls[static_cast<size_t>(slotIndex)];
+    backendThreadPool_.addJob(std::function<juce::ThreadPoolJob::JobStatus()>(
+        [this, baseUrl, remoteFileUrl, slotIndex]() {
+            BackendTaskResult taskResult;
+            taskResult.kind = BackendTaskKind::downloadPreview;
+            taskResult.previewDownload =
+                backendClient_.downloadPreviewFile(baseUrl, remoteFileUrl, slotIndex);
+            const juce::ScopedLock lock(backendTaskLock_);
+            completedBackendTask_ = std::move(taskResult);
+            backendTaskRunning_.store(false);
+            return juce::ThreadPoolJob::jobHasFinished;
+        }));
+}
+
 void ACEStepVST3AudioProcessor::applyCompletedTask(const BackendTaskResult& taskResult)
 {
     switch (taskResult.kind)
@@ -317,9 +415,32 @@ void ACEStepVST3AudioProcessor::applyCompletedTask(const BackendTaskResult& task
                 state_.resultFileUrls[static_cast<size_t>(index)] = slot.remoteFileUrl;
             }
             state_.selectedResultSlot = 0;
-            if (state_.resultFileUrls[0].isEmpty())
+            if (state_.resultFileUrls[0].isNotEmpty())
+            {
+                pendingPreviewDownloadSlot_ = 0;
+            }
+            else
             {
                 state_.errorMessage = "Task finished but no audio file was returned.";
+            }
+            return;
+        case BackendTaskKind::downloadPreview:
+            if (!taskResult.previewDownload.succeeded)
+            {
+                state_.errorMessage = taskResult.previewDownload.errorMessage;
+                return;
+            }
+
+            if (taskResult.previewDownload.slotIndex >= 0
+                && taskResult.previewDownload.slotIndex < kResultSlotCount)
+            {
+                const auto slotIndex = static_cast<size_t>(taskResult.previewDownload.slotIndex);
+                state_.resultLocalPaths[slotIndex] = taskResult.previewDownload.localFilePath;
+                if (state_.selectedResultSlot == taskResult.previewDownload.slotIndex)
+                {
+                    [[maybe_unused]] const auto loaded =
+                        loadPreviewFile(juce::File(taskResult.previewDownload.localFilePath));
+                }
             }
             return;
         case BackendTaskKind::none:
@@ -332,11 +453,32 @@ void ACEStepVST3AudioProcessor::clearGeneratedResults()
     state_.currentTaskId = {};
     state_.progressText = {};
     state_.selectedResultSlot = 0;
+    pendingPreviewDownloadSlot_.reset();
     for (int index = 0; index < kResultSlotCount; ++index)
     {
         state_.resultSlots[static_cast<size_t>(index)] = {};
         state_.resultFileUrls[static_cast<size_t>(index)] = {};
+        state_.resultLocalPaths[static_cast<size_t>(index)] = {};
     }
+}
+
+void ACEStepVST3AudioProcessor::syncPreviewFromState()
+{
+    preview_.clear();
+    if (state_.previewFilePath.isEmpty())
+    {
+        return;
+    }
+
+    juce::String errorMessage;
+    const juce::File previewFile(state_.previewFilePath);
+    if (!preview_.loadFile(previewFile, errorMessage))
+    {
+        state_.errorMessage = errorMessage;
+        return;
+    }
+
+    state_.previewDisplayName = previewFile.getFileName();
 }
 }  // namespace acestep::vst3
 

--- a/plugins/acestep_vst3/src/PluginProcessor.h
+++ b/plugins/acestep_vst3/src/PluginProcessor.h
@@ -7,6 +7,7 @@
 
 #include "PluginBackendClient.h"
 #include "PluginConfig.h"
+#include "PluginPreview.h"
 #include "PluginState.h"
 
 namespace acestep::vst3
@@ -42,6 +43,13 @@ public:
 
     const PluginState& getState() const noexcept;
     PluginState& getMutableState() noexcept;
+    [[nodiscard]] bool loadPreviewFile(const juce::File& file);
+    void clearPreviewFile();
+    void playPreview();
+    void stopPreview();
+    void revealPreviewFile() const;
+    [[nodiscard]] bool hasPreviewFile() const;
+    [[nodiscard]] bool isPreviewPlaying() const;
     void requestGeneration();
     void selectResultSlot(int index);
     void pumpBackendWorkflow();
@@ -53,6 +61,7 @@ private:
         healthCheck,
         submitGeneration,
         pollGeneration,
+        downloadPreview,
     };
 
     struct BackendTaskResult final
@@ -61,15 +70,19 @@ private:
         PluginHealthCheckResult health;
         PluginGenerationStartResult generationStart;
         PluginGenerationPollResult generationPoll;
+        PluginPreviewDownloadResult previewDownload;
     };
 
     void scheduleHealthCheck();
     void scheduleGenerationStart();
     void scheduleGenerationPoll();
+    void schedulePreviewDownload(int slotIndex);
     void applyCompletedTask(const BackendTaskResult& taskResult);
     void clearGeneratedResults();
+    void syncPreviewFromState();
 
     PluginState state_;
+    PluginPreview preview_;
     PluginBackendClient backendClient_;
     juce::ThreadPool backendThreadPool_ {1};
     juce::CriticalSection backendTaskLock_;
@@ -78,6 +91,7 @@ private:
     juce::uint32 lastHealthCheckAtMs_ = 0;
     juce::uint32 lastPollRequestAtMs_ = 0;
     juce::String lastHealthCheckedBaseUrl_;
+    std::optional<int> pendingPreviewDownloadSlot_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ACEStepVST3AudioProcessor)
 };

--- a/plugins/acestep_vst3/src/PluginState.cpp
+++ b/plugins/acestep_vst3/src/PluginState.cpp
@@ -19,12 +19,16 @@ std::unique_ptr<juce::XmlElement> createStateXml(const PluginState& state)
     xml->setAttribute("progressText", state.progressText);
     xml->setAttribute("errorMessage", state.errorMessage);
     xml->setAttribute("selectedResultSlot", state.selectedResultSlot);
+    xml->setAttribute("previewFilePath", state.previewFilePath);
+    xml->setAttribute("previewDisplayName", state.previewDisplayName);
     for (size_t index = 0; index < state.resultSlots.size(); ++index)
     {
         xml->setAttribute("resultSlot" + juce::String(static_cast<int>(index)),
                           state.resultSlots[index]);
         xml->setAttribute("resultFileUrl" + juce::String(static_cast<int>(index)),
                           state.resultFileUrls[index]);
+        xml->setAttribute("resultLocalPath" + juce::String(static_cast<int>(index)),
+                          state.resultLocalPaths[index]);
     }
     return xml;
 }
@@ -52,12 +56,16 @@ std::optional<PluginState> parseStateXml(const juce::XmlElement& xml)
     state.errorMessage = xml.getStringAttribute("errorMessage");
     state.selectedResultSlot =
         juce::jlimit(0, kResultSlotCount - 1, xml.getIntAttribute("selectedResultSlot", 0));
+    state.previewFilePath = xml.getStringAttribute("previewFilePath");
+    state.previewDisplayName = xml.getStringAttribute("previewDisplayName");
     for (size_t index = 0; index < state.resultSlots.size(); ++index)
     {
         state.resultSlots[index] =
             xml.getStringAttribute("resultSlot" + juce::String(static_cast<int>(index)));
         state.resultFileUrls[index] =
             xml.getStringAttribute("resultFileUrl" + juce::String(static_cast<int>(index)));
+        state.resultLocalPaths[index] =
+            xml.getStringAttribute("resultLocalPath" + juce::String(static_cast<int>(index)));
     }
 
     if (state.backendBaseUrl.isEmpty())

--- a/plugins/acestep_vst3/src/PluginState.h
+++ b/plugins/acestep_vst3/src/PluginState.h
@@ -29,6 +29,9 @@ struct PluginState final
     int selectedResultSlot = 0;
     std::array<juce::String, static_cast<size_t>(kResultSlotCount)> resultSlots;
     std::array<juce::String, static_cast<size_t>(kResultSlotCount)> resultFileUrls;
+    std::array<juce::String, static_cast<size_t>(kResultSlotCount)> resultLocalPaths;
+    juce::String previewFilePath;
+    juce::String previewDisplayName;
 };
 
 [[nodiscard]] std::unique_ptr<juce::XmlElement> createStateXml(const PluginState& state);


### PR DESCRIPTION
## Summary
- add processor-owned local file preview playback using JUCE transport primitives
- persist preview file metadata and expose play/stop/clear/reveal controls in the editor
- explicitly defer drag-and-drop into the DAW timeline for MVP stability

## Validation
- code-level review only in this environment
- CMake project generation remains blocked locally by missing Xcode command line tools

Closes #895
Related: #890
Depends on: #900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preview file support: load audio files, play/stop playback, and clear selections
  * Added automatic preview file downloading from search results
  * Added file location reveal functionality
  * Integrated preview playback into the audio engine with real-time playback status tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->