### PR TITLE
fix: pin diffusers>=0.37.0 for torchao 0.16.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "torchaudio>=2.9.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     # Common dependencies
     "transformers>=4.51.0,<4.58.0",
-    "diffusers",
+    "diffusers>=0.37.0",
     "gradio==6.2.0",
     "matplotlib>=3.7.5",
     "scipy>=1.10.1",


### PR DESCRIPTION
## Summary

- Pin `diffusers>=0.37.0` in `pyproject.toml` to fix model initialization crash introduced by #974

## Root Cause

PR #974 bumped `torchao` from `<0.16.0` to `>=0.16.0`, but left `diffusers` unpinned. This created a dependency incompatibility:

| | torchao <0.16.0 | torchao >=0.16.0 |
|---|---|---|
| diffusers <0.37.0 | ✅ Works | ❌ **Crashes** |
| diffusers >=0.37.0 | ✅ Works | ✅ Works |

`torchao` 0.16.0 removed `torchao.dtypes.uintx.uint4_layout`, which `diffusers` 0.36.0 imports at module level. The import failure triggers a `NameError` (`logger` not yet defined), crashing VAE model loading:

```
RuntimeError: Failed to import diffusers.models.autoencoders.autoencoder_oobleck
NameError: name 'logger' is not defined
```

`diffusers` 0.37.0+ fixed this via [huggingface/diffusers#11018](https://github.com/huggingface/diffusers/pull/11018) by gating the import behind `is_torchao_version(">", "0.15.0")`.

## Fix

```diff
-    "diffusers",
+    "diffusers>=0.37.0",
```

## Test plan

- [ ] `uv sync` resolves diffusers >=0.37.0
- [ ] `python -c "from diffusers.models import AutoencoderOobleck"` succeeds
- [ ] Gradio server starts and model initialization completes without errors

Fixes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirement for the diffusers dependency to ensure compatibility with version 0.37.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->