### PR TITLE
docs: document pre-Ampere eager attention fallback

### DIFF
--- a/docs/en/GPU_COMPATIBILITY.md
+++ b/docs/en/GPU_COMPATIBILITY.md
@@ -46,6 +46,30 @@ If you manually select an incompatible option (e.g., trying to use vllm on a 6GB
 - **Auto Chunk Size**: VAE decode chunk size adapts to available free VRAM (64/128/256/512/1024/1536)
 - **Duration/Batch Clamping**: If you request values exceeding your tier's limits, they are clamped with a warning
 
+## Pre-Ampere GPU Attention Fallback
+
+GPUs with CUDA compute capability below 8.0 (pre-Ampere architecture) automatically use **eager attention** instead of Scaled Dot Product Attention (SDPA). This is handled at model load time in `acestep/core/generation/handler/init_service_loader.py` and requires no user configuration.
+
+**Why:** Pre-Ampere GPUs run in float16 (they lack native bfloat16 support). SDPA's fused softmax kernel can overflow in float16 with longer sequences, producing NaN or Inf values in the latents and resulting in noise or silence in the generated audio. Eager attention avoids this by upcasting to float32 for the softmax computation.
+
+**Affected GPU families:**
+
+| GPU Family | Architecture | Compute Capability | Attention Mode |
+|---|---|---|---|
+| GeForce GTX 10xx (Pascal) | Pascal | 6.x | Eager (automatic) |
+| GeForce GTX 16xx (Turing) | Turing | 7.5 | Eager (automatic) |
+| GeForce RTX 20xx (Turing) | Turing | 7.5 | Eager (automatic) |
+| GeForce RTX 30xx (Ampere) | Ampere | 8.6 | SDPA or Flash Attention |
+| GeForce RTX 40xx (Ada Lovelace) | Ada Lovelace | 8.9 | SDPA or Flash Attention |
+
+**No action is needed** -- the fallback is fully automatic. You will see a log message at startup:
+
+```
+[initialize_service] Pre-Ampere CUDA detected: using eager attention for float16 numerical stability.
+```
+
+Eager attention is slightly slower than SDPA but produces correct output on these GPUs.
+
 ## Notes
 
 - **Default settings** are automatically configured based on detected GPU memory

--- a/docs/en/GPU_TROUBLESHOOTING.md
+++ b/docs/en/GPU_TROUBLESHOOTING.md
@@ -234,6 +234,33 @@ If none of the above solutions work:
 
 > **Note on `MAX_CUDA_VRAM`**: When set, this variable not only changes the tier detection logic but also calls `torch.cuda.set_per_process_memory_fraction()` to enforce a hard VRAM limit. This means OOM errors during simulation are realistic and reflect actual behavior on GPUs with that amount of VRAM. See [GPU_COMPATIBILITY.md](GPU_COMPATIBILITY.md) for the full tier table.
 
+## NaN / Noise Output on Pre-Ampere GPUs (Auto-Fixed)
+
+### Issue: Generated Audio Is Static Noise or Silence on Older NVIDIA GPUs
+
+**Symptoms:**
+- Generated audio contains only noise, static, or silence
+- You have a pre-Ampere NVIDIA GPU (GTX 10xx, GTX 16xx, or RTX 20xx series)
+- No explicit error messages in the console
+
+**Status:** Handled automatically (no user action needed)
+
+**Cause:**
+
+Pre-Ampere GPUs (compute capability < 8.0) lack native bfloat16 support, so the model runs in float16. SDPA's fused softmax kernel can overflow in float16 with longer sequences, producing NaN/Inf values in the latents.
+
+**Automatic Fix:**
+
+ACE-Step detects pre-Ampere GPUs at startup and automatically switches from SDPA to eager attention, which upcasts to float32 for the softmax computation. You will see this log message:
+
+```
+[initialize_service] Pre-Ampere CUDA detected: using eager attention for float16 numerical stability.
+```
+
+If you are still experiencing NaN/noise output despite seeing this message, please open an issue on GitHub with your GPU model and the full console log.
+
+**Reference:** See [GPU_COMPATIBILITY.md](GPU_COMPATIBILITY.md#pre-ampere-gpu-attention-fallback) for the full list of affected GPU families.
+
 ## LoRA Memory Issues (FIXED)
 
 ### Issue: High VRAM Usage with LoRA (25-30GB)


### PR DESCRIPTION
## Summary

- Documents the automatic eager attention fallback for pre-Ampere GPUs (compute capability < 8.0) in `docs/en/GPU_COMPATIBILITY.md`
- Adds a troubleshooting entry for NaN/noise output on older NVIDIA GPUs in `docs/en/GPU_TROUBLESHOOTING.md`
- Covers affected GPU families: GTX 10xx (Pascal), GTX 16xx (Turing), RTX 20xx (Turing)

## Context

The fallback logic lives in `acestep/core/generation/handler/init_service_loader.py:146-155` and uses `gpu_config.cuda_supports_bfloat16()` (which checks `torch.cuda.get_device_capability() >= 8`). Pre-Ampere GPUs run in float16, where SDPA's fused softmax can overflow and produce NaN latents. Eager attention avoids this by upcasting to float32 for softmax. This behavior was not previously documented.

## Test plan

- [ ] Verify GPU_COMPATIBILITY.md renders correctly on GitHub
- [ ] Verify GPU_TROUBLESHOOTING.md renders correctly on GitHub
- [ ] Confirm no Python code was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GPU compatibility guide for pre-Ampere NVIDIA GPUs explaining automatic attention optimization behavior
  * Added troubleshooting section addressing audio quality issues on older GPU models with automatic resolution details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->