### PR TITLE
docs: document turbo guidance_scale=1.0 override

### DIFF
--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -196,7 +196,7 @@ User-provided values always win; LM only fills the fields that are empty/missing
 | Parameter Name | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `inference_steps` | int | `8` | Number of inference steps. Turbo model: 1-20 (recommended 8). Base model: 1-200 (recommended 32-64). |
-| `guidance_scale` | float | `7.0` | Prompt guidance coefficient. Only effective for base model. |
+| `guidance_scale` | float | `7.0` | Prompt guidance coefficient. Only effective for base model. **Note:** For turbo models, this value is automatically set to `1.0` regardless of the provided value. |
 | `use_random_seed` | bool | `true` | Whether to use random seed |
 | `seed` | int | `-1` | Specify seed (when use_random_seed=false) |
 | `batch_size` | int | `2` | Batch generation count (max 8) |

--- a/docs/en/INFERENCE.md
+++ b/docs/en/INFERENCE.md
@@ -353,7 +353,7 @@ class FormatSampleResult:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `inference_steps` | `int` | `8` | Number of denoising steps. Turbo model: 1-20 (recommended 8). Base model: 1-200 (recommended 32-64). Higher = better quality but slower. |
-| `guidance_scale` | `float` | `7.0` | Classifier-free guidance scale (1.0-15.0). Higher values increase adherence to text prompt. Only supported for non-turbo model. Typical range: 5.0-9.0. |
+| `guidance_scale` | `float` | `7.0` | Classifier-free guidance scale (1.0-15.0). Higher values increase adherence to text prompt. Only supported for non-turbo model. Typical range: 5.0-9.0. **Note:** For turbo models, this value is automatically set to `1.0` regardless of the provided value — any user-supplied setting is silently overridden. |
 | `seed` | `int` | `-1` | Random seed for reproducibility. Use `-1` for random seed, or any positive integer for fixed seed. |
 
 ### Advanced DiT Parameters


### PR DESCRIPTION
## Summary
- Add notes to `docs/en/API.md` and `docs/en/INFERENCE.md` documenting that turbo models automatically force `guidance_scale=1.0`, ignoring any user-provided value
- The override happens in `acestep/core/generation/handler/generate_music.py:202` (see issue #927)
- No Python code changes — documentation only

## Test plan
- [ ] Verify `docs/en/API.md` renders correctly with the added note
- [ ] Verify `docs/en/INFERENCE.md` renders correctly with the added note
- [ ] Confirm no other English docs reference `guidance_scale` without this caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `guidance_scale` parameter documentation across API and inference resources. For turbo model variants, the parameter is forcibly set to `1.0` regardless of user input, with any supplied values overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->