### PR TITLE
feat: add VRAM warning for XL (4B) DiT model selection in UI

### DIFF
--- a/acestep/ui/gradio/events/generation/model_config.py
+++ b/acestep/ui/gradio/events/generation/model_config.py
@@ -79,6 +79,18 @@ def is_sft_model(config_path_lower: str) -> bool:
     return _has_token("sft", config_path_lower) and not _has_token("turbo", config_path_lower)
 
 
+def is_xl_model(config_path_lower: str) -> bool:
+    """Check whether a model path refers to an XL (4B DiT) variant.
+
+    Args:
+        config_path_lower: Lowercased model config path string.
+
+    Returns:
+        ``True`` when the path contains ``"xl"`` as a delimited token.
+    """
+    return _has_token("xl", config_path_lower)
+
+
 def get_ui_control_config(is_turbo: bool, is_pure_base: bool = False, is_sft: bool = False) -> dict:
     """Return UI control configuration (values, limits, visibility) for model type.
 

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -15,7 +15,7 @@ from acestep.gpu_config import (
     get_gpu_config_for_tier, set_global_gpu_config, GPU_TIER_LABELS, GPU_TIER_CONFIGS,
     resolve_lm_backend,
 )
-from .model_config import is_pure_base_model, is_sft_model, get_model_type_ui_settings
+from .model_config import is_pure_base_model, is_sft_model, is_xl_model, get_model_type_ui_settings
 
 
 def _select_quantization_value(
@@ -161,6 +161,15 @@ def init_service_wrapper(
     )
 
     gpu_config = get_global_gpu_config()
+
+    # Warn if XL (4B) model selected on a GPU with limited VRAM
+    if is_xl_model(config_path_lower) and gpu_config is not None:
+        gpu_mem = getattr(gpu_config, "gpu_memory_gb", 0)
+        if 0 < gpu_mem < 16:
+            gr.Warning(
+                f"XL (4B) model requires ≥16GB VRAM (detected {gpu_mem:.0f}GB). "
+                "Consider using a 2B model, or enable CPU offload."
+            )
     lm_actually_initialized = llm_handler.llm_initialized if llm_handler else False
     max_duration = gpu_config.max_duration_with_lm if lm_actually_initialized else gpu_config.max_duration_without_lm
     max_batch = gpu_config.max_batch_size_with_lm if lm_actually_initialized else gpu_config.max_batch_size_without_lm


### PR DESCRIPTION
## Summary
- Add `is_xl_model()` detection function to `model_config.py`
- Show `gr.Warning` when XL model is selected on GPU with <16GB VRAM
- Minimal change — no dropdown filtering, just a warning on init

## Test plan
- [x] Verified `is_xl_model()` correctly detects XL paths and rejects non-XL paths
- [x] Warning only triggers when `gpu_memory_gb < 16` and model path contains "xl" token
- [x] No warning for 2B models or GPUs with ≥16GB VRAM

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for XL model variants with comprehensive GPU memory validation. When using XL models with insufficient GPU VRAM (less than 16GB), the system now alerts users with helpful recommendations to ensure optimal performance, suggesting either switching to a smaller 2B model or enabling CPU offload for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->