### PR TITLE
docs: add missing environment variables

### DIFF
--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -697,6 +697,33 @@ The API server can be configured using environment variables:
 | `ACESTEP_AVG_JOB_SECONDS` | `5.0` | Initial average job duration estimate |
 | `ACESTEP_AVG_WINDOW` | `50` | Window for averaging job duration |
 
+### Generation Configuration
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `ACESTEP_NO_INIT` | `true` (API server) | Skip model loading at startup; models are lazy-loaded on first request. Set to `false` to force eager loading. CLI `--no-init` flag also accepted. |
+| `ACESTEP_COMPILE_MODEL` | `false` | Enable `torch.compile` for the DiT model. Can improve throughput on supported hardware. |
+| `ACESTEP_GENERATION_TIMEOUT` | `600` | Maximum wall-clock seconds to wait for a single generation before it is considered hung. |
+| `ACESTEP_SAVE_MEMORY` | `false` | Skip storing intermediate tensors and disable auto_lrc/auto_score to reduce RAM usage. Fixes system RAM leaks when using CPU offload. Set to `1` or `true` to enable. |
+
+### Platform-Specific Configuration
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `ACESTEP_ROCM_DTYPE` | `float32` | Override the compute dtype on AMD ROCm GPUs. Accepted values: `float32`, `bfloat16`, `float16`. Defaults to `float32` to avoid segfaults on GPUs with incomplete bfloat16 kernel support. |
+| `ACESTEP_MLX_VAE_FP16` | `0` | Enable FP16 VAE on Apple Silicon (MLX). Set to `1` or `true` to enable half-precision VAE decode/encode. |
+| `ACESTEP_VAE_DECODE_CHUNK_SIZE` | auto | Override the VAE decode chunk size (integer). When unset, chunk size is chosen automatically based on available free memory. |
+
+### Diagnostics
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `ACESTEP_DISABLE_TQDM` | `false` | Suppress tqdm progress bars during inference. Also automatically disabled when stderr is not a TTY. |
+| `ACESTEP_DEBUG_STATS` | `false` | Enable memory and timing debug statistics during generation. |
+| `MAX_CUDA_VRAM` | (unset) | Simulate a CUDA GPU with the specified VRAM in GB for testing. Also enforces a hard VRAM cap via `torch.cuda.set_per_process_memory_fraction()`. |
+| `MAX_MPS_VRAM` | (unset) | Simulate Apple Silicon MPS GPU memory size in GB for testing. |
+| `MAX_XPU_VRAM` | (unset) | Simulate Intel XPU memory size in GB for testing. |
+
 ### Cache Configuration
 
 | Variable | Default | Description |

--- a/docs/en/GPU_COMPATIBILITY.md
+++ b/docs/en/GPU_COMPATIBILITY.md
@@ -64,6 +64,7 @@ If you manually select an incompatible option (e.g., trying to use vllm on a 6GB
 3. **Medium VRAM (8-16GB)**: Use the 0.6B or 1.7B LM model. `vllm` backend works well on Tier 4+.
 4. **High VRAM (16-24GB)**: Enable larger LM models (1.7B recommended). Quantization becomes optional on 20GB+.
 5. **Very High VRAM (≥24GB)**: All models fit without offloading or quantization. Use 4B LM for best quality.
+6. **CPU Offload RAM Leak**: When using CPU offload (`ACESTEP_OFFLOAD_TO_CPU=true`), system RAM usage can grow over time because intermediate tensors are retained on the CPU between generations. Set `ACESTEP_SAVE_MEMORY=1` to skip storing these intermediate tensors and disable auto_lrc/auto_score, which eliminates the RAM leak.
 
 ## Debug Mode: Simulating Different GPU Configurations
 

--- a/docs/en/GRADIO_GUIDE.md
+++ b/docs/en/GRADIO_GUIDE.md
@@ -309,8 +309,8 @@ This is where I belong
 | Option | Default | Description |
 |--------|---------|-------------|
 | **LM Codes Strength** | 1.0 | How strongly LM codes influence generation (0.0-1.0) |
-| **Auto Score** | ✗ | Automatically calculate quality scores |
-| **Auto LRC** | ✗ | Automatically generate lyrics timestamps |
+| **Auto Score** | ✗ | Automatically calculate quality scores. Disabled when `ACESTEP_SAVE_MEMORY=1`. |
+| **Auto LRC** | ✗ | Automatically generate lyrics timestamps. Disabled when `ACESTEP_SAVE_MEMORY=1`. |
 | **LM Batch Chunk Size** | 8 | Max items per LM batch (GPU memory) |
 
 ### Main Generation Controls


### PR DESCRIPTION
## Summary
- Add 11 undocumented environment variables to `docs/en/API.md` in three new subsections: Generation Configuration, Platform-Specific Configuration, and Diagnostics
- Add `ACESTEP_SAVE_MEMORY=1` RAM leak fix note to `docs/en/GPU_COMPATIBILITY.md` memory optimization tips
- Note that Auto Score and Auto LRC are disabled under `ACESTEP_SAVE_MEMORY=1` in `docs/en/GRADIO_GUIDE.md`

## New env vars documented
`ACESTEP_SAVE_MEMORY`, `ACESTEP_NO_INIT`, `ACESTEP_COMPILE_MODEL`, `ACESTEP_GENERATION_TIMEOUT`, `ACESTEP_ROCM_DTYPE`, `ACESTEP_MLX_VAE_FP16`, `ACESTEP_VAE_DECODE_CHUNK_SIZE`, `ACESTEP_DISABLE_TQDM`, `ACESTEP_DEBUG_STATS`, `MAX_MPS_VRAM`, `MAX_XPU_VRAM`

## Test plan
- [ ] Verify each env var description matches source code behavior
- [ ] Confirm markdown table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation with new environment variables for generation configuration, platform-specific settings, and diagnostics.
  * Added memory optimization guidance for CPU offload workflows.
  * Clarified behavior of Auto Score and Auto LRC features under memory-saving conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->