### PR TITLE
feat: slot-aware DiT initialization for multi-handler API

### DIFF
--- a/acestep/api/http/model_init_service.py
+++ b/acestep/api/http/model_init_service.py
@@ -12,6 +12,46 @@ from acestep.gpu_config import (
 )
 
 
+def _resolve_slot(
+    app_state: Any,
+    slot: Optional[int],
+    get_model_name: Callable[[str], str],
+) -> tuple:
+    """Return ``(handler, config_attr, init_attr, error_attr, current_config_path)`` for *slot*.
+
+    Raises ``RuntimeError`` when the requested slot's handler was never
+    constructed (environment variable not set at startup).
+    """
+
+    slot = slot or 1
+    if slot == 1:
+        return (
+            app_state.handler,
+            "_config_path",
+            "_initialized",
+            "_init_error",
+            getattr(app_state, "_config_path", ""),
+        )
+
+    handler_attr = f"handler{slot}"
+    handler = getattr(app_state, handler_attr, None)
+    if handler is None:
+        env_var = f"ACESTEP_CONFIG_PATH{slot}"
+        raise RuntimeError(
+            f"Slot {slot} is not available because {env_var} was not set at "
+            f"startup. Restart the API with {env_var} to enable this slot."
+        )
+
+    suffix = str(slot)
+    return (
+        handler,
+        f"_config_path{suffix}",
+        f"_initialized{suffix}",
+        f"_init_error{suffix}",
+        getattr(app_state, f"_config_path{suffix}", ""),
+    )
+
+
 def initialize_models_for_request(
     app_state: Any,
     model_name: Optional[str],
@@ -21,6 +61,7 @@ def initialize_models_for_request(
     get_model_name: Callable[[str], str],
     ensure_model_downloaded: Callable[[str, str], str],
     env_bool: Callable[[str, bool], bool],
+    slot: Optional[int] = None,
 ) -> Dict[str, Optional[str]]:
     """Initialize DiT and optional LM models.
 
@@ -33,20 +74,26 @@ def initialize_models_for_request(
         get_model_name: Normalizes a model path to its model name.
         ensure_model_downloaded: Ensures a named model exists under checkpoints.
         env_bool: Reads boolean environment variables.
+        slot: Handler slot to initialize (1, 2, or 3).  Defaults to 1.
     Returns:
-        Mapping with keys ``loaded_model`` and ``loaded_lm_model``.
+        Mapping with keys ``slot``, ``loaded_model`` and ``loaded_lm_model``.
     Raises:
-        RuntimeError: When model names are invalid or DiT/LLM initialization fails.
+        RuntimeError: When model names are invalid, slot is unavailable, or
+            DiT/LLM initialization fails.
         AttributeError: When required app state attributes are missing (legacy behavior).
     """
 
-    handler = app_state.handler
+    resolved_slot = slot or 1
+    handler, config_attr, init_attr, error_attr, current_config = _resolve_slot(
+        app_state, resolved_slot, get_model_name,
+    )
+
     llm = app_state.llm_handler
     project_root = get_project_root()
     checkpoint_dir = os.path.join(project_root, "checkpoints")
     os.makedirs(checkpoint_dir, exist_ok=True)
 
-    target_model = (model_name or get_model_name(getattr(app_state, "_config_path", ""))).strip()
+    target_model = (model_name or get_model_name(current_config)).strip()
     if not target_model:
         raise RuntimeError("No DiT model specified")
 
@@ -72,11 +119,12 @@ def initialize_models_for_request(
         offload_dit_to_cpu=offload_dit_to_cpu,
     )
     if not ok:
-        raise RuntimeError(f"DiT init failed: {status_msg}")
+        setattr(app_state, error_attr, status_msg)
+        raise RuntimeError(f"DiT init failed for slot {resolved_slot}: {status_msg}")
 
-    app_state._config_path = target_model
-    app_state._initialized = True
-    app_state._init_error = None
+    setattr(app_state, config_attr, target_model)
+    setattr(app_state, init_attr, True)
+    setattr(app_state, error_attr, None)
 
     loaded_lm_model: Optional[str] = None
     if init_llm:
@@ -114,4 +162,4 @@ def initialize_models_for_request(
             app_state._llm_lazy_load_disabled = False
         loaded_lm_model = lm_model_name or lm_model_path
 
-    return {"loaded_model": target_model, "loaded_lm_model": loaded_lm_model}
+    return {"slot": resolved_slot, "loaded_model": target_model, "loaded_lm_model": loaded_lm_model}

--- a/acestep/api/http/model_init_service_test.py
+++ b/acestep/api/http/model_init_service_test.py
@@ -128,6 +128,150 @@ class ModelInitServiceTests(unittest.TestCase):
         self.assertFalse(state._llm_initialized)
         self.assertEqual("llm-failed", state._llm_init_error)
 
+    def test_slot1_default_uses_primary_handler(self):
+        """Slot 1 (default) should initialize the primary handler and set _config_path."""
+
+        state = SimpleNamespace(
+            handler=_FakeHandler(),
+            llm_handler=_FakeLlm(),
+            _llm_init_lock=threading.Lock(),
+            _config_path="",
+            _init_error=None,
+        )
+        with mock.patch("acestep.api.http.model_init_service.os.makedirs"):
+            result = initialize_models_for_request(
+                app_state=state,
+                model_name="acestep-v15-base",
+                init_llm=False,
+                requested_lm_model_path=None,
+                get_project_root=lambda: "/tmp/non-existent",
+                get_model_name=lambda p: str(p).split("/")[-1].split("\\")[-1],
+                ensure_model_downloaded=lambda *_: "",
+                env_bool=lambda *_: False,
+                slot=None,
+            )
+
+        self.assertEqual(1, result["slot"])
+        self.assertEqual("acestep-v15-base", result["loaded_model"])
+        self.assertTrue(state._initialized)
+        self.assertEqual("acestep-v15-base", state._config_path)
+
+    def test_slot2_uses_secondary_handler(self):
+        """Slot 2 should initialize handler2 and set _config_path2."""
+
+        handler2 = _FakeHandler()
+        state = SimpleNamespace(
+            handler=_FakeHandler(),
+            handler2=handler2,
+            llm_handler=_FakeLlm(),
+            _llm_init_lock=threading.Lock(),
+            _config_path="acestep-v15-turbo",
+            _config_path2="",
+            _initialized2=False,
+            _init_error2=None,
+        )
+        with mock.patch("acestep.api.http.model_init_service.os.makedirs"):
+            result = initialize_models_for_request(
+                app_state=state,
+                model_name="acestep-v15-base",
+                init_llm=False,
+                requested_lm_model_path=None,
+                get_project_root=lambda: "/tmp/non-existent",
+                get_model_name=lambda p: str(p).split("/")[-1].split("\\")[-1],
+                ensure_model_downloaded=lambda *_: "",
+                env_bool=lambda *_: False,
+                slot=2,
+            )
+
+        self.assertEqual(2, result["slot"])
+        self.assertEqual("acestep-v15-base", result["loaded_model"])
+        self.assertTrue(state._initialized2)
+        self.assertEqual("acestep-v15-base", state._config_path2)
+
+    def test_slot3_uses_third_handler(self):
+        """Slot 3 should initialize handler3 and set _config_path3."""
+
+        handler3 = _FakeHandler()
+        state = SimpleNamespace(
+            handler=_FakeHandler(),
+            handler3=handler3,
+            llm_handler=_FakeLlm(),
+            _llm_init_lock=threading.Lock(),
+            _config_path="acestep-v15-turbo",
+            _config_path3="",
+            _initialized3=False,
+            _init_error3=None,
+        )
+        with mock.patch("acestep.api.http.model_init_service.os.makedirs"):
+            result = initialize_models_for_request(
+                app_state=state,
+                model_name="acestep-v15-base",
+                init_llm=False,
+                requested_lm_model_path=None,
+                get_project_root=lambda: "/tmp/non-existent",
+                get_model_name=lambda p: str(p).split("/")[-1].split("\\")[-1],
+                ensure_model_downloaded=lambda *_: "",
+                env_bool=lambda *_: False,
+                slot=3,
+            )
+
+        self.assertEqual(3, result["slot"])
+        self.assertEqual("acestep-v15-base", result["loaded_model"])
+        self.assertTrue(state._initialized3)
+        self.assertEqual("acestep-v15-base", state._config_path3)
+
+    def test_slot2_raises_when_handler_not_constructed(self):
+        """Slot 2 should raise RuntimeError when handler2 is None."""
+
+        state = SimpleNamespace(
+            handler=_FakeHandler(),
+            handler2=None,
+            llm_handler=_FakeLlm(),
+            _llm_init_lock=threading.Lock(),
+            _config_path="",
+        )
+        with mock.patch("acestep.api.http.model_init_service.os.makedirs"):
+            with self.assertRaises(RuntimeError) as ctx:
+                initialize_models_for_request(
+                    app_state=state,
+                    model_name="acestep-v15-base",
+                    init_llm=False,
+                    requested_lm_model_path=None,
+                    get_project_root=lambda: "/tmp/non-existent",
+                    get_model_name=lambda p: str(p).split("/")[-1].split("\\")[-1],
+                    ensure_model_downloaded=lambda *_: "",
+                    env_bool=lambda *_: False,
+                    slot=2,
+                )
+        self.assertIn("Slot 2", str(ctx.exception))
+        self.assertIn("ACESTEP_CONFIG_PATH2", str(ctx.exception))
+
+    def test_slot3_raises_when_handler_not_constructed(self):
+        """Slot 3 should raise RuntimeError when handler3 is None."""
+
+        state = SimpleNamespace(
+            handler=_FakeHandler(),
+            handler3=None,
+            llm_handler=_FakeLlm(),
+            _llm_init_lock=threading.Lock(),
+            _config_path="",
+        )
+        with mock.patch("acestep.api.http.model_init_service.os.makedirs"):
+            with self.assertRaises(RuntimeError) as ctx:
+                initialize_models_for_request(
+                    app_state=state,
+                    model_name="acestep-v15-base",
+                    init_llm=False,
+                    requested_lm_model_path=None,
+                    get_project_root=lambda: "/tmp/non-existent",
+                    get_model_name=lambda p: str(p).split("/")[-1].split("\\")[-1],
+                    ensure_model_downloaded=lambda *_: "",
+                    env_bool=lambda *_: False,
+                    slot=3,
+                )
+        self.assertIn("Slot 3", str(ctx.exception))
+        self.assertIn("ACESTEP_CONFIG_PATH3", str(ctx.exception))
+
     def test_init_llm_uses_pt_backend_for_legacy_cuda_gpu(self):
         """Legacy CUDA GPU configs should coerce LM init away from vllm."""
 

--- a/acestep/api/http/model_service_routes.py
+++ b/acestep/api/http/model_service_routes.py
@@ -18,6 +18,14 @@ class InitModelRequest(BaseModel):
     """Request payload for on-demand DiT/LM model initialization."""
 
     model: Optional[str] = Field(default=None, description="DiT model name to initialize (e.g., 'acestep-v15-base')")
+    slot: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=3,
+        description="Handler slot to initialize (1, 2, or 3). Defaults to 1. "
+        "Slots 2 and 3 require ACESTEP_CONFIG_PATH2 / ACESTEP_CONFIG_PATH3 "
+        "to have been set at startup so that the handler was constructed.",
+    )
     init_llm: bool = Field(default=False, description="Whether to initialize LLM as part of this request")
     lm_model_path: Optional[str] = Field(default=None, description="LLM model path/name (e.g., 'acestep-5Hz-lm-1.7B')")
 
@@ -193,6 +201,7 @@ def register_model_service_routes(
                     lambda: initialize_models_for_request(
                         app_state=app.state,
                         model_name=request.model,
+                        slot=request.slot,
                         init_llm=request.init_llm,
                         requested_lm_model_path=request.lm_model_path,
                         get_project_root=get_project_root,
@@ -205,6 +214,7 @@ def register_model_service_routes(
                 return wrap_response(
                     {
                         "message": "Model initialization completed",
+                        "slot": result.get("slot", 1),
                         "loaded_model": result.get("loaded_model"),
                         "loaded_lm_model": result.get("loaded_lm_model"),
                         "models": inventory["models"],
@@ -212,5 +222,10 @@ def register_model_service_routes(
                         "llm_initialized": inventory["llm_initialized"],
                     }
                 )
+            except RuntimeError as exc:
+                msg = str(exc)
+                if "slot" in msg.lower() and "not available" in msg.lower():
+                    return wrap_response(None, code=400, error=msg)
+                return wrap_response(None, code=500, error=f"Model initialization failed: {msg}")
             except Exception as exc:
                 return wrap_response(None, code=500, error=f"Model initialization failed: {str(exc)}")

--- a/acestep/api/http/model_service_routes_http_test.py
+++ b/acestep/api/http/model_service_routes_http_test.py
@@ -180,6 +180,67 @@ class ModelServiceRoutesHttpTests(unittest.TestCase):
         self.assertEqual(500, payload["code"])
         self.assertIn("Model initialization failed", payload["error"])
 
+    def test_init_route_passes_slot_to_initializer(self):
+        """POST /v1/init with slot should forward slot to the initializer."""
+
+        client = self._build_client()
+        with mock.patch(
+            "acestep.api.http.model_service_routes.initialize_models_for_request",
+            return_value={"slot": 2, "loaded_model": "acestep-v15-base", "loaded_lm_model": None},
+        ) as mock_init:
+            response = client.post(
+                "/v1/init",
+                headers={"Authorization": "Bearer test-token"},
+                json={"model": "acestep-v15-base", "slot": 2, "init_llm": False},
+            )
+
+        self.assertEqual(200, response.status_code)
+        payload = response.json()
+        self.assertEqual(200, payload["code"])
+        self.assertEqual(2, payload["data"]["slot"])
+        # Verify slot was passed through to the service function
+        call_kwargs = mock_init.call_args.kwargs
+        self.assertEqual(2, call_kwargs["slot"])
+
+    def test_init_route_returns_400_for_unavailable_slot(self):
+        """POST /v1/init for a disabled slot should return code=400."""
+
+        client = self._build_client()
+        with mock.patch(
+            "acestep.api.http.model_service_routes.initialize_models_for_request",
+            side_effect=RuntimeError(
+                "Slot 2 is not available because ACESTEP_CONFIG_PATH2 was not set at startup."
+            ),
+        ):
+            response = client.post(
+                "/v1/init",
+                headers={"Authorization": "Bearer test-token"},
+                json={"model": "acestep-v15-base", "slot": 2, "init_llm": False},
+            )
+
+        self.assertEqual(200, response.status_code)
+        payload = response.json()
+        self.assertEqual(400, payload["code"])
+        self.assertIn("Slot 2", payload["error"])
+
+    def test_init_route_rejects_invalid_slot_values(self):
+        """POST /v1/init with slot outside 1-3 should return HTTP 422."""
+
+        client = self._build_client()
+        response = client.post(
+            "/v1/init",
+            headers={"Authorization": "Bearer test-token"},
+            json={"model": "acestep-v15-base", "slot": 4, "init_llm": False},
+        )
+        self.assertEqual(422, response.status_code)
+
+        response = client.post(
+            "/v1/init",
+            headers={"Authorization": "Bearer test-token"},
+            json={"model": "acestep-v15-base", "slot": 0, "init_llm": False},
+        )
+        self.assertEqual(422, response.status_code)
+
     def test_init_route_returns_wrapped_error_when_llm_init_fails(self):
         """POST /v1/init with init_llm should wrap LLM initialization failures."""
 

--- a/acestep/api/lifespan_runtime.py
+++ b/acestep/api/lifespan_runtime.py
@@ -108,6 +108,8 @@ def initialize_lifespan_runtime(
     app.state.handler3 = handler3
     app.state._initialized2 = False
     app.state._initialized3 = False
+    app.state._init_error2 = None
+    app.state._init_error3 = None
     app.state._config_path = os.getenv("ACESTEP_CONFIG_PATH", "acestep-v15-turbo")
     app.state._config_path2 = config_path2
     app.state._config_path3 = config_path3

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -565,16 +565,80 @@ curl http://localhost:8001/v1/models
 
 ---
 
-## 9. Server Statistics
+## 9. Initialize or Switch Models
 
 ### 9.1 API Definition
+
+- **URL**: `/v1/init`
+- **Method**: `POST`
+
+Initialize or switch DiT and LM models on demand without restarting the server.
+
+### 9.2 Request Parameters
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `model` | string | null | DiT model name to load (e.g., `"acestep-v15-base"`). If omitted, re-initializes the current model for the target slot. |
+| `slot` | int (1-3) | 1 | Handler slot to initialize. Slots 2 and 3 require `ACESTEP_CONFIG_PATH2` / `ACESTEP_CONFIG_PATH3` to have been set at startup. |
+| `init_llm` | bool | false | Whether to also initialize the LM in this request. |
+| `lm_model_path` | string | null | LM model path override (e.g., `"acestep-5Hz-lm-1.7B"`). |
+
+### 9.3 Response Example
+
+```json
+{
+  "data": {
+    "message": "Model initialization completed",
+    "slot": 2,
+    "loaded_model": "acestep-v15-base",
+    "loaded_lm_model": null,
+    "models": [
+      {"name": "acestep-v15-base", "is_default": false, "is_loaded": true},
+      {"name": "acestep-v15-turbo", "is_default": true, "is_loaded": true}
+    ],
+    "lm_models": [],
+    "llm_initialized": false
+  },
+  "code": 200,
+  "error": null,
+  "timestamp": 1700000000000,
+  "extra": null
+}
+```
+
+### 9.4 Usage Examples
+
+```bash
+# Initialize default slot (slot 1)
+curl -X POST http://localhost:8001/v1/init \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "acestep-v15-base"}'
+
+# Load a different model into slot 2
+curl -X POST http://localhost:8001/v1/init \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "acestep-v15-base", "slot": 2}'
+
+# Initialize slot 1 with LM
+curl -X POST http://localhost:8001/v1/init \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "acestep-v15-turbo", "init_llm": true, "lm_model_path": "acestep-5Hz-lm-1.7B"}'
+```
+
+> **Note**: Slots 2 and 3 are only available when `ACESTEP_CONFIG_PATH2` / `ACESTEP_CONFIG_PATH3` environment variables were set before starting the server. Attempting to initialize an unavailable slot returns a `400` error.
+
+---
+
+## 10. Server Statistics
+
+### 10.1 API Definition
 
 - **URL**: `/v1/stats`
 - **Method**: `GET`
 
 Returns server runtime statistics.
 
-### 9.2 Response Example
+### 10.2 Response Example
 
 ```json
 {
@@ -597,7 +661,7 @@ Returns server runtime statistics.
 }
 ```
 
-### 9.3 Usage Example
+### 10.3 Usage Example
 
 ```bash
 curl http://localhost:8001/v1/stats
@@ -605,22 +669,22 @@ curl http://localhost:8001/v1/stats
 
 ---
 
-## 10. Download Audio Files
+## 11. Download Audio Files
 
-### 10.1 API Definition
+### 11.1 API Definition
 
 - **URL**: `/v1/audio`
 - **Method**: `GET`
 
 Download generated audio files by path.
 
-### 10.2 Request Parameters
+### 11.2 Request Parameters
 
 | Parameter Name | Type | Description |
 | :--- | :--- | :--- |
 | `path` | string | URL-encoded path to the audio file |
 
-### 10.3 Usage Example
+### 11.3 Usage Example
 
 ```bash
 # Download using the URL from task result
@@ -629,16 +693,16 @@ curl "http://localhost:8001/v1/audio?path=%2Ftmp%2Fapi_audio%2Fabc123.mp3" -o ou
 
 ---
 
-## 11. Health Check
+## 12. Health Check
 
-### 11.1 API Definition
+### 12.1 API Definition
 
 - **URL**: `/health`
 - **Method**: `GET`
 
 Returns service health status.
 
-### 11.2 Response Example
+### 12.2 Response Example
 
 ```json
 {
@@ -656,7 +720,7 @@ Returns service health status.
 
 ---
 
-## 12. Environment Variables
+## 13. Environment Variables
 
 The API server can be configured using environment variables:
 


### PR DESCRIPTION
## Summary

Closes #973

- Add optional `slot` parameter (1, 2, or 3) to `POST /v1/init` so operators can initialize or reload DiT weights for handler slots 2 and 3 without restarting the API process
- Return `400` with a clear message when the target slot's handler was not constructed at startup (Option A from the issue)
- Add `_init_error2` / `_init_error3` tracking to app state for per-slot error reporting
- Document the new `/v1/init` endpoint with slot examples in `docs/en/API.md`

## Test plan

- [x] Unit tests for slot routing in `model_init_service_test.py` (slot 1/2/3 success, slot 2/3 unavailable)
- [x] HTTP integration tests in `model_service_routes_http_test.py` (slot forwarding, 400 for disabled slot, 422 for invalid slot values)
- [x] All 23 existing + new tests pass
- [x] All modified modules import successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-slot model initialization support, enabling management of up to 3 model instances simultaneously.
  * Introduced optional `slot` parameter to model initialization endpoint for selecting which model instance to configure.
  * Enhanced error handling with clearer feedback for unavailable slots.

* **Documentation**
  * Updated API documentation with new initialization parameters and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->