### PR TITLE
fix: resolve legacy GPU NaN/noise and duration=-1 garbage output

### DIFF
--- a/acestep/api/job_generation_setup.py
+++ b/acestep/api/job_generation_setup.py
@@ -164,7 +164,7 @@ def build_generation_setup(
         bpm=bpm,
         keyscale=key_scale,
         timesignature=time_signature,
-        duration=audio_duration if audio_duration else _API_DEFAULT_DURATION_SECONDS,
+        duration=audio_duration if (audio_duration and audio_duration > 0) else _API_DEFAULT_DURATION_SECONDS,
         inference_steps=req.inference_steps,
         seed=req.seed,
         guidance_scale=req.guidance_scale,

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -196,6 +196,17 @@ class GenerateMusicMixin:
             instruction=instruction,
         )
 
+        # Turbo models bake guidance into the distillation process and do not
+        # use CFG.  Forcing guidance_scale to 1.0 avoids double-application of
+        # guidance that produces noise or NaN/Inf on float16 (see issue #927).
+        if self.is_turbo_model() and guidance_scale != 1.0:
+            logger.info(
+                "[generate_music] Turbo model detected: overriding "
+                "guidance_scale {:.1f} -> 1.0 (turbo does not use CFG).",
+                guidance_scale,
+            )
+            guidance_scale = 1.0
+
         logger.info("[generate_music] Starting generation...")
         if progress:
             progress(0.51, desc="Preparing inputs...")

--- a/acestep/core/generation/handler/generate_music_test.py
+++ b/acestep/core/generation/handler/generate_music_test.py
@@ -64,13 +64,14 @@ class _Host(GenerateMusicMixin):
     payloads so tests can assert orchestration sequencing and return behavior.
     """
 
-    def __init__(self, offload_to_cpu: bool = False):
+    def __init__(self, offload_to_cpu: bool = False, is_turbo: bool = False):
         """Initialize deterministic state and stub payloads for orchestration tests."""
         self.model = object()
         self.vae = object()
         self.text_tokenizer = object()
         self.text_encoder = object()
         self.offload_to_cpu = offload_to_cpu
+        self._is_turbo = is_turbo
         self.sample_rate = 48000
         self.calls: Dict[str, Any] = {}
         self._final_payload = {"audios": [{"tensor": torch.zeros(1, 4), "sample_rate": 48000}], "success": True}
@@ -81,6 +82,10 @@ class _Host(GenerateMusicMixin):
             "success": False,
             "error": "Model not fully initialized",
         }
+
+    def is_turbo_model(self):
+        """Return whether this host simulates a turbo model."""
+        return self._is_turbo
 
     def _resolve_generate_music_progress(self, progress):
         """Return provided callback or deterministic no-op callback."""
@@ -259,6 +264,48 @@ class VramPreflightCheckTests(unittest.TestCase):
             guidance_scale=7.0,
         )
         self.assertIsNone(result)
+
+
+class TurboGuidanceScaleTests(unittest.TestCase):
+    """Verify turbo models force guidance_scale to 1.0 (issue #927)."""
+
+    def test_turbo_model_overrides_guidance_scale_to_one(self):
+        """Turbo model should clamp guidance_scale to 1.0 before service call."""
+        host = _Host(is_turbo=True)
+        host._readiness_error = None
+        out = host.generate_music(
+            captions="cap",
+            lyrics="lyr",
+            inference_steps=8,
+            guidance_scale=7.0,
+            use_random_seed=False,
+            seed=77,
+            task_type="text2music",
+        )
+        self.assertEqual(out, host._final_payload)
+        self.assertEqual(
+            host.calls["_run_generate_music_service_with_progress"]["guidance_scale"],
+            1.0,
+        )
+
+    def test_non_turbo_model_preserves_guidance_scale(self):
+        """Non-turbo model should keep the user-provided guidance_scale."""
+        host = _Host(is_turbo=False)
+        host._readiness_error = None
+        out = host.generate_music(
+            captions="cap",
+            lyrics="lyr",
+            inference_steps=8,
+            guidance_scale=7.0,
+            use_random_seed=False,
+            seed=77,
+            task_type="text2music",
+        )
+        self.assertEqual(out, host._final_payload)
+        self.assertEqual(
+            host.calls["_run_generate_music_service_with_progress"]["guidance_scale"],
+            7.0,
+        )
 
 
 if __name__ == "__main__":

--- a/acestep/core/generation/handler/init_service_loader.py
+++ b/acestep/core/generation/handler/init_service_loader.py
@@ -7,6 +7,7 @@ from typing import Optional
 import torch
 from loguru import logger
 
+from acestep import gpu_config
 from .init_service_loader_components import InitServiceLoaderComponentsMixin
 
 
@@ -142,6 +143,16 @@ class InitServiceLoaderMixin(InitServiceLoaderComponentsMixin):
 
         if use_flash_attention and self.is_flash_attention_available(device):
             attn_implementation = "flash_attention_2"
+        elif device == "cuda" and not gpu_config.cuda_supports_bfloat16():
+            # Pre-Ampere GPUs (compute capability < 8.0) run in float16 which
+            # can overflow in SDPA's fused softmax with longer sequences,
+            # producing NaN/Inf latents (see issues #924, #927).  Eager
+            # attention upcasts to float32 for softmax, avoiding the overflow.
+            logger.info(
+                "[initialize_service] Pre-Ampere CUDA detected: using eager "
+                "attention for float16 numerical stability."
+            )
+            attn_implementation = "eager"
         else:
             if use_flash_attention:
                 logger.warning(

--- a/acestep/core/generation/handler/padding_utils.py
+++ b/acestep/core/generation/handler/padding_utils.py
@@ -75,10 +75,17 @@ class PaddingMixin:
                     if audio_duration is not None and float(audio_duration) > 0:
                         batch_target_wavs = self.create_target_wavs(float(audio_duration))
                     else:
-                        import random
-
-                        random_duration = random.uniform(10.0, 120.0)
-                        batch_target_wavs = self.create_target_wavs(random_duration)
+                        # Fall back to a sensible default instead of a random duration.
+                        # Random durations caused garbage output when duration=-1 was
+                        # passed without LM auto-detection (see issue #929).
+                        fallback_duration = 120.0
+                        logger.warning(
+                            "[padding] No valid audio_duration provided (got %s); "
+                            "using fallback duration %.0fs.",
+                            audio_duration,
+                            fallback_duration,
+                        )
+                        batch_target_wavs = self.create_target_wavs(fallback_duration)
                 target_wavs_batch.append(batch_target_wavs)
 
             # Stack target_wavs into batch tensor

--- a/acestep/null_duration_fixes_test.py
+++ b/acestep/null_duration_fixes_test.py
@@ -205,6 +205,30 @@ class ApiDefaultDurationTests(unittest.TestCase):
         )
         self.assertEqual(setup.params.duration, _API_DEFAULT_DURATION_SECONDS)
 
+    def test_negative_duration_gets_default(self):
+        """Negative duration (-1) should fall back to API default (issue #929)."""
+        setup = build_generation_setup(
+            req=self._base_req(),
+            caption="cap",
+            lyrics="lyr",
+            bpm=None,
+            key_scale="",
+            time_signature="",
+            audio_duration=-1.0,
+            thinking=False,
+            sample_mode=False,
+            format_has_duration=False,
+            use_cot_caption=False,
+            use_cot_language=False,
+            lm_top_k=0,
+            lm_top_p=0.9,
+            parse_timesteps=lambda _: None,
+            is_instrumental=lambda _: False,
+            default_dit_instruction="default instruction",
+            task_instructions={},
+        )
+        self.assertEqual(setup.params.duration, _API_DEFAULT_DURATION_SECONDS)
+
     def test_explicit_duration_preserved(self):
         """When audio_duration is explicitly set, it should be preserved."""
         setup = build_generation_setup(


### PR DESCRIPTION
## Summary
- **Fix #929**: `duration=-1` now falls back to 120s default instead of `random.uniform(10, 120)` which produced garbage noise output
- **Fix #924**: Pre-Ampere GPUs (compute capability < 8.0) now use eager attention instead of SDPA to avoid float16 softmax overflow with longer lyric sequences
- **Fix #927**: Turbo models now force `guidance_scale=1.0` since turbo does not use CFG — the default 7.0 caused noise/NaN on float16 hardware

## Changes

### `job_generation_setup.py`
- Fix duration check: `audio_duration if audio_duration` → `audio_duration if (audio_duration and audio_duration > 0)` to catch negative sentinel values

### `padding_utils.py`
- Replace `random.uniform(10.0, 120.0)` fallback with deterministic 120s default + warning log

### `init_service_loader.py`
- Detect pre-Ampere CUDA via `gpu_config.cuda_supports_bfloat16()` and force `eager` attention implementation (upcasts softmax to float32, preventing overflow)

### `generate_music.py`
- Detect turbo model via `is_turbo_model()` and override `guidance_scale` to 1.0 with info log

### Tests
- `null_duration_fixes_test.py`: Added `test_negative_duration_gets_default` for the -1 sentinel case
- `generate_music_test.py`: Added `TurboGuidanceScaleTests` with turbo override and non-turbo passthrough tests

## Test plan
- [x] `python acestep/core/generation/handler/generate_music_test.py` — 9 tests pass
- [ ] Manual test on pre-Ampere GPU with longer lyrics (Titan X / T4 / RTX 2070)
- [ ] Manual test with `duration=-1` without LM enabled

Closes #924, #927, #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio duration validation now properly requires non-null and positive values before applying.
  * Turbo models automatically override guidance scale to 1.0 for compatibility.
  * GPU devices without bfloat16 support now properly use eager attention mode.
  * Audio duration fallback now uses deterministic 120-second default instead of random values.

* **Tests**
  * Added test coverage for turbo model guidance scale behavior.
  * Added test coverage for negative duration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->