### PR TITLE
fix: capture repaint settings in AutoGen batch parameter snapshot

### DIFF
--- a/acestep/ui/gradio/events/results/batch_queue.py
+++ b/acestep/ui/gradio/events/results/batch_queue.py
@@ -101,6 +101,7 @@ def capture_current_params(
     enable_normalization, normalization_db,
     fade_in_duration, fade_out_duration,
     latent_shift, latent_rescale,
+    repaint_mode, repaint_strength,
 ):
     """Capture current UI parameters for next-batch generation.
 
@@ -158,6 +159,8 @@ def capture_current_params(
         "fade_out_duration": fade_out_duration,
         "latent_shift": latent_shift,
         "latent_rescale": latent_rescale,
+        "repaint_mode": repaint_mode,
+        "repaint_strength": repaint_strength,
     }
 
 

--- a/acestep/ui/gradio/events/results/batch_queue_test.py
+++ b/acestep/ui/gradio/events/results/batch_queue_test.py
@@ -3,6 +3,7 @@
 import unittest
 
 from acestep.ui.gradio.events.results.batch_queue import (
+    capture_current_params,
     store_batch_in_queue,
     update_batch_indicator,
     update_navigation_buttons,
@@ -208,6 +209,62 @@ class StoreBatchInQueueTests(unittest.TestCase):
         # Non-tensor values should be preserved since only CUDA tensors are offloaded
         self.assertEqual(queue[0]["extra_outputs"]["lrcs"], ["[00:00.00] hello"])
         self.assertEqual(queue[0]["extra_outputs"]["subtitles"], [None])
+
+
+class CaptureCurrentParamsTests(unittest.TestCase):
+    """Tests for capture_current_params."""
+
+    def _build_args(self, **overrides):
+        """Build a complete positional arg list for capture_current_params.
+
+        All values default to None; supply keyword overrides for specific fields.
+        """
+        fields = [
+            "captions", "lyrics", "bpm", "key_scale", "time_signature",
+            "vocal_language", "inference_steps", "guidance_scale",
+            "random_seed_checkbox", "seed", "reference_audio", "audio_duration",
+            "batch_size_input", "src_audio", "text2music_audio_code_string",
+            "repainting_start", "repainting_end", "instruction_display_gen",
+            "audio_cover_strength", "cover_noise_strength", "task_type",
+            "use_adg", "cfg_interval_start", "cfg_interval_end", "shift",
+            "infer_method", "custom_timesteps", "audio_format", "lm_temperature",
+            "think_checkbox", "lm_cfg_scale", "lm_top_k", "lm_top_p",
+            "lm_negative_prompt", "use_cot_metas", "use_cot_caption",
+            "use_cot_language", "constrained_decoding_debug", "allow_lm_batch",
+            "auto_score", "auto_lrc", "score_scale", "lm_batch_chunk_size",
+            "track_name", "complete_track_classes", "enable_normalization",
+            "normalization_db", "fade_in_duration", "fade_out_duration",
+            "latent_shift", "latent_rescale", "repaint_mode", "repaint_strength",
+        ]
+        defaults = {f: None for f in fields}
+        defaults.update(overrides)
+        return [defaults[f] for f in fields]
+
+    def test_repaint_params_included_in_capture(self):
+        """Repaint mode and strength must be captured for AutoGen batches."""
+        args = self._build_args(repaint_mode="aggressive", repaint_strength=0.8)
+        result = capture_current_params(*args)
+        self.assertEqual(result["repaint_mode"], "aggressive")
+        self.assertEqual(result["repaint_strength"], 0.8)
+
+    def test_repaint_params_default_values_captured(self):
+        """Default repaint values (balanced, 0.5) must round-trip through capture."""
+        args = self._build_args(repaint_mode="balanced", repaint_strength=0.5)
+        result = capture_current_params(*args)
+        self.assertEqual(result["repaint_mode"], "balanced")
+        self.assertEqual(result["repaint_strength"], 0.5)
+
+    def test_capture_clears_audio_codes(self):
+        """Audio codes should be cleared so AutoGen batches generate fresh content."""
+        args = self._build_args(text2music_audio_code_string="some_code")
+        result = capture_current_params(*args)
+        self.assertEqual(result["text2music_audio_code_string"], "")
+
+    def test_capture_forces_random_seed(self):
+        """Random seed should be forced True for AutoGen variation."""
+        args = self._build_args(random_seed_checkbox=False)
+        result = capture_current_params(*args)
+        self.assertTrue(result["random_seed_checkbox"])
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/wiring/generation_batch_navigation_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_batch_navigation_wiring.py
@@ -102,7 +102,8 @@ def _build_capture_current_params_inputs(generation_section: dict[str, Any]) -> 
             `use_cot_language`), automation controls
             (`auto_score`, `auto_lrc`, `score_scale`), and normalization/latent
             controls (`enable_normalization`, `normalization_db`,
-            `latent_shift`, `latent_rescale`).
+            `latent_shift`, `latent_rescale`), and repaint controls
+            (`repaint_mode`, `repaint_strength`).
 
     Returns:
         list[Any]: Ordered generation control values used to preserve and
@@ -161,6 +162,8 @@ def _build_capture_current_params_inputs(generation_section: dict[str, Any]) -> 
         generation_section["fade_out_duration"],
         generation_section["latent_shift"],
         generation_section["latent_rescale"],
+        generation_section["repaint_mode"],
+        generation_section["repaint_strength"],
     ]
 
 


### PR DESCRIPTION
## Summary

- Capture `repaint_mode` and `repaint_strength` in the AutoGen batch parameter snapshot so background generation uses the user's actual settings instead of silently falling back to defaults

## Problem

PR #816 added `repaint_mode` and `repaint_strength` as required parameters to `generate_with_progress()` and wired them into the foreground generation path. The batch/AutoGen path was not updated — `capture_current_params()` never captured these values, and `_build_capture_current_params_inputs()` never passed the UI components.

PR #877 fixed the resulting crash by adding `.get()` fallbacks with defaults in `generate_next_batch_background()`, but the parameter capture itself was still missing. The result: AutoGen batches always generate with `"balanced"` mode at strength `0.5` regardless of what the user selects in the UI. No error, no crash — just silently ignored settings.

## Fix

Added `repaint_mode` and `repaint_strength` to two functions that were missed during the #816 wiring:

- `capture_current_params()` in `batch_queue.py` — added to function signature and return dict so the snapshot includes the user's repaint settings
- `_build_capture_current_params_inputs()` in `generation_batch_navigation_wiring.py` — added the two UI components to the Gradio input list so their values are passed to the capture function

Total change is 6 lines of production code across 2 files. Follows the exact same pattern as every other parameter in both functions.

Completes the fix started in #877.

## Platform impact

| Platform | Effect |
|---|---|
| Windows (CUDA) | AutoGen batches now respect repaint settings |
| Linux (CUDA/ROCm) | Structurally identical — no platform-specific code paths touched |
| macOS (MPS) | Structurally identical — no platform-specific code paths touched |
| CPU / no accelerator | Structurally identical — no platform-specific code paths touched |

## Test plan

- `test_repaint_params_included_in_capture` — non-default values (aggressive, 0.8) round-trip through capture
- `test_repaint_params_default_values_captured` — default values (balanced, 0.5) round-trip through capture
- `test_capture_clears_audio_codes` — existing behavior preserved (audio codes cleared for fresh AutoGen content)
- `test_capture_forces_random_seed` — existing behavior preserved (random seed forced for variation)
- All 31 existing tests across `batch_queue_test.py`, `batch_management_background_test.py`, and `decomposition_contract_generation_test.py` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repaint configuration settings are now preserved when navigating between batches during generation operations.

* **Tests**
  * Added test coverage for repaint parameter preservation in batch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->