### PR TITLE
feat: expose cot_caption and cot_lyrics in generation result

### DIFF
--- a/acestep/api/job_result_payload.py
+++ b/acestep/api/job_result_payload.py
@@ -122,4 +122,6 @@ def build_generation_success_response(
         "timesignature": _none_if_na_str(metas_out.get("timesignature")),
         "lm_model": lm_model_name,
         "dit_model": dit_model_name,
+        "cot_caption": getattr(params, "cot_caption", "") or "",
+        "cot_lyrics": getattr(params, "cot_lyrics", "") or "",
     }


### PR DESCRIPTION
## Summary

- Add `cot_caption` and `cot_lyrics` fields to generation success response
- Contains the LM-enhanced/rewritten caption and lyrics (CoT output)
- Backward compatible: defaults to empty string when CoT is disabled

## Fields

| Field | Description |
|---|---|
| `cot_caption` | LM-enhanced caption (expanded from user's short prompt) |
| `cot_lyrics` | LM-enhanced lyrics (not used yet, reserved) |

Existing `prompt` field already contains the enhanced caption, but `cot_caption` makes it explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include `cot_caption` and `cot_lyrics` fields, providing additional output data when available from generation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->