### PR TITLE
feat: add conditioning modes to the VST3 workflow

### DIFF
--- a/plugins/acestep_vst3/src/PluginBackendClient.cpp
+++ b/plugins/acestep_vst3/src/PluginBackendClient.cpp
@@ -157,6 +157,12 @@ int chooseInferenceSteps(QualityMode qualityMode)
     return 8;
 }
 
+bool modeNeedsPrompt(WorkflowMode mode)
+{
+    return mode == WorkflowMode::text || mode == WorkflowMode::reference
+           || mode == WorkflowMode::coverRemix;
+}
+
 juce::String chooseFileExtension(const juce::String& remoteFileUrl)
 {
     const auto decoded = juce::URL::removeEscapeChars(remoteFileUrl);
@@ -204,9 +210,10 @@ PluginGenerationStartResult PluginBackendClient::startGeneration(const PluginSta
     PluginGenerationStartResult result;
 
     juce::DynamicObject::Ptr payload = new juce::DynamicObject();
-    payload->setProperty("prompt", state.prompt);
+    payload->setProperty("prompt", modeNeedsPrompt(state.workflowMode) ? state.prompt : juce::String());
     payload->setProperty("lyrics", state.lyrics);
-    payload->setProperty("task_type", "text2music");
+    payload->setProperty("task_type",
+                         state.workflowMode == WorkflowMode::coverRemix ? "cover" : "text2music");
     payload->setProperty("audio_duration", state.durationSeconds);
     payload->setProperty("batch_size", 1);
     payload->setProperty("audio_format", "wav");
@@ -219,6 +226,27 @@ PluginGenerationStartResult PluginBackendClient::startGeneration(const PluginSta
     if (const auto modelName = chooseModelName(state.modelPreset); modelName.isNotEmpty())
     {
         payload->setProperty("model", modelName);
+    }
+
+    switch (state.workflowMode)
+    {
+        case WorkflowMode::text:
+            break;
+        case WorkflowMode::reference:
+            payload->setProperty("reference_audio_path", state.referenceAudioPath);
+            break;
+        case WorkflowMode::coverRemix:
+            payload->setProperty("src_audio_path", state.sourceAudioPath);
+            payload->setProperty("audio_cover_strength", state.audioCoverStrength);
+            if (state.referenceAudioPath.isNotEmpty())
+            {
+                payload->setProperty("reference_audio_path", state.referenceAudioPath);
+            }
+            break;
+        case WorkflowMode::customConditioning:
+            payload->setProperty("audio_code_string", state.customConditioningCodes);
+            payload->setProperty("audio_cover_strength", state.audioCoverStrength);
+            break;
     }
 
     juce::var response;

--- a/plugins/acestep_vst3/src/PluginEditor.cpp
+++ b/plugins/acestep_vst3/src/PluginEditor.cpp
@@ -8,7 +8,7 @@ namespace acestep::vst3
 namespace
 {
 constexpr int kEditorWidth = 1080;
-constexpr int kEditorHeight = 820;
+constexpr int kEditorHeight = 900;
 }  // namespace
 
 ACEStepVST3AudioProcessorEditor::ACEStepVST3AudioProcessorEditor(
@@ -53,7 +53,7 @@ void ACEStepVST3AudioProcessorEditor::resized()
     statusStrip_.setBounds(bounds.removeFromTop(96));
     bounds.removeFromTop(14);
 
-    auto upper = bounds.removeFromTop(400);
+    auto upper = bounds.removeFromTop(480);
     auto lower = bounds;
 
     auto synthBounds = upper.removeFromLeft((upper.getWidth() * 11) / 20);

--- a/plugins/acestep_vst3/src/PluginEditor.h
+++ b/plugins/acestep_vst3/src/PluginEditor.h
@@ -33,6 +33,10 @@ private:
     void refreshResultSelector();
     void refreshStatusViews();
     void choosePreviewFile();
+    void chooseReferenceFile();
+    void clearReferenceFile();
+    void chooseSourceFile();
+    void clearSourceFile();
     void playPreviewFile();
     void stopPreviewFile();
     void clearPreviewFile();
@@ -46,6 +50,8 @@ private:
     ResultDeckComponent resultDeck_;
     PreviewDeckComponent previewDeck_;
     std::unique_ptr<juce::FileChooser> previewChooser_;
+    std::unique_ptr<juce::FileChooser> referenceChooser_;
+    std::unique_ptr<juce::FileChooser> sourceChooser_;
     bool isSyncing_ = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ACEStepVST3AudioProcessorEditor)

--- a/plugins/acestep_vst3/src/PluginEditorPreview.cpp
+++ b/plugins/acestep_vst3/src/PluginEditorPreview.cpp
@@ -4,11 +4,16 @@
 
 namespace acestep::vst3
 {
+namespace
+{
+constexpr auto kAudioFileFilter = "*.wav;*.aiff;*.flac;*.ogg;*.mp3";
+}
+
 void ACEStepVST3AudioProcessorEditor::choosePreviewFile()
 {
     previewChooser_ = std::make_unique<juce::FileChooser>("Select preview audio file",
                                                           juce::File(),
-                                                          "*.wav;*.aiff;*.flac;*.ogg;*.mp3");
+                                                          kAudioFileFilter);
     previewChooser_->launchAsync(juce::FileBrowserComponent::openMode
                                      | juce::FileBrowserComponent::canSelectFiles,
                                  [this](const juce::FileChooser& chooser) {
@@ -23,6 +28,60 @@ void ACEStepVST3AudioProcessorEditor::choosePreviewFile()
                                      [[maybe_unused]] const auto loaded = processor_.loadPreviewFile(file);
                                      refreshStatusViews();
                                  });
+}
+
+void ACEStepVST3AudioProcessorEditor::chooseReferenceFile()
+{
+    referenceChooser_ = std::make_unique<juce::FileChooser>("Select reference audio file",
+                                                            juce::File(),
+                                                            kAudioFileFilter);
+    referenceChooser_->launchAsync(juce::FileBrowserComponent::openMode
+                                       | juce::FileBrowserComponent::canSelectFiles,
+                                   [this](const juce::FileChooser& chooser) {
+                                       const auto file = chooser.getResult();
+                                       referenceChooser_.reset();
+                                       if (file == juce::File())
+                                       {
+                                           return;
+                                       }
+
+                                       synthPanel_.referenceAudioEditor().setText(file.getFullPathName(),
+                                                                                  juce::sendNotification);
+                                       persistTextFields();
+                                   });
+}
+
+void ACEStepVST3AudioProcessorEditor::clearReferenceFile()
+{
+    synthPanel_.referenceAudioEditor().clear();
+    persistTextFields();
+}
+
+void ACEStepVST3AudioProcessorEditor::chooseSourceFile()
+{
+    sourceChooser_ = std::make_unique<juce::FileChooser>("Select source audio file",
+                                                         juce::File(),
+                                                         kAudioFileFilter);
+    sourceChooser_->launchAsync(juce::FileBrowserComponent::openMode
+                                    | juce::FileBrowserComponent::canSelectFiles,
+                                [this](const juce::FileChooser& chooser) {
+                                    const auto file = chooser.getResult();
+                                    sourceChooser_.reset();
+                                    if (file == juce::File())
+                                    {
+                                        return;
+                                    }
+
+                                    synthPanel_.sourceAudioEditor().setText(file.getFullPathName(),
+                                                                            juce::sendNotification);
+                                    persistTextFields();
+                                });
+}
+
+void ACEStepVST3AudioProcessorEditor::clearSourceFile()
+{
+    synthPanel_.sourceAudioEditor().clear();
+    persistTextFields();
 }
 
 void ACEStepVST3AudioProcessorEditor::playPreviewFile()

--- a/plugins/acestep_vst3/src/PluginEditorState.cpp
+++ b/plugins/acestep_vst3/src/PluginEditorState.cpp
@@ -14,12 +14,23 @@ void ACEStepVST3AudioProcessorEditor::configureLabels()
 void ACEStepVST3AudioProcessorEditor::configureEditors()
 {
     auto& backendEditor = synthPanel_.backendUrlEditor();
+    auto& modeBox = synthPanel_.modeBox();
     auto& promptEditor = synthPanel_.promptEditor();
     auto& lyricsEditor = synthPanel_.lyricsEditor();
+    auto& referenceAudioEditor = synthPanel_.referenceAudioEditor();
+    auto& sourceAudioEditor = synthPanel_.sourceAudioEditor();
+    auto& conditioningCodesEditor = synthPanel_.conditioningCodesEditor();
     auto& seedEditor = synthPanel_.seedEditor();
+    auto& coverStrengthSlider = synthPanel_.coverStrengthSlider();
 
     backendEditor.setTextToShowWhenEmpty(kDefaultBackendBaseUrl, juce::Colours::grey);
     backendEditor.onTextChange = [this] { persistTextFields(); };
+
+    modeBox.addItem(toString(WorkflowMode::text), 1);
+    modeBox.addItem(toString(WorkflowMode::reference), 2);
+    modeBox.addItem(toString(WorkflowMode::coverRemix), 3);
+    modeBox.addItem(toString(WorkflowMode::customConditioning), 4);
+    modeBox.onChange = [this] { persistTextFields(); };
 
     promptEditor.setTextToShowWhenEmpty("Describe the tape pass you want to print.",
                                         juce::Colours::grey);
@@ -29,8 +40,21 @@ void ACEStepVST3AudioProcessorEditor::configureEditors()
                                         juce::Colours::grey);
     lyricsEditor.onTextChange = [this] { persistTextFields(); };
 
+    referenceAudioEditor.setTextToShowWhenEmpty("Reference WAV or render path",
+                                                juce::Colours::grey);
+    referenceAudioEditor.onTextChange = [this] { persistTextFields(); };
+
+    sourceAudioEditor.setTextToShowWhenEmpty("Source audio path for cover/remix",
+                                             juce::Colours::grey);
+    sourceAudioEditor.onTextChange = [this] { persistTextFields(); };
+
+    conditioningCodesEditor.setTextToShowWhenEmpty("Semantic audio codes for custom mode",
+                                                   juce::Colours::grey);
+    conditioningCodesEditor.onTextChange = [this] { persistTextFields(); };
+
     seedEditor.setInputRestrictions(10, "0123456789");
     seedEditor.onTextChange = [this] { persistTextFields(); };
+    coverStrengthSlider.onValueChange = [this] { persistTextFields(); };
 }
 
 void ACEStepVST3AudioProcessorEditor::configureSelectors()
@@ -54,6 +78,10 @@ void ACEStepVST3AudioProcessorEditor::configureSelectors()
     durationBox.onChange = [this] { persistTextFields(); };
     modelBox.onChange = [this] { persistTextFields(); };
     qualityBox.onChange = [this] { persistTextFields(); };
+    synthPanel_.chooseReferenceButton().onClick = [this] { chooseReferenceFile(); };
+    synthPanel_.clearReferenceButton().onClick = [this] { clearReferenceFile(); };
+    synthPanel_.chooseSourceButton().onClick = [this] { chooseSourceFile(); };
+    synthPanel_.clearSourceButton().onClick = [this] { clearSourceFile(); };
     resultSlotBox.onChange = [this] {
         if (isSyncing_)
         {
@@ -79,14 +107,21 @@ void ACEStepVST3AudioProcessorEditor::syncFromProcessor()
     const auto& state = processor_.getState();
     isSyncing_ = true;
     synthPanel_.backendUrlEditor().setText(state.backendBaseUrl, juce::dontSendNotification);
+    synthPanel_.modeBox().setSelectedId(static_cast<int>(state.workflowMode) + 1,
+                                        juce::dontSendNotification);
     synthPanel_.promptEditor().setText(state.prompt, juce::dontSendNotification);
     synthPanel_.lyricsEditor().setText(state.lyrics, juce::dontSendNotification);
+    synthPanel_.referenceAudioEditor().setText(state.referenceAudioPath, juce::dontSendNotification);
+    synthPanel_.sourceAudioEditor().setText(state.sourceAudioPath, juce::dontSendNotification);
+    synthPanel_.conditioningCodesEditor().setText(state.customConditioningCodes,
+                                                  juce::dontSendNotification);
     synthPanel_.seedEditor().setText(juce::String(state.seed), juce::dontSendNotification);
     synthPanel_.durationBox().setSelectedId(state.durationSeconds, juce::dontSendNotification);
     synthPanel_.modelBox().setSelectedId(static_cast<int>(state.modelPreset) + 1,
                                          juce::dontSendNotification);
     synthPanel_.qualityBox().setSelectedId(static_cast<int>(state.qualityMode) + 1,
                                            juce::dontSendNotification);
+    synthPanel_.coverStrengthSlider().setValue(state.audioCoverStrength, juce::dontSendNotification);
     isSyncing_ = false;
 }
 
@@ -99,12 +134,17 @@ void ACEStepVST3AudioProcessorEditor::persistTextFields()
 
     auto& state = processor_.getMutableState();
     auto& backendEditor = synthPanel_.backendUrlEditor();
+    auto& modeBox = synthPanel_.modeBox();
     auto& promptEditor = synthPanel_.promptEditor();
     auto& lyricsEditor = synthPanel_.lyricsEditor();
+    auto& referenceAudioEditor = synthPanel_.referenceAudioEditor();
+    auto& sourceAudioEditor = synthPanel_.sourceAudioEditor();
+    auto& conditioningCodesEditor = synthPanel_.conditioningCodesEditor();
     auto& seedEditor = synthPanel_.seedEditor();
     auto& durationBox = synthPanel_.durationBox();
     auto& modelBox = synthPanel_.modelBox();
     auto& qualityBox = synthPanel_.qualityBox();
+    auto& coverStrengthSlider = synthPanel_.coverStrengthSlider();
 
     state.backendBaseUrl = backendEditor.getText().trim();
     if (state.backendBaseUrl.isEmpty())
@@ -113,11 +153,16 @@ void ACEStepVST3AudioProcessorEditor::persistTextFields()
         backendEditor.setText(state.backendBaseUrl, juce::dontSendNotification);
     }
 
+    state.workflowMode = static_cast<WorkflowMode>(juce::jmax(0, modeBox.getSelectedItemIndex()));
     state.prompt = promptEditor.getText();
     state.lyrics = lyricsEditor.getText();
+    state.referenceAudioPath = referenceAudioEditor.getText();
+    state.sourceAudioPath = sourceAudioEditor.getText();
+    state.customConditioningCodes = conditioningCodesEditor.getText();
     state.durationSeconds = durationBox.getSelectedId() == 0 ? kDefaultDurationSeconds
                                                              : durationBox.getSelectedId();
     state.seed = seedEditor.getText().getIntValue();
+    state.audioCoverStrength = coverStrengthSlider.getValue();
     if (state.seed <= 0)
     {
         state.seed = kDefaultSeed;
@@ -154,7 +199,7 @@ void ACEStepVST3AudioProcessorEditor::refreshStatusViews()
     const auto sessionName = state.prompt.trim().isEmpty() ? "UNTITLED SESSION"
                                                            : state.prompt.substring(0, 48).toUpperCase();
     statusStrip_.setSessionName("SESSION // " + sessionName);
-    statusStrip_.setModeName("TEXT MODE");
+    statusStrip_.setModeName(toString(state.workflowMode).toUpperCase() + " MODE");
     statusStrip_.setBackendStatus(state.backendStatus);
 
     auto transportMessage = state.progressText;

--- a/plugins/acestep_vst3/src/PluginProcessor.cpp
+++ b/plugins/acestep_vst3/src/PluginProcessor.cpp
@@ -37,6 +37,11 @@ void refreshSessionFlags(PluginState& state)
         state.session.sessionName = deriveSessionName(state);
     }
 }
+
+bool hasValidAudioFilePath(const juce::String& path)
+{
+    return path.isNotEmpty() && juce::File(path).existsAsFile();
+}
 }  // namespace
 
 ACEStepVST3AudioProcessor::ACEStepVST3AudioProcessor()
@@ -230,7 +235,7 @@ bool ACEStepVST3AudioProcessor::isPreviewPlaying() const
 
 void ACEStepVST3AudioProcessor::requestGeneration()
 {
-    if (state_.prompt.trim().isEmpty())
+    if (state_.workflowMode == WorkflowMode::text && state_.prompt.trim().isEmpty())
     {
         state_.jobStatus = JobStatus::failed;
         state_.transportState = TransportState::failed;
@@ -240,10 +245,54 @@ void ACEStepVST3AudioProcessor::requestGeneration()
         return;
     }
 
+    if (state_.workflowMode == WorkflowMode::reference
+        && !hasValidAudioFilePath(state_.referenceAudioPath))
+    {
+        state_.jobStatus = JobStatus::failed;
+        state_.transportState = TransportState::failed;
+        state_.progressText = {};
+        state_.errorMessage = "Reference mode requires a valid reference audio file.";
+        refreshSessionFlags(state_);
+        return;
+    }
+
+    if (state_.workflowMode == WorkflowMode::coverRemix
+        && !hasValidAudioFilePath(state_.sourceAudioPath))
+    {
+        state_.jobStatus = JobStatus::failed;
+        state_.transportState = TransportState::failed;
+        state_.progressText = {};
+        state_.errorMessage = "Cover / Remix mode requires a valid source audio file.";
+        refreshSessionFlags(state_);
+        return;
+    }
+
+    if (state_.workflowMode == WorkflowMode::coverRemix
+        && state_.referenceAudioPath.isNotEmpty()
+        && !hasValidAudioFilePath(state_.referenceAudioPath))
+    {
+        state_.jobStatus = JobStatus::failed;
+        state_.transportState = TransportState::failed;
+        state_.progressText = {};
+        state_.errorMessage = "Reference audio path is set but the file does not exist.";
+        refreshSessionFlags(state_);
+        return;
+    }
+
+    if (state_.workflowMode == WorkflowMode::customConditioning
+        && state_.customConditioningCodes.trim().isEmpty())
+    {
+        state_.jobStatus = JobStatus::failed;
+        state_.transportState = TransportState::failed;
+        state_.progressText = {};
+        state_.errorMessage = "Custom Conditioning mode requires audio semantic codes.";
+        refreshSessionFlags(state_);
+        return;
+    }
+
     clearGeneratedResults();
     stopPreview();
     clearPreviewFile();
-    state_.workflowMode = WorkflowMode::text;
     state_.session.sessionName = deriveSessionName(state_);
     state_.jobStatus = JobStatus::submitting;
     state_.transportState = TransportState::submitting;

--- a/plugins/acestep_vst3/src/PluginState.cpp
+++ b/plugins/acestep_vst3/src/PluginState.cpp
@@ -42,8 +42,12 @@ std::unique_ptr<juce::XmlElement> createStateXml(const PluginState& state)
     xml->setAttribute("backendBaseUrl", state.backendBaseUrl);
     xml->setAttribute("prompt", state.prompt);
     xml->setAttribute("lyrics", state.lyrics);
+    xml->setAttribute("referenceAudioPath", state.referenceAudioPath);
+    xml->setAttribute("sourceAudioPath", state.sourceAudioPath);
+    xml->setAttribute("customConditioningCodes", state.customConditioningCodes);
     xml->setAttribute("durationSeconds", state.durationSeconds);
     xml->setAttribute("seed", state.seed);
+    xml->setAttribute("audioCoverStrength", state.audioCoverStrength);
     xml->setAttribute("modelPreset", toString(state.modelPreset));
     xml->setAttribute("qualityMode", toString(state.qualityMode));
     xml->setAttribute("backendStatus", toString(state.backendStatus));
@@ -110,8 +114,12 @@ std::optional<PluginState> parseStateXml(const juce::XmlElement& xml)
     state.backendBaseUrl = xml.getStringAttribute("backendBaseUrl", kDefaultBackendBaseUrl).trim();
     state.prompt = xml.getStringAttribute("prompt");
     state.lyrics = xml.getStringAttribute("lyrics");
+    state.referenceAudioPath = xml.getStringAttribute("referenceAudioPath");
+    state.sourceAudioPath = xml.getStringAttribute("sourceAudioPath");
+    state.customConditioningCodes = xml.getStringAttribute("customConditioningCodes");
     state.durationSeconds = xml.getIntAttribute("durationSeconds", kDefaultDurationSeconds);
     state.seed = xml.getIntAttribute("seed", kDefaultSeed);
+    state.audioCoverStrength = xml.getDoubleAttribute("audioCoverStrength", 0.6);
     state.modelPreset = modelPresetFromString(xml.getStringAttribute("modelPreset"));
     state.qualityMode = qualityModeFromString(xml.getStringAttribute("qualityMode"));
     state.backendStatus = backendStatusFromString(xml.getStringAttribute("backendStatus"));

--- a/plugins/acestep_vst3/src/PluginState.h
+++ b/plugins/acestep_vst3/src/PluginState.h
@@ -42,8 +42,12 @@ struct PluginState final
     juce::String backendBaseUrl = kDefaultBackendBaseUrl;
     juce::String prompt;
     juce::String lyrics;
+    juce::String referenceAudioPath;
+    juce::String sourceAudioPath;
+    juce::String customConditioningCodes;
     int durationSeconds = kDefaultDurationSeconds;
     int seed = kDefaultSeed;
+    double audioCoverStrength = 0.6;
     ModelPreset modelPreset = ModelPreset::turbo;
     QualityMode qualityMode = QualityMode::balanced;
     BackendStatus backendStatus = BackendStatus::ready;

--- a/plugins/acestep_vst3/src/SynthPanelComponent.cpp
+++ b/plugins/acestep_vst3/src/SynthPanelComponent.cpp
@@ -6,16 +6,23 @@ namespace acestep::vst3
 {
 SynthPanelComponent::SynthPanelComponent()
 {
-    for (auto* label : {&backendUrlLabel_, &promptLabel_, &lyricsLabel_, &durationLabel_, &seedLabel_,
-                        &modelLabel_, &qualityLabel_})
+    for (auto* label : {&backendUrlLabel_, &promptLabel_, &lyricsLabel_, &modeLabel_,
+                        &referenceAudioLabel_, &sourceAudioLabel_, &conditioningCodesLabel_,
+                        &coverStrengthLabel_, &durationLabel_, &seedLabel_, &modelLabel_,
+                        &qualityLabel_})
     {
         label->setColour(juce::Label::textColourId, v2::kLabelMuted);
         addAndMakeVisible(*label);
     }
 
     backendUrlLabel_.setText("Signal Path", juce::dontSendNotification);
+    modeLabel_.setText("Workflow Mode", juce::dontSendNotification);
     promptLabel_.setText("Prompt", juce::dontSendNotification);
     lyricsLabel_.setText("Lyrics", juce::dontSendNotification);
+    referenceAudioLabel_.setText("Reference Audio", juce::dontSendNotification);
+    sourceAudioLabel_.setText("Source Audio", juce::dontSendNotification);
+    conditioningCodesLabel_.setText("Conditioning Codes", juce::dontSendNotification);
+    coverStrengthLabel_.setText("Conditioning Strength", juce::dontSendNotification);
     durationLabel_.setText("Duration", juce::dontSendNotification);
     seedLabel_.setText("Seed", juce::dontSendNotification);
     modelLabel_.setText("Engine", juce::dontSendNotification);
@@ -23,14 +30,27 @@ SynthPanelComponent::SynthPanelComponent()
 
     promptEditor_.setMultiLine(true);
     lyricsEditor_.setMultiLine(true);
+    conditioningCodesEditor_.setMultiLine(true);
+    coverStrengthSlider_.setSliderStyle(juce::Slider::LinearHorizontal);
+    coverStrengthSlider_.setTextBoxStyle(juce::Slider::TextBoxRight, false, 64, 22);
+    coverStrengthSlider_.setRange(0.0, 1.0, 0.05);
 
     for (auto* component : {static_cast<juce::Component*>(&backendUrlEditor_),
+                            static_cast<juce::Component*>(&modeBox_),
                             static_cast<juce::Component*>(&promptEditor_),
                             static_cast<juce::Component*>(&lyricsEditor_),
+                            static_cast<juce::Component*>(&referenceAudioEditor_),
+                            static_cast<juce::Component*>(&sourceAudioEditor_),
+                            static_cast<juce::Component*>(&conditioningCodesEditor_),
                             static_cast<juce::Component*>(&seedEditor_),
                             static_cast<juce::Component*>(&durationBox_),
                             static_cast<juce::Component*>(&modelBox_),
-                            static_cast<juce::Component*>(&qualityBox_)})
+                            static_cast<juce::Component*>(&qualityBox_),
+                            static_cast<juce::Component*>(&coverStrengthSlider_),
+                            static_cast<juce::Component*>(&chooseReferenceButton_),
+                            static_cast<juce::Component*>(&clearReferenceButton_),
+                            static_cast<juce::Component*>(&chooseSourceButton_),
+                            static_cast<juce::Component*>(&clearSourceButton_)})
     {
         addAndMakeVisible(*component);
     }
@@ -45,7 +65,7 @@ void SynthPanelComponent::resized()
 {
     auto area = getLocalBounds().reduced(18);
     area.removeFromTop(24);
-    auto left = area.removeFromLeft(area.getWidth() / 2 + 10);
+    auto left = area.removeFromLeft(area.getWidth() / 2 + 18);
     auto right = area;
     const auto labelHeight = 18;
     const auto fieldHeight = 32;
@@ -53,12 +73,35 @@ void SynthPanelComponent::resized()
     backendUrlLabel_.setBounds(left.removeFromTop(labelHeight));
     backendUrlEditor_.setBounds(left.removeFromTop(fieldHeight));
     left.removeFromTop(8);
+    modeLabel_.setBounds(left.removeFromTop(labelHeight));
+    modeBox_.setBounds(left.removeFromTop(fieldHeight));
+    left.removeFromTop(8);
     promptLabel_.setBounds(left.removeFromTop(labelHeight));
     promptEditor_.setBounds(left.removeFromTop(72));
     left.removeFromTop(8);
     lyricsLabel_.setBounds(left.removeFromTop(labelHeight));
     lyricsEditor_.setBounds(left.removeFromTop(90));
 
+    referenceAudioLabel_.setBounds(right.removeFromTop(labelHeight));
+    referenceAudioEditor_.setBounds(right.removeFromTop(fieldHeight));
+    auto referenceButtons = right.removeFromTop(26);
+    chooseReferenceButton_.setBounds(referenceButtons.removeFromLeft(82));
+    referenceButtons.removeFromLeft(8);
+    clearReferenceButton_.setBounds(referenceButtons.removeFromLeft(70));
+    right.removeFromTop(8);
+    sourceAudioLabel_.setBounds(right.removeFromTop(labelHeight));
+    sourceAudioEditor_.setBounds(right.removeFromTop(fieldHeight));
+    auto sourceButtons = right.removeFromTop(26);
+    chooseSourceButton_.setBounds(sourceButtons.removeFromLeft(82));
+    sourceButtons.removeFromLeft(8);
+    clearSourceButton_.setBounds(sourceButtons.removeFromLeft(70));
+    right.removeFromTop(8);
+    conditioningCodesLabel_.setBounds(right.removeFromTop(labelHeight));
+    conditioningCodesEditor_.setBounds(right.removeFromTop(64));
+    right.removeFromTop(8);
+    coverStrengthLabel_.setBounds(right.removeFromTop(labelHeight));
+    coverStrengthSlider_.setBounds(right.removeFromTop(24));
+    right.removeFromTop(8);
     durationLabel_.setBounds(right.removeFromTop(labelHeight));
     durationBox_.setBounds(right.removeFromTop(fieldHeight));
     right.removeFromTop(8);
@@ -75,8 +118,26 @@ void SynthPanelComponent::resized()
 juce::TextEditor& SynthPanelComponent::backendUrlEditor() noexcept { return backendUrlEditor_; }
 juce::TextEditor& SynthPanelComponent::promptEditor() noexcept { return promptEditor_; }
 juce::TextEditor& SynthPanelComponent::lyricsEditor() noexcept { return lyricsEditor_; }
+juce::TextEditor& SynthPanelComponent::referenceAudioEditor() noexcept { return referenceAudioEditor_; }
+juce::TextEditor& SynthPanelComponent::sourceAudioEditor() noexcept { return sourceAudioEditor_; }
+juce::TextEditor& SynthPanelComponent::conditioningCodesEditor() noexcept
+{
+    return conditioningCodesEditor_;
+}
 juce::TextEditor& SynthPanelComponent::seedEditor() noexcept { return seedEditor_; }
+juce::ComboBox& SynthPanelComponent::modeBox() noexcept { return modeBox_; }
 juce::ComboBox& SynthPanelComponent::durationBox() noexcept { return durationBox_; }
 juce::ComboBox& SynthPanelComponent::modelBox() noexcept { return modelBox_; }
 juce::ComboBox& SynthPanelComponent::qualityBox() noexcept { return qualityBox_; }
+juce::Slider& SynthPanelComponent::coverStrengthSlider() noexcept { return coverStrengthSlider_; }
+juce::TextButton& SynthPanelComponent::chooseReferenceButton() noexcept
+{
+    return chooseReferenceButton_;
+}
+juce::TextButton& SynthPanelComponent::clearReferenceButton() noexcept
+{
+    return clearReferenceButton_;
+}
+juce::TextButton& SynthPanelComponent::chooseSourceButton() noexcept { return chooseSourceButton_; }
+juce::TextButton& SynthPanelComponent::clearSourceButton() noexcept { return clearSourceButton_; }
 }  // namespace acestep::vst3

--- a/plugins/acestep_vst3/src/SynthPanelComponent.h
+++ b/plugins/acestep_vst3/src/SynthPanelComponent.h
@@ -15,15 +15,29 @@ public:
     juce::TextEditor& backendUrlEditor() noexcept;
     juce::TextEditor& promptEditor() noexcept;
     juce::TextEditor& lyricsEditor() noexcept;
+    juce::TextEditor& referenceAudioEditor() noexcept;
+    juce::TextEditor& sourceAudioEditor() noexcept;
+    juce::TextEditor& conditioningCodesEditor() noexcept;
     juce::TextEditor& seedEditor() noexcept;
+    juce::ComboBox& modeBox() noexcept;
     juce::ComboBox& durationBox() noexcept;
     juce::ComboBox& modelBox() noexcept;
     juce::ComboBox& qualityBox() noexcept;
+    juce::Slider& coverStrengthSlider() noexcept;
+    juce::TextButton& chooseReferenceButton() noexcept;
+    juce::TextButton& clearReferenceButton() noexcept;
+    juce::TextButton& chooseSourceButton() noexcept;
+    juce::TextButton& clearSourceButton() noexcept;
 
 private:
     juce::Label backendUrlLabel_;
     juce::Label promptLabel_;
     juce::Label lyricsLabel_;
+    juce::Label modeLabel_;
+    juce::Label referenceAudioLabel_;
+    juce::Label sourceAudioLabel_;
+    juce::Label conditioningCodesLabel_;
+    juce::Label coverStrengthLabel_;
     juce::Label durationLabel_;
     juce::Label seedLabel_;
     juce::Label modelLabel_;
@@ -31,9 +45,18 @@ private:
     juce::TextEditor backendUrlEditor_;
     juce::TextEditor promptEditor_;
     juce::TextEditor lyricsEditor_;
+    juce::TextEditor referenceAudioEditor_;
+    juce::TextEditor sourceAudioEditor_;
+    juce::TextEditor conditioningCodesEditor_;
     juce::TextEditor seedEditor_;
+    juce::ComboBox modeBox_;
     juce::ComboBox durationBox_;
     juce::ComboBox modelBox_;
     juce::ComboBox qualityBox_;
+    juce::Slider coverStrengthSlider_;
+    juce::TextButton chooseReferenceButton_ {"Choose"};
+    juce::TextButton clearReferenceButton_ {"Clear"};
+    juce::TextButton chooseSourceButton_ {"Choose"};
+    juce::TextButton clearSourceButton_ {"Clear"};
 };
 }  // namespace acestep::vst3


### PR DESCRIPTION
## Summary
- add VST3 workflow modes for text, reference, cover/remix, and custom conditioning
- expand the current MVP editor so users can choose source/reference audio paths, enter audio semantic codes, and tune conditioning strength
- route  payloads by mode while keeping the existing generate, poll, preview, and reveal workflow intact

## Validation
- cmake --build build/acestep_vst3 --config Release
- synced the rebuilt bundle to ~/Library/Audio/Plug-Ins/VST3/ACE-Step VST3 Shell.vst3 for Reaper smoke testing

Closes #907
Refs #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow selector with Text, Reference, Cover/Remix, and Custom Conditioning modes
  * Reference/source audio pickers, preview controls, and cover-strength slider
  * New transport/status strip, result and preview decks, and central synth/transport panels
  * Persisted session/result tracking with per-take metadata and compare slots
  * New visual theme and updated UI layout, buttons and controls

* **Bug Fixes / Validation**
  * Mode-specific input validation and clearer transport state reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->