### PR TITLE
fix: support separate encoder_hidden_size for 4B models

### DIFF
--- a/acestep/models/base/modeling_acestep_v15_base.py
+++ b/acestep/models/base/modeling_acestep_v15_base.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import math
 import time
 from typing import Callable, List, Optional, Union
@@ -1279,7 +1280,8 @@ class AceStepDiTModel(AceStepPreTrainedModel):
         self.time_embed_r = TimestepEmbedding(in_channels=256, time_embed_dim=inner_dim)
 
         # Project encoder hidden states to model dimension
-        self.condition_embedder = nn.Linear(inner_dim, inner_dim, bias=True)
+        condition_dim = getattr(config, "encoder_hidden_size", config.hidden_size)
+        self.condition_embedder = nn.Linear(condition_dim, inner_dim, bias=True)
 
         # Output normalization and projection
         # Adaptive layer norm with scale-shift modulation, then de-patchify
@@ -1600,11 +1602,22 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
         self.config = config
         # Diffusion model components
         self.decoder = AceStepDiTModel(config)  # Main diffusion transformer
-        self.encoder = AceStepConditionEncoder(config)  # Condition encoder
-        self.tokenizer = AceStepAudioTokenizer(config)  # Audio tokenizer
-        self.detokenizer = AudioTokenDetokenizer(config)  # Audio detokenizer
+        # Build encoder config: use separate encoder_hidden_size when available
+        # (4B models have encoder_hidden_size=2048 != hidden_size=2560)
+        _enc_hs = getattr(config, "encoder_hidden_size", config.hidden_size)
+        if _enc_hs != config.hidden_size:
+            encoder_config = copy.deepcopy(config)
+            encoder_config.hidden_size = _enc_hs
+            encoder_config.intermediate_size = getattr(config, "encoder_intermediate_size", config.intermediate_size)
+            encoder_config.num_attention_heads = getattr(config, "encoder_num_attention_heads", config.num_attention_heads)
+            encoder_config.num_key_value_heads = getattr(config, "encoder_num_key_value_heads", config.num_key_value_heads)
+        else:
+            encoder_config = config
+        self.encoder = AceStepConditionEncoder(encoder_config)  # Condition encoder
+        self.tokenizer = AceStepAudioTokenizer(encoder_config)  # Audio tokenizer
+        self.detokenizer = AudioTokenDetokenizer(encoder_config)  # Audio detokenizer
         # Null condition embedding for classifier-free guidance
-        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, config.hidden_size))
+        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, encoder_config.hidden_size))
 
         # Initialize weights and apply final processing
         self.post_init()

--- a/acestep/models/sft/modeling_acestep_v15_base.py
+++ b/acestep/models/sft/modeling_acestep_v15_base.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import math
 import time
 from typing import Callable, List, Optional, Union
@@ -1279,7 +1280,8 @@ class AceStepDiTModel(AceStepPreTrainedModel):
         self.time_embed_r = TimestepEmbedding(in_channels=256, time_embed_dim=inner_dim)
 
         # Project encoder hidden states to model dimension
-        self.condition_embedder = nn.Linear(inner_dim, inner_dim, bias=True)
+        condition_dim = getattr(config, "encoder_hidden_size", config.hidden_size)
+        self.condition_embedder = nn.Linear(condition_dim, inner_dim, bias=True)
 
         # Output normalization and projection
         # Adaptive layer norm with scale-shift modulation, then de-patchify
@@ -1600,11 +1602,22 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
         self.config = config
         # Diffusion model components
         self.decoder = AceStepDiTModel(config)  # Main diffusion transformer
-        self.encoder = AceStepConditionEncoder(config)  # Condition encoder
-        self.tokenizer = AceStepAudioTokenizer(config)  # Audio tokenizer
-        self.detokenizer = AudioTokenDetokenizer(config)  # Audio detokenizer
+        # Build encoder config: use separate encoder_hidden_size when available
+        # (4B models have encoder_hidden_size=2048 != hidden_size=2560)
+        _enc_hs = getattr(config, "encoder_hidden_size", config.hidden_size)
+        if _enc_hs != config.hidden_size:
+            encoder_config = copy.deepcopy(config)
+            encoder_config.hidden_size = _enc_hs
+            encoder_config.intermediate_size = getattr(config, "encoder_intermediate_size", config.intermediate_size)
+            encoder_config.num_attention_heads = getattr(config, "encoder_num_attention_heads", config.num_attention_heads)
+            encoder_config.num_key_value_heads = getattr(config, "encoder_num_key_value_heads", config.num_key_value_heads)
+        else:
+            encoder_config = config
+        self.encoder = AceStepConditionEncoder(encoder_config)  # Condition encoder
+        self.tokenizer = AceStepAudioTokenizer(encoder_config)  # Audio tokenizer
+        self.detokenizer = AudioTokenDetokenizer(encoder_config)  # Audio detokenizer
         # Null condition embedding for classifier-free guidance
-        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, config.hidden_size))
+        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, encoder_config.hidden_size))
 
         # Initialize weights and apply final processing
         self.post_init()

--- a/acestep/models/turbo/modeling_acestep_v15_turbo.py
+++ b/acestep/models/turbo/modeling_acestep_v15_turbo.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import math
 import time
 from typing import Callable, List, Optional, Union
@@ -1276,7 +1277,8 @@ class AceStepDiTModel(AceStepPreTrainedModel):
         self.time_embed_r = TimestepEmbedding(in_channels=256, time_embed_dim=inner_dim)
         
         # Project encoder hidden states to model dimension
-        self.condition_embedder = nn.Linear(inner_dim, inner_dim, bias=True)
+        condition_dim = getattr(config, "encoder_hidden_size", config.hidden_size)
+        self.condition_embedder = nn.Linear(condition_dim, inner_dim, bias=True)
 
         # Output normalization and projection
         # Adaptive layer norm with scale-shift modulation, then de-patchify
@@ -1597,11 +1599,22 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
         self.config = config
         # Diffusion model components
         self.decoder = AceStepDiTModel(config)  # Main diffusion transformer
-        self.encoder = AceStepConditionEncoder(config)  # Condition encoder
-        self.tokenizer = AceStepAudioTokenizer(config)  # Audio tokenizer
-        self.detokenizer = AudioTokenDetokenizer(config)  # Audio detokenizer
+        # Build encoder config: use separate encoder_hidden_size when available
+        # (4B models have encoder_hidden_size=2048 != hidden_size=2560)
+        _enc_hs = getattr(config, "encoder_hidden_size", config.hidden_size)
+        if _enc_hs != config.hidden_size:
+            encoder_config = copy.deepcopy(config)
+            encoder_config.hidden_size = _enc_hs
+            encoder_config.intermediate_size = getattr(config, "encoder_intermediate_size", config.intermediate_size)
+            encoder_config.num_attention_heads = getattr(config, "encoder_num_attention_heads", config.num_attention_heads)
+            encoder_config.num_key_value_heads = getattr(config, "encoder_num_key_value_heads", config.num_key_value_heads)
+        else:
+            encoder_config = config
+        self.encoder = AceStepConditionEncoder(encoder_config)  # Condition encoder
+        self.tokenizer = AceStepAudioTokenizer(encoder_config)  # Audio tokenizer
+        self.detokenizer = AudioTokenDetokenizer(encoder_config)  # Audio detokenizer
         # Null condition embedding for classifier-free guidance
-        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, config.hidden_size))
+        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, encoder_config.hidden_size))
 
         # Initialize weights and apply final processing
         self.post_init()


### PR DESCRIPTION
## Summary

- Fix modeling files to support 4B models with separate `encoder_hidden_size` (2048) and `hidden_size` (2560)
- Use `getattr(config, 'encoder_hidden_size', config.hidden_size)` for backward-compatible config reading
- No changes to `configuration_acestep_v15.py` — `PretrainedConfig` already loads extra JSON fields via `**kwargs`

## Root Cause

Training code (`modeling_acestep_20260208_diffusion_4b.py`) creates a separate `encoder_config` via `deepcopy` with overridden dimensions, but inference modeling files passed the same `config` to both encoder and decoder, causing `RuntimeError: size mismatch` on load.

## Changes (3 files)

| Component | Before | After |
|---|---|---|
| `null_condition_emb` | `[1,1,config.hidden_size]` = [1,1,2560] | `[1,1,encoder_config.hidden_size]` = [1,1,2048] |
| `condition_embedder` | `Linear(hidden_size, hidden_size)` = Linear(2560,2560) | `Linear(encoder_hidden_size, hidden_size)` = Linear(2048,2560) |
| encoder/tokenizer/detokenizer | use `config` directly | use `encoder_config` (deepcopy with overridden dims) when `encoder_hidden_size != hidden_size` |

## Test Results

```
=== 4B model (acestep-v15-base-4B-900k-sft-60k) ===
  null_condition_emb: [1, 1, 2048] ✅
  condition_embedder: [2560, 2048] ✅

=== Old turbo model (acestep-v15-turbo-shift3) ===
  null_condition_emb: [1, 1, 2048] ✅
  condition_embedder: [2048, 2048] ✅ (backward compatible)

=== Lego model (acestep-v15-lego-cover-repaint) ===
  null_condition_emb: [1, 1, 2048] ✅
  condition_embedder: [2048, 2048] ✅
```

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for independent encoder and decoder hidden dimensions across all model variants. The model now allows encoder and decoder to operate with different embedding sizes, providing greater flexibility in architecture configuration and enabling more optimized designs tailored to specific application requirements without requiring matched dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->