### PR TITLE
feat: add V2 tape-synth design system components

### DIFF
--- a/plugins/acestep_vst3/CMakeLists.txt
+++ b/plugins/acestep_vst3/CMakeLists.txt
@@ -43,6 +43,13 @@ target_sources(
         src/PluginPreview.cpp
         src/PluginProcessor.cpp
         src/PluginState.cpp
+        src/PreviewDeckComponent.cpp
+        src/ResultDeckComponent.cpp
+        src/StatusStripComponent.cpp
+        src/SynthPanelComponent.cpp
+        src/TapeTransportComponent.cpp
+        src/V2Chrome.cpp
+        src/V2LookAndFeel.cpp
 )
 
 target_compile_features(acestep_vst3 PRIVATE cxx_std_20)

--- a/plugins/acestep_vst3/src/PluginEditor.cpp
+++ b/plugins/acestep_vst3/src/PluginEditor.cpp
@@ -1,20 +1,33 @@
 #include "PluginEditor.h"
 
 #include "PluginProcessor.h"
+#include "V2Chrome.h"
 
 namespace acestep::vst3
 {
 namespace
 {
-constexpr int kEditorWidth = 720;
-constexpr int kEditorHeight = 760;
+constexpr int kEditorWidth = 1080;
+constexpr int kEditorHeight = 820;
 }  // namespace
 
 ACEStepVST3AudioProcessorEditor::ACEStepVST3AudioProcessorEditor(
     ACEStepVST3AudioProcessor& processor)
     : juce::AudioProcessorEditor(&processor), processor_(processor)
 {
+    lookAndFeel_ = std::make_unique<V2LookAndFeel>();
+    setLookAndFeel(lookAndFeel_.get());
     setSize(kEditorWidth, kEditorHeight);
+
+    for (auto* component : {static_cast<juce::Component*>(&statusStrip_),
+                            static_cast<juce::Component*>(&synthPanel_),
+                            static_cast<juce::Component*>(&transport_),
+                            static_cast<juce::Component*>(&resultDeck_),
+                            static_cast<juce::Component*>(&previewDeck_)})
+    {
+        addAndMakeVisible(*component);
+    }
+
     configureLabels();
     configureEditors();
     configureSelectors();
@@ -24,83 +37,34 @@ ACEStepVST3AudioProcessorEditor::ACEStepVST3AudioProcessorEditor(
     startTimerHz(4);
 }
 
-ACEStepVST3AudioProcessorEditor::~ACEStepVST3AudioProcessorEditor() = default;
+ACEStepVST3AudioProcessorEditor::~ACEStepVST3AudioProcessorEditor()
+{
+    setLookAndFeel(nullptr);
+}
 
 void ACEStepVST3AudioProcessorEditor::paint(juce::Graphics& g)
 {
-    g.fillAll(juce::Colour::fromRGB(18, 22, 32));
-    g.setColour(juce::Colour::fromRGB(44, 54, 74));
-    g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(12.0f), 12.0f, 1.5f);
+    v2::drawChassis(g, getLocalBounds());
 }
 
 void ACEStepVST3AudioProcessorEditor::resized()
 {
-    auto bounds = getLocalBounds().reduced(20);
-    auto header = bounds.removeFromTop(56);
-    titleLabel_.setBounds(header.removeFromTop(28));
-    subtitleLabel_.setBounds(header.removeFromTop(20));
+    auto bounds = getLocalBounds().reduced(26);
+    statusStrip_.setBounds(bounds.removeFromTop(96));
+    bounds.removeFromTop(14);
 
-    auto top = bounds.removeFromTop(168);
-    auto left = top.removeFromLeft(top.getWidth() / 2).reduced(0, 4);
-    auto right = top.reduced(0, 4);
+    auto upper = bounds.removeFromTop(400);
+    auto lower = bounds;
 
-    backendUrlLabel_.setBounds(left.removeFromTop(18));
-    backendUrlEditor_.setBounds(left.removeFromTop(28));
-    left.removeFromTop(8);
-    promptLabel_.setBounds(left.removeFromTop(18));
-    promptEditor_.setBounds(left.removeFromTop(44));
-    left.removeFromTop(8);
-    lyricsLabel_.setBounds(left.removeFromTop(18));
-    promptEditor_.setBounds(promptEditor_.getBounds());
-    lyricsEditor_.setBounds(left.removeFromTop(44));
+    auto synthBounds = upper.removeFromLeft((upper.getWidth() * 11) / 20);
+    synthPanel_.setBounds(synthBounds.reduced(0, 2));
+    upper.removeFromLeft(14);
+    transport_.setBounds(upper.reduced(0, 2));
 
-    durationLabel_.setBounds(right.removeFromTop(18));
-    durationBox_.setBounds(right.removeFromTop(28));
-    right.removeFromTop(8);
-    seedLabel_.setBounds(right.removeFromTop(18));
-    seedEditor_.setBounds(right.removeFromTop(28));
-    right.removeFromTop(8);
-    modelLabel_.setBounds(right.removeFromTop(18));
-    modelBox_.setBounds(right.removeFromTop(28));
-    right.removeFromTop(8);
-    qualityLabel_.setBounds(right.removeFromTop(18));
-    qualityBox_.setBounds(right.removeFromTop(28));
-
-    auto statusArea = bounds.removeFromTop(156);
-    auto statusLeft = statusArea.removeFromLeft(statusArea.getWidth() / 2).reduced(0, 4);
-    auto statusRight = statusArea.reduced(0, 4);
-
-    backendStatusTitle_.setBounds(statusLeft.removeFromTop(18));
-    backendStatusBox_.setBounds(statusLeft.removeFromTop(28));
-    statusLeft.removeFromTop(8);
-    backendStatusValue_.setBounds(statusLeft.removeFromTop(40));
-    statusLeft.removeFromTop(8);
-    jobStatusTitle_.setBounds(statusLeft.removeFromTop(18));
-    jobStatusValue_.setBounds(statusLeft.removeFromTop(40));
-
-    errorTitle_.setBounds(statusRight.removeFromTop(18));
-    errorValue_.setBounds(statusRight.removeFromTop(94));
-    statusRight.removeFromTop(10);
-    generateButton_.setBounds(statusRight.removeFromTop(30).removeFromLeft(180));
-
-    bounds.removeFromTop(8);
-    resultsLabel_.setBounds(bounds.removeFromTop(18));
-    resultSlotBox_.setBounds(bounds.removeFromTop(28));
-
-    bounds.removeFromTop(12);
-    previewTitle_.setBounds(bounds.removeFromTop(18));
-    previewValue_.setBounds(bounds.removeFromTop(56));
-    bounds.removeFromTop(8);
-    auto previewButtons = bounds.removeFromTop(30);
-    choosePreviewButton_.setBounds(previewButtons.removeFromLeft(180));
-    previewButtons.removeFromLeft(8);
-    playPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
-    previewButtons.removeFromLeft(8);
-    stopPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
-    previewButtons.removeFromLeft(8);
-    clearPreviewButton_.setBounds(previewButtons.removeFromLeft(72));
-    previewButtons.removeFromLeft(8);
-    revealPreviewButton_.setBounds(previewButtons.removeFromLeft(120));
+    auto resultBounds = lower.removeFromTop(150);
+    resultDeck_.setBounds(resultBounds);
+    lower.removeFromTop(14);
+    previewDeck_.setBounds(lower);
 }
 
 void ACEStepVST3AudioProcessorEditor::timerCallback()

--- a/plugins/acestep_vst3/src/PluginEditor.h
+++ b/plugins/acestep_vst3/src/PluginEditor.h
@@ -2,6 +2,13 @@
 
 #include <JuceHeader.h>
 
+#include "PreviewDeckComponent.h"
+#include "ResultDeckComponent.h"
+#include "StatusStripComponent.h"
+#include "SynthPanelComponent.h"
+#include "TapeTransportComponent.h"
+#include "V2LookAndFeel.h"
+
 namespace acestep::vst3
 {
 class ACEStepVST3AudioProcessor;
@@ -32,39 +39,12 @@ private:
     void revealPreviewFile();
 
     ACEStepVST3AudioProcessor& processor_;
-    juce::Label titleLabel_;
-    juce::Label subtitleLabel_;
-    juce::Label backendUrlLabel_;
-    juce::Label promptLabel_;
-    juce::Label lyricsLabel_;
-    juce::Label durationLabel_;
-    juce::Label seedLabel_;
-    juce::Label modelLabel_;
-    juce::Label qualityLabel_;
-    juce::Label backendStatusTitle_;
-    juce::Label backendStatusValue_;
-    juce::Label jobStatusTitle_;
-    juce::Label jobStatusValue_;
-    juce::Label errorTitle_;
-    juce::Label errorValue_;
-    juce::Label resultsLabel_;
-    juce::Label previewTitle_;
-    juce::Label previewValue_;
-    juce::TextEditor backendUrlEditor_;
-    juce::TextEditor promptEditor_;
-    juce::TextEditor lyricsEditor_;
-    juce::TextEditor seedEditor_;
-    juce::ComboBox durationBox_;
-    juce::ComboBox modelBox_;
-    juce::ComboBox qualityBox_;
-    juce::ComboBox backendStatusBox_;
-    juce::ComboBox resultSlotBox_;
-    juce::TextButton generateButton_ {"Generate"};
-    juce::TextButton choosePreviewButton_ {"Load Preview File"};
-    juce::TextButton playPreviewButton_ {"Play"};
-    juce::TextButton stopPreviewButton_ {"Stop"};
-    juce::TextButton clearPreviewButton_ {"Clear"};
-    juce::TextButton revealPreviewButton_ {"Reveal File"};
+    std::unique_ptr<V2LookAndFeel> lookAndFeel_;
+    StatusStripComponent statusStrip_;
+    SynthPanelComponent synthPanel_;
+    TapeTransportComponent transport_;
+    ResultDeckComponent resultDeck_;
+    PreviewDeckComponent previewDeck_;
     std::unique_ptr<juce::FileChooser> previewChooser_;
     bool isSyncing_ = false;
 

--- a/plugins/acestep_vst3/src/PluginEditorState.cpp
+++ b/plugins/acestep_vst3/src/PluginEditorState.cpp
@@ -1,5 +1,6 @@
 #include "PluginEditor.h"
 
+#include "PluginConfig.h"
 #include "PluginEnums.h"
 #include "PluginProcessor.h"
 
@@ -7,123 +8,85 @@ namespace acestep::vst3
 {
 void ACEStepVST3AudioProcessorEditor::configureLabels()
 {
-    titleLabel_.setText("ACE-Step VST3 MVP UI", juce::dontSendNotification);
-    titleLabel_.setFont(juce::Font(juce::FontOptions(20.0f, juce::Font::bold)));
-    subtitleLabel_.setText("State-driven prompt, job, and result workflow shell.",
-                           juce::dontSendNotification);
-
-    for (auto* label : {&titleLabel_, &subtitleLabel_, &backendUrlLabel_, &promptLabel_,
-                        &lyricsLabel_, &durationLabel_, &seedLabel_, &modelLabel_,
-                        &qualityLabel_, &backendStatusTitle_, &backendStatusValue_,
-                        &jobStatusTitle_, &jobStatusValue_, &errorTitle_, &errorValue_,
-                        &resultsLabel_, &previewTitle_, &previewValue_})
-    {
-        label->setJustificationType(juce::Justification::centredLeft);
-        addAndMakeVisible(*label);
-    }
-
-    backendUrlLabel_.setText("Backend URL", juce::dontSendNotification);
-    promptLabel_.setText("Prompt", juce::dontSendNotification);
-    lyricsLabel_.setText("Lyrics", juce::dontSendNotification);
-    durationLabel_.setText("Duration", juce::dontSendNotification);
-    seedLabel_.setText("Seed", juce::dontSendNotification);
-    modelLabel_.setText("Model preset", juce::dontSendNotification);
-    qualityLabel_.setText("Quality mode", juce::dontSendNotification);
-    backendStatusTitle_.setText("Backend status", juce::dontSendNotification);
-    jobStatusTitle_.setText("Job status", juce::dontSendNotification);
-    errorTitle_.setText("Error state", juce::dontSendNotification);
-    resultsLabel_.setText("Result slot selection", juce::dontSendNotification);
-    previewTitle_.setText("Preview and file handoff", juce::dontSendNotification);
-    errorValue_.setColour(juce::Label::textColourId, juce::Colours::lightsalmon);
+    refreshStatusViews();
 }
 
 void ACEStepVST3AudioProcessorEditor::configureEditors()
 {
-    backendUrlEditor_.setTextToShowWhenEmpty(kDefaultBackendBaseUrl, juce::Colours::grey);
-    backendUrlEditor_.onTextChange = [this] { persistTextFields(); };
-    promptEditor_.setTextToShowWhenEmpty("Describe the song idea", juce::Colours::grey);
-    promptEditor_.onTextChange = [this] { persistTextFields(); };
-    lyricsEditor_.setTextToShowWhenEmpty("Optional lyric sketch", juce::Colours::grey);
-    lyricsEditor_.setMultiLine(true);
-    lyricsEditor_.onTextChange = [this] { persistTextFields(); };
-    seedEditor_.setInputRestrictions(10, "0123456789");
-    seedEditor_.onTextChange = [this] { persistTextFields(); };
+    auto& backendEditor = synthPanel_.backendUrlEditor();
+    auto& promptEditor = synthPanel_.promptEditor();
+    auto& lyricsEditor = synthPanel_.lyricsEditor();
+    auto& seedEditor = synthPanel_.seedEditor();
 
-    for (auto* editor : {&backendUrlEditor_, &promptEditor_, &lyricsEditor_, &seedEditor_})
-    {
-        addAndMakeVisible(*editor);
-    }
+    backendEditor.setTextToShowWhenEmpty(kDefaultBackendBaseUrl, juce::Colours::grey);
+    backendEditor.onTextChange = [this] { persistTextFields(); };
+
+    promptEditor.setTextToShowWhenEmpty("Describe the tape pass you want to print.",
+                                        juce::Colours::grey);
+    promptEditor.onTextChange = [this] { persistTextFields(); };
+
+    lyricsEditor.setTextToShowWhenEmpty("Optional lyric sketch or arrangement notes.",
+                                        juce::Colours::grey);
+    lyricsEditor.onTextChange = [this] { persistTextFields(); };
+
+    seedEditor.setInputRestrictions(10, "0123456789");
+    seedEditor.onTextChange = [this] { persistTextFields(); };
 }
 
 void ACEStepVST3AudioProcessorEditor::configureSelectors()
 {
+    auto& durationBox = synthPanel_.durationBox();
+    auto& modelBox = synthPanel_.modelBox();
+    auto& qualityBox = synthPanel_.qualityBox();
+    auto& resultSlotBox = resultDeck_.resultSelector();
+
     for (const auto duration : {10, 30, 60, 120})
     {
-        durationBox_.addItem(juce::String(duration) + " seconds", duration);
+        durationBox.addItem(juce::String(duration) + " seconds", duration);
     }
-    modelBox_.addItem(toString(ModelPreset::turbo), 1);
-    modelBox_.addItem(toString(ModelPreset::standard), 2);
-    modelBox_.addItem(toString(ModelPreset::quality), 3);
-    qualityBox_.addItem(toString(QualityMode::fast), 1);
-    qualityBox_.addItem(toString(QualityMode::balanced), 2);
-    qualityBox_.addItem(toString(QualityMode::high), 3);
-    backendStatusBox_.addItem(toString(BackendStatus::ready), 1);
-    backendStatusBox_.addItem(toString(BackendStatus::offline), 2);
-    backendStatusBox_.addItem(toString(BackendStatus::degraded), 3);
-    backendStatusBox_.setEnabled(false);
+    modelBox.addItem(toString(ModelPreset::turbo), 1);
+    modelBox.addItem(toString(ModelPreset::standard), 2);
+    modelBox.addItem(toString(ModelPreset::quality), 3);
+    qualityBox.addItem(toString(QualityMode::fast), 1);
+    qualityBox.addItem(toString(QualityMode::balanced), 2);
+    qualityBox.addItem(toString(QualityMode::high), 3);
 
-    durationBox_.onChange = [this] { persistTextFields(); };
-    modelBox_.onChange = [this] { persistTextFields(); };
-    qualityBox_.onChange = [this] { persistTextFields(); };
-    resultSlotBox_.onChange = [this] {
+    durationBox.onChange = [this] { persistTextFields(); };
+    modelBox.onChange = [this] { persistTextFields(); };
+    qualityBox.onChange = [this] { persistTextFields(); };
+    resultSlotBox.onChange = [this] {
         if (isSyncing_)
         {
             return;
         }
-        processor_.selectResultSlot(juce::jmax(0, resultSlotBox_.getSelectedItemIndex()));
+        processor_.selectResultSlot(juce::jmax(0, resultDeck_.resultSelector().getSelectedItemIndex()));
         refreshStatusViews();
     };
-    generateButton_.onClick = [this] {
+    transport_.generateButton().onClick = [this] {
         persistTextFields();
         processor_.requestGeneration();
         refreshStatusViews();
     };
-    choosePreviewButton_.onClick = [this] { choosePreviewFile(); };
-    playPreviewButton_.onClick = [this] { playPreviewFile(); };
-    stopPreviewButton_.onClick = [this] { stopPreviewFile(); };
-    clearPreviewButton_.onClick = [this] { clearPreviewFile(); };
-    revealPreviewButton_.onClick = [this] { revealPreviewFile(); };
-
-    for (auto* component : {static_cast<juce::Component*>(&durationBox_),
-                            static_cast<juce::Component*>(&modelBox_),
-                            static_cast<juce::Component*>(&qualityBox_),
-                            static_cast<juce::Component*>(&backendStatusBox_),
-                            static_cast<juce::Component*>(&resultSlotBox_),
-                            static_cast<juce::Component*>(&generateButton_),
-                            static_cast<juce::Component*>(&choosePreviewButton_),
-                            static_cast<juce::Component*>(&playPreviewButton_),
-                            static_cast<juce::Component*>(&stopPreviewButton_),
-                            static_cast<juce::Component*>(&clearPreviewButton_),
-                            static_cast<juce::Component*>(&revealPreviewButton_)})
-    {
-        addAndMakeVisible(*component);
-    }
+    previewDeck_.loadButton().onClick = [this] { choosePreviewFile(); };
+    previewDeck_.playButton().onClick = [this] { playPreviewFile(); };
+    previewDeck_.stopButton().onClick = [this] { stopPreviewFile(); };
+    previewDeck_.clearButton().onClick = [this] { clearPreviewFile(); };
+    previewDeck_.revealButton().onClick = [this] { revealPreviewFile(); };
 }
 
 void ACEStepVST3AudioProcessorEditor::syncFromProcessor()
 {
     const auto& state = processor_.getState();
     isSyncing_ = true;
-    backendUrlEditor_.setText(state.backendBaseUrl, juce::dontSendNotification);
-    promptEditor_.setText(state.prompt, juce::dontSendNotification);
-    lyricsEditor_.setText(state.lyrics, juce::dontSendNotification);
-    seedEditor_.setText(juce::String(state.seed), juce::dontSendNotification);
-    durationBox_.setSelectedId(state.durationSeconds, juce::dontSendNotification);
-    modelBox_.setSelectedId(static_cast<int>(state.modelPreset) + 1, juce::dontSendNotification);
-    qualityBox_.setSelectedId(static_cast<int>(state.qualityMode) + 1,
-                              juce::dontSendNotification);
-    backendStatusBox_.setSelectedId(static_cast<int>(state.backendStatus) + 1,
-                                    juce::dontSendNotification);
+    synthPanel_.backendUrlEditor().setText(state.backendBaseUrl, juce::dontSendNotification);
+    synthPanel_.promptEditor().setText(state.prompt, juce::dontSendNotification);
+    synthPanel_.lyricsEditor().setText(state.lyrics, juce::dontSendNotification);
+    synthPanel_.seedEditor().setText(juce::String(state.seed), juce::dontSendNotification);
+    synthPanel_.durationBox().setSelectedId(state.durationSeconds, juce::dontSendNotification);
+    synthPanel_.modelBox().setSelectedId(static_cast<int>(state.modelPreset) + 1,
+                                         juce::dontSendNotification);
+    synthPanel_.qualityBox().setSelectedId(static_cast<int>(state.qualityMode) + 1,
+                                           juce::dontSendNotification);
     isSyncing_ = false;
 }
 
@@ -135,34 +98,43 @@ void ACEStepVST3AudioProcessorEditor::persistTextFields()
     }
 
     auto& state = processor_.getMutableState();
-    state.backendBaseUrl = backendUrlEditor_.getText().trim();
+    auto& backendEditor = synthPanel_.backendUrlEditor();
+    auto& promptEditor = synthPanel_.promptEditor();
+    auto& lyricsEditor = synthPanel_.lyricsEditor();
+    auto& seedEditor = synthPanel_.seedEditor();
+    auto& durationBox = synthPanel_.durationBox();
+    auto& modelBox = synthPanel_.modelBox();
+    auto& qualityBox = synthPanel_.qualityBox();
+
+    state.backendBaseUrl = backendEditor.getText().trim();
     if (state.backendBaseUrl.isEmpty())
     {
         state.backendBaseUrl = kDefaultBackendBaseUrl;
-        backendUrlEditor_.setText(state.backendBaseUrl, juce::dontSendNotification);
+        backendEditor.setText(state.backendBaseUrl, juce::dontSendNotification);
     }
 
-    state.prompt = promptEditor_.getText();
-    state.lyrics = lyricsEditor_.getText();
-    state.durationSeconds = durationBox_.getSelectedId() == 0 ? kDefaultDurationSeconds
-                                                              : durationBox_.getSelectedId();
-    state.seed = seedEditor_.getText().getIntValue();
+    state.prompt = promptEditor.getText();
+    state.lyrics = lyricsEditor.getText();
+    state.durationSeconds = durationBox.getSelectedId() == 0 ? kDefaultDurationSeconds
+                                                             : durationBox.getSelectedId();
+    state.seed = seedEditor.getText().getIntValue();
     if (state.seed <= 0)
     {
         state.seed = kDefaultSeed;
-        seedEditor_.setText(juce::String(state.seed), juce::dontSendNotification);
+        seedEditor.setText(juce::String(state.seed), juce::dontSendNotification);
     }
 
-    state.modelPreset = static_cast<ModelPreset>(juce::jmax(0, modelBox_.getSelectedItemIndex()));
-    state.qualityMode = static_cast<QualityMode>(juce::jmax(0, qualityBox_.getSelectedItemIndex()));
+    state.modelPreset = static_cast<ModelPreset>(juce::jmax(0, modelBox.getSelectedItemIndex()));
+    state.qualityMode = static_cast<QualityMode>(juce::jmax(0, qualityBox.getSelectedItemIndex()));
     refreshStatusViews();
 }
 
 void ACEStepVST3AudioProcessorEditor::refreshResultSelector()
 {
     const auto& state = processor_.getState();
+    auto& resultSelector = resultDeck_.resultSelector();
     isSyncing_ = true;
-    resultSlotBox_.clear(juce::dontSendNotification);
+    resultSelector.clear(juce::dontSendNotification);
     for (int index = 0; index < kResultSlotCount; ++index)
     {
         auto label = state.resultSlots[static_cast<size_t>(index)];
@@ -170,41 +142,58 @@ void ACEStepVST3AudioProcessorEditor::refreshResultSelector()
         {
             label = "Result " + juce::String(index + 1) + " - empty";
         }
-        resultSlotBox_.addItem(label, index + 1);
+        resultSelector.addItem(label, index + 1);
     }
-    resultSlotBox_.setSelectedId(state.selectedResultSlot + 1, juce::dontSendNotification);
+    resultSelector.setSelectedId(state.selectedResultSlot + 1, juce::dontSendNotification);
     isSyncing_ = false;
 }
 
 void ACEStepVST3AudioProcessorEditor::refreshStatusViews()
 {
     const auto& state = processor_.getState();
-    backendStatusBox_.setSelectedId(static_cast<int>(state.backendStatus) + 1,
-                                    juce::dontSendNotification);
-    backendStatusValue_.setText(
-        "Target: " + state.backendBaseUrl + "\nStatus: " + toString(state.backendStatus),
-        juce::dontSendNotification);
-    jobStatusValue_.setText("State: " + toString(state.jobStatus) + "\nSelected slot: "
-                                + juce::String(state.selectedResultSlot + 1) + "\nMessage: "
-                                + (state.progressText.isEmpty() ? "Idle" : state.progressText),
-                            juce::dontSendNotification);
-    errorValue_.setText(state.errorMessage.isEmpty() ? "No active error." : state.errorMessage,
-                        juce::dontSendNotification);
+    const auto sessionName = state.prompt.trim().isEmpty() ? "UNTITLED SESSION"
+                                                           : state.prompt.substring(0, 48).toUpperCase();
+    statusStrip_.setSessionName("SESSION // " + sessionName);
+    statusStrip_.setModeName("TEXT MODE");
+    statusStrip_.setBackendStatus(state.backendStatus);
+
+    auto transportMessage = state.progressText;
+    if (transportMessage.isEmpty())
+    {
+        transportMessage = "Slot " + juce::String(state.selectedResultSlot + 1) + " armed.";
+    }
+    transport_.setTransportState(state.backendStatus,
+                                 state.jobStatus,
+                                 transportMessage,
+                                 state.errorMessage);
+
+    auto takeTitle = "Take " + juce::String(state.selectedResultSlot + 1);
+    auto takeDetail = state.resultSlots[static_cast<size_t>(state.selectedResultSlot)];
+    if (takeDetail.isEmpty())
+    {
+        takeDetail = "No printed result yet.";
+    }
+    const auto& localPath = state.resultLocalPaths[static_cast<size_t>(state.selectedResultSlot)];
+    const auto& remoteUrl = state.resultFileUrls[static_cast<size_t>(state.selectedResultSlot)];
+    if (!localPath.isEmpty())
+    {
+        takeDetail += "\nLOCAL // " + localPath;
+    }
+    else if (!remoteUrl.isEmpty())
+    {
+        takeDetail += "\nREMOTE // " + remoteUrl;
+    }
+    resultDeck_.setTakeSummary(takeTitle, takeDetail);
 
     auto previewText = state.previewDisplayName.isEmpty() ? "No preview file loaded."
-                                                          : state.previewDisplayName;
+                                                          : "Loaded // " + state.previewDisplayName;
     previewText += "\n";
-    previewText += state.previewFilePath.isEmpty() ? "Choose a local audio file to preview or reveal."
+    previewText += state.previewFilePath.isEmpty() ? "Choose a local or generated file to preview."
                                                    : state.previewFilePath;
     if (processor_.isPreviewPlaying())
     {
-        previewText += "\nPlayback: active";
+        previewText += "\nPlayback // active";
     }
-    previewValue_.setText(previewText, juce::dontSendNotification);
-
-    const auto isBusy = state.jobStatus == JobStatus::submitting
-                        || state.jobStatus == JobStatus::queuedOrRunning;
-    generateButton_.setEnabled(!isBusy);
-    generateButton_.setButtonText(isBusy ? "Rendering..." : "Generate");
+    previewDeck_.setPreviewSummary(previewText);
 }
 }  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PreviewDeckComponent.cpp
+++ b/plugins/acestep_vst3/src/PreviewDeckComponent.cpp
@@ -1,0 +1,54 @@
+#include "PreviewDeckComponent.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+PreviewDeckComponent::PreviewDeckComponent()
+{
+    summaryLabel_.setColour(juce::Label::textColourId, v2::kLabelPrimary);
+    summaryLabel_.setJustificationType(juce::Justification::centredLeft);
+    addAndMakeVisible(summaryLabel_);
+    for (auto* button : {&loadButton_, &playButton_, &stopButton_, &clearButton_, &revealButton_})
+    {
+        addAndMakeVisible(*button);
+    }
+}
+
+void PreviewDeckComponent::paint(juce::Graphics& g)
+{
+    v2::drawModule(g, getLocalBounds(), "Preview Deck", v2::kAccentMint);
+
+    auto waveformZone = getLocalBounds().reduced(22).removeFromTop(24);
+    juce::ignoreUnused(waveformZone);
+}
+
+void PreviewDeckComponent::resized()
+{
+    auto area = getLocalBounds().reduced(18);
+    area.removeFromTop(24);
+    summaryLabel_.setBounds(area.removeFromTop(68));
+    area.removeFromTop(10);
+    auto buttons = area.removeFromTop(36);
+    loadButton_.setBounds(buttons.removeFromLeft(150));
+    buttons.removeFromLeft(8);
+    playButton_.setBounds(buttons.removeFromLeft(80));
+    buttons.removeFromLeft(8);
+    stopButton_.setBounds(buttons.removeFromLeft(80));
+    buttons.removeFromLeft(8);
+    clearButton_.setBounds(buttons.removeFromLeft(80));
+    buttons.removeFromLeft(8);
+    revealButton_.setBounds(buttons.removeFromLeft(120));
+}
+
+juce::TextButton& PreviewDeckComponent::loadButton() noexcept { return loadButton_; }
+juce::TextButton& PreviewDeckComponent::playButton() noexcept { return playButton_; }
+juce::TextButton& PreviewDeckComponent::stopButton() noexcept { return stopButton_; }
+juce::TextButton& PreviewDeckComponent::clearButton() noexcept { return clearButton_; }
+juce::TextButton& PreviewDeckComponent::revealButton() noexcept { return revealButton_; }
+
+void PreviewDeckComponent::setPreviewSummary(const juce::String& summary)
+{
+    summaryLabel_.setText(summary, juce::dontSendNotification);
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/PreviewDeckComponent.h
+++ b/plugins/acestep_vst3/src/PreviewDeckComponent.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace acestep::vst3
+{
+class PreviewDeckComponent final : public juce::Component
+{
+public:
+    PreviewDeckComponent();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    juce::TextButton& loadButton() noexcept;
+    juce::TextButton& playButton() noexcept;
+    juce::TextButton& stopButton() noexcept;
+    juce::TextButton& clearButton() noexcept;
+    juce::TextButton& revealButton() noexcept;
+    void setPreviewSummary(const juce::String& summary);
+
+private:
+    juce::Label summaryLabel_;
+    juce::TextButton loadButton_ {"Load Preview"};
+    juce::TextButton playButton_ {"Play"};
+    juce::TextButton stopButton_ {"Stop"};
+    juce::TextButton clearButton_ {"Clear"};
+    juce::TextButton revealButton_ {"Reveal File"};
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/ResultDeckComponent.cpp
+++ b/plugins/acestep_vst3/src/ResultDeckComponent.cpp
@@ -1,0 +1,39 @@
+#include "ResultDeckComponent.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+ResultDeckComponent::ResultDeckComponent()
+{
+    resultLabel_.setText("Take Select", juce::dontSendNotification);
+    resultLabel_.setColour(juce::Label::textColourId, v2::kLabelMuted);
+    summaryLabel_.setColour(juce::Label::textColourId, v2::kLabelPrimary);
+    summaryLabel_.setJustificationType(juce::Justification::centredLeft);
+    addAndMakeVisible(resultLabel_);
+    addAndMakeVisible(resultSelector_);
+    addAndMakeVisible(summaryLabel_);
+}
+
+void ResultDeckComponent::paint(juce::Graphics& g)
+{
+    v2::drawModule(g, getLocalBounds(), "Result Deck", v2::kAccentBlue);
+}
+
+void ResultDeckComponent::resized()
+{
+    auto area = getLocalBounds().reduced(18);
+    area.removeFromTop(24);
+    resultLabel_.setBounds(area.removeFromTop(18));
+    resultSelector_.setBounds(area.removeFromTop(32));
+    area.removeFromTop(10);
+    summaryLabel_.setBounds(area.removeFromTop(52));
+}
+
+juce::ComboBox& ResultDeckComponent::resultSelector() noexcept { return resultSelector_; }
+
+void ResultDeckComponent::setTakeSummary(const juce::String& title, const juce::String& detail)
+{
+    summaryLabel_.setText(title + "\n" + detail, juce::dontSendNotification);
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/ResultDeckComponent.h
+++ b/plugins/acestep_vst3/src/ResultDeckComponent.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace acestep::vst3
+{
+class ResultDeckComponent final : public juce::Component
+{
+public:
+    ResultDeckComponent();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    juce::ComboBox& resultSelector() noexcept;
+    void setTakeSummary(const juce::String& title, const juce::String& detail);
+
+private:
+    juce::Label resultLabel_;
+    juce::ComboBox resultSelector_;
+    juce::Label summaryLabel_;
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/StatusStripComponent.cpp
+++ b/plugins/acestep_vst3/src/StatusStripComponent.cpp
@@ -1,0 +1,58 @@
+#include "StatusStripComponent.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+StatusStripComponent::StatusStripComponent()
+{
+    brandLabel_.setText("ACE-STEP // TAPE SYNTH", juce::dontSendNotification);
+    brandLabel_.setFont(juce::Font(juce::FontOptions(24.0f, juce::Font::bold)));
+    brandLabel_.setColour(juce::Label::textColourId, v2::kLabelPrimary);
+    sessionLabel_.setColour(juce::Label::textColourId, v2::kLabelMuted);
+    modeLabel_.setColour(juce::Label::textColourId, v2::kAccentMint);
+    backendLabel_.setColour(juce::Label::textColourId, v2::kLabelPrimary);
+
+    for (auto* label : {&brandLabel_, &sessionLabel_, &modeLabel_, &backendLabel_})
+    {
+        label->setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(*label);
+    }
+}
+
+void StatusStripComponent::paint(juce::Graphics& g)
+{
+    auto bounds = getLocalBounds();
+    v2::drawModule(g, bounds, "Status Strip", v2::kAccentBlue);
+    auto lamp = juce::Rectangle<float>(18.0f, 18.0f)
+                    .withCentre({static_cast<float>(bounds.getRight() - 32), static_cast<float>(bounds.getY() + 32)});
+    v2::drawLamp(g, lamp, v2::statusColour(backendStatus_), backendStatus_ == BackendStatus::ready);
+}
+
+void StatusStripComponent::resized()
+{
+    auto area = getLocalBounds().reduced(18, 12);
+    auto top = area.removeFromTop(28);
+    brandLabel_.setBounds(top.removeFromLeft(area.getWidth() / 2 + 140));
+    modeLabel_.setBounds(top.removeFromLeft(170));
+    backendLabel_.setBounds(top.removeFromLeft(170));
+    sessionLabel_.setBounds(area.removeFromTop(20));
+}
+
+void StatusStripComponent::setSessionName(const juce::String& sessionName)
+{
+    sessionLabel_.setText(sessionName, juce::dontSendNotification);
+}
+
+void StatusStripComponent::setModeName(const juce::String& modeName)
+{
+    modeLabel_.setText(modeName, juce::dontSendNotification);
+}
+
+void StatusStripComponent::setBackendStatus(BackendStatus status)
+{
+    backendStatus_ = status;
+    backendLabel_.setText("BACKEND " + toString(status).toUpperCase(), juce::dontSendNotification);
+    repaint();
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/StatusStripComponent.h
+++ b/plugins/acestep_vst3/src/StatusStripComponent.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "PluginEnums.h"
+
+namespace acestep::vst3
+{
+class StatusStripComponent final : public juce::Component
+{
+public:
+    StatusStripComponent();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    void setSessionName(const juce::String& sessionName);
+    void setModeName(const juce::String& modeName);
+    void setBackendStatus(BackendStatus status);
+
+private:
+    juce::Label brandLabel_;
+    juce::Label sessionLabel_;
+    juce::Label modeLabel_;
+    juce::Label backendLabel_;
+    BackendStatus backendStatus_ = BackendStatus::offline;
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/SynthPanelComponent.cpp
+++ b/plugins/acestep_vst3/src/SynthPanelComponent.cpp
@@ -1,0 +1,82 @@
+#include "SynthPanelComponent.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+SynthPanelComponent::SynthPanelComponent()
+{
+    for (auto* label : {&backendUrlLabel_, &promptLabel_, &lyricsLabel_, &durationLabel_, &seedLabel_,
+                        &modelLabel_, &qualityLabel_})
+    {
+        label->setColour(juce::Label::textColourId, v2::kLabelMuted);
+        addAndMakeVisible(*label);
+    }
+
+    backendUrlLabel_.setText("Signal Path", juce::dontSendNotification);
+    promptLabel_.setText("Prompt", juce::dontSendNotification);
+    lyricsLabel_.setText("Lyrics", juce::dontSendNotification);
+    durationLabel_.setText("Duration", juce::dontSendNotification);
+    seedLabel_.setText("Seed", juce::dontSendNotification);
+    modelLabel_.setText("Engine", juce::dontSendNotification);
+    qualityLabel_.setText("Quality", juce::dontSendNotification);
+
+    promptEditor_.setMultiLine(true);
+    lyricsEditor_.setMultiLine(true);
+
+    for (auto* component : {static_cast<juce::Component*>(&backendUrlEditor_),
+                            static_cast<juce::Component*>(&promptEditor_),
+                            static_cast<juce::Component*>(&lyricsEditor_),
+                            static_cast<juce::Component*>(&seedEditor_),
+                            static_cast<juce::Component*>(&durationBox_),
+                            static_cast<juce::Component*>(&modelBox_),
+                            static_cast<juce::Component*>(&qualityBox_)})
+    {
+        addAndMakeVisible(*component);
+    }
+}
+
+void SynthPanelComponent::paint(juce::Graphics& g)
+{
+    v2::drawModule(g, getLocalBounds(), "Compose / Engine", v2::kAccentBlue);
+}
+
+void SynthPanelComponent::resized()
+{
+    auto area = getLocalBounds().reduced(18);
+    area.removeFromTop(24);
+    auto left = area.removeFromLeft(area.getWidth() / 2 + 10);
+    auto right = area;
+    const auto labelHeight = 18;
+    const auto fieldHeight = 32;
+
+    backendUrlLabel_.setBounds(left.removeFromTop(labelHeight));
+    backendUrlEditor_.setBounds(left.removeFromTop(fieldHeight));
+    left.removeFromTop(8);
+    promptLabel_.setBounds(left.removeFromTop(labelHeight));
+    promptEditor_.setBounds(left.removeFromTop(72));
+    left.removeFromTop(8);
+    lyricsLabel_.setBounds(left.removeFromTop(labelHeight));
+    lyricsEditor_.setBounds(left.removeFromTop(90));
+
+    durationLabel_.setBounds(right.removeFromTop(labelHeight));
+    durationBox_.setBounds(right.removeFromTop(fieldHeight));
+    right.removeFromTop(8);
+    seedLabel_.setBounds(right.removeFromTop(labelHeight));
+    seedEditor_.setBounds(right.removeFromTop(fieldHeight));
+    right.removeFromTop(8);
+    modelLabel_.setBounds(right.removeFromTop(labelHeight));
+    modelBox_.setBounds(right.removeFromTop(fieldHeight));
+    right.removeFromTop(8);
+    qualityLabel_.setBounds(right.removeFromTop(labelHeight));
+    qualityBox_.setBounds(right.removeFromTop(fieldHeight));
+}
+
+juce::TextEditor& SynthPanelComponent::backendUrlEditor() noexcept { return backendUrlEditor_; }
+juce::TextEditor& SynthPanelComponent::promptEditor() noexcept { return promptEditor_; }
+juce::TextEditor& SynthPanelComponent::lyricsEditor() noexcept { return lyricsEditor_; }
+juce::TextEditor& SynthPanelComponent::seedEditor() noexcept { return seedEditor_; }
+juce::ComboBox& SynthPanelComponent::durationBox() noexcept { return durationBox_; }
+juce::ComboBox& SynthPanelComponent::modelBox() noexcept { return modelBox_; }
+juce::ComboBox& SynthPanelComponent::qualityBox() noexcept { return qualityBox_; }
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/SynthPanelComponent.h
+++ b/plugins/acestep_vst3/src/SynthPanelComponent.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace acestep::vst3
+{
+class SynthPanelComponent final : public juce::Component
+{
+public:
+    SynthPanelComponent();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    juce::TextEditor& backendUrlEditor() noexcept;
+    juce::TextEditor& promptEditor() noexcept;
+    juce::TextEditor& lyricsEditor() noexcept;
+    juce::TextEditor& seedEditor() noexcept;
+    juce::ComboBox& durationBox() noexcept;
+    juce::ComboBox& modelBox() noexcept;
+    juce::ComboBox& qualityBox() noexcept;
+
+private:
+    juce::Label backendUrlLabel_;
+    juce::Label promptLabel_;
+    juce::Label lyricsLabel_;
+    juce::Label durationLabel_;
+    juce::Label seedLabel_;
+    juce::Label modelLabel_;
+    juce::Label qualityLabel_;
+    juce::TextEditor backendUrlEditor_;
+    juce::TextEditor promptEditor_;
+    juce::TextEditor lyricsEditor_;
+    juce::TextEditor seedEditor_;
+    juce::ComboBox durationBox_;
+    juce::ComboBox modelBox_;
+    juce::ComboBox qualityBox_;
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/TapeTransportComponent.cpp
+++ b/plugins/acestep_vst3/src/TapeTransportComponent.cpp
@@ -1,0 +1,74 @@
+#include "TapeTransportComponent.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+TapeTransportComponent::TapeTransportComponent()
+{
+    backendLabel_.setColour(juce::Label::textColourId, v2::kLabelMuted);
+    stateLabel_.setColour(juce::Label::textColourId, v2::kLabelPrimary);
+    messageLabel_.setColour(juce::Label::textColourId, v2::kAccentMint);
+    errorLabel_.setColour(juce::Label::textColourId, v2::kAccentRed);
+    for (auto* label : {&backendLabel_, &stateLabel_, &messageLabel_, &errorLabel_})
+    {
+        label->setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(*label);
+    }
+    addAndMakeVisible(generateButton_);
+}
+
+void TapeTransportComponent::paint(juce::Graphics& g)
+{
+    auto bounds = getLocalBounds();
+    v2::drawModule(g, bounds, "Tape Transport", v2::statusColour(jobStatus_));
+
+    auto top = bounds.removeFromTop(180).reduced(30, 38);
+    auto leftReel = top.removeFromLeft(150).toFloat();
+    auto rightReel = top.removeFromRight(150).toFloat();
+    auto display = top.reduced(12, 22);
+    v2::drawTapeReel(g, leftReel, v2::kAccentBlue, jobStatus_ == JobStatus::queuedOrRunning);
+    v2::drawTapeReel(g, rightReel, v2::kAccentMint, jobStatus_ == JobStatus::queuedOrRunning);
+    v2::drawDisplay(g, display.toNearestInt(), true);
+    g.setColour(v2::kLabelPrimary);
+    g.setFont(juce::Font(juce::FontOptions(26.0f, juce::Font::bold)));
+    g.drawText(toString(jobStatus_).toUpperCase(), display.reduced(16.0f, 12.0f), juce::Justification::centred);
+
+    auto lamp = juce::Rectangle<float>(18.0f, 18.0f)
+                    .withCentre({static_cast<float>(bounds.getRight() - 38), 36.0f});
+    v2::drawLamp(g, lamp, v2::statusColour(backendStatus_), backendStatus_ == BackendStatus::ready);
+}
+
+void TapeTransportComponent::resized()
+{
+    auto area = getLocalBounds().reduced(22);
+    area.removeFromTop(186);
+    backendLabel_.setBounds(area.removeFromTop(20));
+    stateLabel_.setBounds(area.removeFromTop(26));
+    area.removeFromTop(4);
+    messageLabel_.setBounds(area.removeFromTop(22));
+    area.removeFromTop(8);
+    errorLabel_.setBounds(area.removeFromTop(44));
+    area.removeFromTop(12);
+    generateButton_.setBounds(area.removeFromTop(40).removeFromLeft(220));
+}
+
+juce::TextButton& TapeTransportComponent::generateButton() noexcept { return generateButton_; }
+
+void TapeTransportComponent::setTransportState(BackendStatus backendStatus,
+                                               JobStatus jobStatus,
+                                               const juce::String& message,
+                                               const juce::String& errorText)
+{
+    backendStatus_ = backendStatus;
+    jobStatus_ = jobStatus;
+    backendLabel_.setText("Backend // " + toString(backendStatus), juce::dontSendNotification);
+    stateLabel_.setText("Transport // " + toString(jobStatus), juce::dontSendNotification);
+    messageLabel_.setText(message.isEmpty() ? "Transport armed." : message, juce::dontSendNotification);
+    errorLabel_.setText(errorText.isEmpty() ? "No critical warnings." : errorText, juce::dontSendNotification);
+    const auto busy = jobStatus == JobStatus::submitting || jobStatus == JobStatus::queuedOrRunning;
+    generateButton_.setEnabled(!busy);
+    generateButton_.setButtonText(busy ? "Rendering..." : "Render");
+    repaint();
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/TapeTransportComponent.h
+++ b/plugins/acestep_vst3/src/TapeTransportComponent.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "PluginEnums.h"
+
+namespace acestep::vst3
+{
+class TapeTransportComponent final : public juce::Component
+{
+public:
+    TapeTransportComponent();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    juce::TextButton& generateButton() noexcept;
+    void setTransportState(BackendStatus backendStatus,
+                           JobStatus jobStatus,
+                           const juce::String& message,
+                           const juce::String& errorText);
+
+private:
+    juce::Label backendLabel_;
+    juce::Label stateLabel_;
+    juce::Label messageLabel_;
+    juce::Label errorLabel_;
+    juce::TextButton generateButton_ {"Render"};
+    BackendStatus backendStatus_ = BackendStatus::offline;
+    JobStatus jobStatus_ = JobStatus::idle;
+};
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/V2Chrome.cpp
+++ b/plugins/acestep_vst3/src/V2Chrome.cpp
@@ -1,0 +1,132 @@
+#include "V2Chrome.h"
+
+namespace acestep::vst3::v2
+{
+void drawChassis(juce::Graphics& g, juce::Rectangle<int> bounds)
+{
+    auto area = bounds.toFloat();
+    g.setGradientFill(
+        juce::ColourGradient(kChassisOuter, area.getTopLeft(), kChassisInner, area.getBottomLeft(), false));
+    g.fillRoundedRectangle(area, 24.0f);
+
+    g.setColour(juce::Colours::black.withAlpha(0.45f));
+    g.drawRoundedRectangle(area.reduced(1.0f), 24.0f, 3.0f);
+
+    g.setColour(kModuleStroke.withAlpha(0.55f));
+    g.drawRoundedRectangle(area.reduced(8.0f), 18.0f, 1.4f);
+
+    g.setColour(kLabelMuted.withAlpha(0.07f));
+    for (int x = bounds.getX() + 20; x < bounds.getRight() - 20; x += 12)
+    {
+        g.drawVerticalLine(x, static_cast<float>(bounds.getY() + 18), static_cast<float>(bounds.getBottom() - 18));
+    }
+}
+
+void drawModule(juce::Graphics& g,
+                juce::Rectangle<int> bounds,
+                const juce::String& title,
+                juce::Colour accent)
+{
+    auto area = bounds.toFloat();
+    g.setColour(accent.withAlpha(0.12f));
+    g.fillRoundedRectangle(area.expanded(1.0f), 18.0f);
+
+    g.setGradientFill(
+        juce::ColourGradient(kModuleRaised, area.getTopLeft(), kModuleFill, area.getBottomLeft(), false));
+    g.fillRoundedRectangle(area, 18.0f);
+
+    g.setColour(juce::Colours::black.withAlpha(0.35f));
+    g.drawRoundedRectangle(area.translated(0.0f, 1.0f), 18.0f, 2.0f);
+    g.setColour(kModuleStroke);
+    g.drawRoundedRectangle(area, 18.0f, 1.1f);
+
+    auto titleBar = area.removeFromTop(30.0f).reduced(14.0f, 6.0f);
+    g.setColour(accent.withAlpha(0.22f));
+    g.fillRoundedRectangle(titleBar, 8.0f);
+    g.setColour(kLabelPrimary);
+    g.setFont(juce::Font(juce::FontOptions(13.0f, juce::Font::bold)));
+    g.drawText(title.toUpperCase(), titleBar.reduced(12.0f, 0.0f), juce::Justification::centredLeft);
+}
+
+void drawDisplay(juce::Graphics& g, juce::Rectangle<int> bounds, bool active)
+{
+    auto area = bounds.toFloat();
+    auto fill = active ? kDisplayFill.brighter(0.08f) : kDisplayFill;
+    g.setGradientFill(juce::ColourGradient(fill.brighter(0.08f), area.getTopLeft(), fill, area.getBottomLeft(), false));
+    g.fillRoundedRectangle(area, 14.0f);
+    g.setColour(kDisplayGlow.withAlpha(active ? 0.42f : 0.18f));
+    g.drawRoundedRectangle(area, 14.0f, 1.2f);
+}
+
+void drawLamp(juce::Graphics& g, juce::Rectangle<float> bounds, juce::Colour colour, bool active)
+{
+    const auto base = active ? colour : kModuleStroke.darker(0.6f);
+    g.setColour(base.darker(0.7f));
+    g.fillEllipse(bounds);
+    g.setColour(base.brighter(active ? 0.2f : 0.05f));
+    g.fillEllipse(bounds.reduced(2.0f));
+    if (active)
+    {
+        g.setColour(base.withAlpha(0.22f));
+        g.fillEllipse(bounds.expanded(6.0f));
+    }
+}
+
+void drawTapeReel(juce::Graphics& g, juce::Rectangle<float> bounds, juce::Colour accent, bool active)
+{
+    g.setColour(kModuleStroke.withAlpha(0.5f));
+    g.fillEllipse(bounds);
+    g.setColour(accent.withAlpha(active ? 0.28f : 0.12f));
+    g.fillEllipse(bounds.reduced(6.0f));
+    g.setColour(kLabelPrimary.withAlpha(0.75f));
+    g.drawEllipse(bounds.reduced(8.0f), 1.2f);
+
+    const auto centre = bounds.getCentre();
+    const auto radius = bounds.getWidth() * 0.18f;
+    for (int index = 0; index < 3; ++index)
+    {
+        juce::Path spoke;
+        const auto angle = juce::MathConstants<float>::twoPi * static_cast<float>(index) / 3.0f
+                           + (active ? 0.35f : 0.0f);
+        spoke.startNewSubPath(centre);
+        spoke.lineTo(centre.x + std::cos(angle) * radius, centre.y + std::sin(angle) * radius);
+        g.strokePath(spoke, juce::PathStrokeType(2.0f));
+    }
+
+    g.setColour(kChassisOuter);
+    g.fillEllipse(juce::Rectangle<float>(16.0f, 16.0f).withCentre(centre));
+}
+
+juce::Colour statusColour(BackendStatus status)
+{
+    switch (status)
+    {
+        case BackendStatus::ready:
+            return kAccentMint;
+        case BackendStatus::offline:
+            return kAccentRed;
+        case BackendStatus::degraded:
+            return kAccentAmber;
+    }
+
+    return kAccentMint;
+}
+
+juce::Colour statusColour(JobStatus status)
+{
+    switch (status)
+    {
+        case JobStatus::idle:
+            return kAccentBlue;
+        case JobStatus::submitting:
+        case JobStatus::queuedOrRunning:
+            return kAccentAmber;
+        case JobStatus::succeeded:
+            return kAccentMint;
+        case JobStatus::failed:
+            return kAccentRed;
+    }
+
+    return kAccentBlue;
+}
+}  // namespace acestep::vst3::v2

--- a/plugins/acestep_vst3/src/V2Chrome.h
+++ b/plugins/acestep_vst3/src/V2Chrome.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "PluginEnums.h"
+
+namespace acestep::vst3::v2
+{
+inline const auto kChassisOuter = juce::Colour::fromRGB(10, 15, 20);
+inline const auto kChassisInner = juce::Colour::fromRGB(18, 24, 31);
+inline const auto kModuleFill = juce::Colour::fromRGB(17, 23, 30);
+inline const auto kModuleRaised = juce::Colour::fromRGB(29, 38, 49);
+inline const auto kModuleStroke = juce::Colour::fromRGB(63, 82, 100);
+inline const auto kDisplayFill = juce::Colour::fromRGB(13, 28, 31);
+inline const auto kDisplayGlow = juce::Colour::fromRGB(96, 224, 205);
+inline const auto kLabelPrimary = juce::Colour::fromRGB(229, 235, 240);
+inline const auto kLabelMuted = juce::Colour::fromRGB(134, 152, 167);
+inline const auto kAccentMint = juce::Colour::fromRGB(83, 226, 203);
+inline const auto kAccentAmber = juce::Colour::fromRGB(255, 177, 92);
+inline const auto kAccentRed = juce::Colour::fromRGB(255, 108, 112);
+inline const auto kAccentBlue = juce::Colour::fromRGB(108, 154, 255);
+
+void drawChassis(juce::Graphics& g, juce::Rectangle<int> bounds);
+void drawModule(juce::Graphics& g,
+                juce::Rectangle<int> bounds,
+                const juce::String& title,
+                juce::Colour accent);
+void drawDisplay(juce::Graphics& g, juce::Rectangle<int> bounds, bool active);
+void drawLamp(juce::Graphics& g, juce::Rectangle<float> bounds, juce::Colour colour, bool active);
+void drawTapeReel(juce::Graphics& g, juce::Rectangle<float> bounds, juce::Colour accent, bool active);
+juce::Colour statusColour(BackendStatus status);
+juce::Colour statusColour(JobStatus status);
+}  // namespace acestep::vst3::v2

--- a/plugins/acestep_vst3/src/V2LookAndFeel.cpp
+++ b/plugins/acestep_vst3/src/V2LookAndFeel.cpp
@@ -1,0 +1,106 @@
+#include "V2LookAndFeel.h"
+
+#include "V2Chrome.h"
+
+namespace acestep::vst3
+{
+V2LookAndFeel::V2LookAndFeel()
+{
+    setColour(juce::Label::textColourId, v2::kLabelPrimary);
+    setColour(juce::TextEditor::backgroundColourId, v2::kModuleFill.brighter(0.06f));
+    setColour(juce::TextEditor::outlineColourId, v2::kModuleStroke);
+    setColour(juce::TextEditor::focusedOutlineColourId, v2::kAccentMint);
+    setColour(juce::TextEditor::textColourId, v2::kLabelPrimary);
+    setColour(juce::TextEditor::highlightColourId, v2::kAccentBlue.withAlpha(0.24f));
+    setColour(juce::CaretComponent::caretColourId, v2::kAccentMint);
+    setColour(juce::ComboBox::backgroundColourId, v2::kModuleFill);
+    setColour(juce::ComboBox::outlineColourId, v2::kModuleStroke);
+    setColour(juce::ComboBox::arrowColourId, v2::kLabelMuted);
+    setColour(juce::ComboBox::textColourId, v2::kLabelPrimary);
+    setColour(juce::PopupMenu::backgroundColourId, v2::kModuleFill);
+    setColour(juce::PopupMenu::textColourId, v2::kLabelPrimary);
+}
+
+juce::Font V2LookAndFeel::getTextButtonFont(juce::TextButton&, int buttonHeight)
+{
+    return juce::Font(
+        juce::FontOptions(static_cast<float>(juce::jmin(18, buttonHeight / 2 + 4)), juce::Font::bold));
+}
+
+juce::Font V2LookAndFeel::getComboBoxFont(juce::ComboBox& box)
+{
+    return juce::Font(
+        juce::FontOptions(static_cast<float>(juce::jmin(17, box.getHeight() / 2 + 2)), juce::Font::plain));
+}
+
+void V2LookAndFeel::drawButtonBackground(juce::Graphics& g,
+                                         juce::Button& button,
+                                         const juce::Colour&,
+                                         bool isMouseOverButton,
+                                         bool isButtonDown)
+{
+    auto bounds = button.getLocalBounds().toFloat().reduced(0.5f);
+    auto fill = button.getButtonText().containsIgnoreCase("render")
+                    || button.getButtonText().containsIgnoreCase("generate")
+                    ? v2::kAccentAmber
+                    : v2::kModuleRaised;
+    if (!button.isEnabled())
+    {
+        fill = fill.darker(0.65f);
+    }
+    if (isMouseOverButton)
+    {
+        fill = fill.brighter(0.14f);
+    }
+    if (isButtonDown)
+    {
+        fill = fill.darker(0.2f);
+    }
+
+    g.setGradientFill(juce::ColourGradient(fill.brighter(0.08f), bounds.getTopLeft(), fill.darker(0.24f), bounds.getBottomLeft(), false));
+    g.fillRoundedRectangle(bounds, 10.0f);
+    g.setColour(juce::Colours::black.withAlpha(0.35f));
+    g.drawRoundedRectangle(bounds.translated(0.0f, 1.0f), 10.0f, 1.8f);
+    g.setColour(v2::kModuleStroke.withAlpha(0.9f));
+    g.drawRoundedRectangle(bounds, 10.0f, 1.0f);
+}
+
+void V2LookAndFeel::drawComboBox(juce::Graphics& g,
+                                 int width,
+                                 int height,
+                                 bool,
+                                 int,
+                                 int,
+                                 int,
+                                 int,
+                                 juce::ComboBox& box)
+{
+    auto bounds = juce::Rectangle<float>(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height))
+                      .reduced(0.5f);
+    g.setGradientFill(juce::ColourGradient(v2::kModuleRaised, bounds.getTopLeft(), v2::kModuleFill, bounds.getBottomLeft(), false));
+    g.fillRoundedRectangle(bounds, 10.0f);
+    g.setColour(v2::kModuleStroke);
+    g.drawRoundedRectangle(bounds, 10.0f, 1.0f);
+
+    auto arrowZone = bounds.removeFromRight(28.0f).reduced(6.0f, 9.0f);
+    juce::Path arrow;
+    arrow.startNewSubPath(arrowZone.getX(), arrowZone.getY());
+    arrow.lineTo(arrowZone.getCentreX(), arrowZone.getBottom());
+    arrow.lineTo(arrowZone.getRight(), arrowZone.getY());
+    g.setColour(box.isEnabled() ? v2::kAccentMint : v2::kLabelMuted);
+    g.strokePath(arrow, juce::PathStrokeType(1.8f));
+}
+
+void V2LookAndFeel::drawTextEditorOutline(juce::Graphics& g,
+                                          int width,
+                                          int height,
+                                          juce::TextEditor& textEditor)
+{
+    auto bounds = juce::Rectangle<float>(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height))
+                      .reduced(0.5f);
+    g.setColour(juce::Colours::black.withAlpha(0.35f));
+    g.drawRoundedRectangle(bounds.translated(0.0f, 1.0f), 10.0f, 1.6f);
+    g.setColour(textEditor.hasKeyboardFocus(true) ? v2::kAccentMint : v2::kModuleStroke);
+    g.drawRoundedRectangle(bounds, 10.0f, textEditor.hasKeyboardFocus(true) ? 1.3f : 1.0f);
+}
+}  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/V2LookAndFeel.h
+++ b/plugins/acestep_vst3/src/V2LookAndFeel.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace acestep::vst3
+{
+class V2LookAndFeel final : public juce::LookAndFeel_V4
+{
+public:
+    V2LookAndFeel();
+
+    juce::Font getTextButtonFont(juce::TextButton& button, int buttonHeight) override;
+    juce::Font getComboBoxFont(juce::ComboBox& box) override;
+    void drawButtonBackground(juce::Graphics& g,
+                              juce::Button& button,
+                              const juce::Colour& backgroundColour,
+                              bool isMouseOverButton,
+                              bool isButtonDown) override;
+    void drawComboBox(juce::Graphics& g,
+                      int width,
+                      int height,
+                      bool isButtonDown,
+                      int buttonX,
+                      int buttonY,
+                      int buttonW,
+                      int buttonH,
+                      juce::ComboBox& box) override;
+    void drawTextEditorOutline(juce::Graphics& g,
+                               int width,
+                               int height,
+                               juce::TextEditor& textEditor) override;
+};
+}  // namespace acestep::vst3


### PR DESCRIPTION
## Summary
- add a dedicated V2 tape-synth chrome and look-and-feel layer for the VST3 plugin
- replace the monolithic MVP editor surface with modular status, synth, transport, result, and preview components
- preserve the existing MVP backend/generate/preview flow while giving it a future hardware synth + magnetic tape layout

## Validation
- cmake --build build/acestep_vst3 --config Release
- synced the rebuilt bundle to ~/Library/Audio/Plug-Ins/VST3/ACE-Step VST3 Shell.vst3 for Reaper smoke testing

Closes #905
Refs #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned editor interface with new V2 visual theme and styling.
  * Increased window size for improved layout and usability.
  * Reorganized interface into themed modular sections (Preview, Results, Status, Compose/Engine, Transport).
  * Enhanced visual design with styled module frames, status indicators, and custom UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->