### PR TITLE
docs: add News section with XL (4B DiT) release announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@
     <img src="./assets/organization_logos.png" width="100%" alt="StepFun Logo">
 </p>
 
+## 📰 News
+
+- **[2026-04-02] 🎉 ACE-Step 1.5 XL (4B DiT) Released!** — We introduce the XL series with a 4B-parameter DiT decoder for higher audio quality. Three variants available: [xl-base](https://huggingface.co/ACE-Step/acestep-v15-xl-base), [xl-sft](https://huggingface.co/ACE-Step/acestep-v15-xl-sft), [xl-turbo](https://huggingface.co/ACE-Step/acestep-v15-xl-turbo). Requires ≥12GB VRAM (with offload), ≥20GB recommended. All LM models fully compatible. See [Model Zoo](#-model-zoo) for details.
+
 ## Table of Contents
 
+- [📰 News](#-news)
 - [✨ Features](#-features)
 - [⚡ Quick Start](#-quick-start)
 - [🚀 Launch Scripts](#-launch-scripts)


### PR DESCRIPTION
## Summary
- Add 📰 News section to README.md (first entry: XL release)
- Links to all 3 XL HuggingFace repos (xl-base, xl-sft, xl-turbo)
- Add News to Table of Contents

## Context
All XL models have been uploaded to HuggingFace:
- https://huggingface.co/ACE-Step/acestep-v15-xl-base
- https://huggingface.co/ACE-Step/acestep-v15-xl-sft
- https://huggingface.co/ACE-Step/acestep-v15-xl-turbo

## Test plan
- [x] Markdown renders correctly
- [x] All HF links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new News section to the documentation to showcase the latest model releases and announcements
  * Introduced the ACE-Step 1.5 XL (4B DiT) variant with links to three new XL model variants for download and use
  * Provided comprehensive VRAM requirements and system compatibility information to help users select the appropriate models for their setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->