### PR TITLE
fix: default Gradio model to acestep-v15-xl-turbo

### DIFF
--- a/acestep/ui/gradio/interfaces/generation_defaults.py
+++ b/acestep/ui/gradio/interfaces/generation_defaults.py
@@ -118,9 +118,13 @@ def resolve_is_pure_base_model(
 
     available_models = dit_handler.get_available_acestep_v15_models()
     default_model = (
-        "acestep-v15-turbo"
-        if "acestep-v15-turbo" in available_models
-        else (available_models[0] if available_models else None)
+        "acestep-v15-xl-turbo"
+        if "acestep-v15-xl-turbo" in available_models
+        else (
+            "acestep-v15-turbo"
+            if "acestep-v15-turbo" in available_models
+            else (available_models[0] if available_models else None)
+        )
     )
     actual_model = init_params.get("config_path", default_model) if init_params else default_model
     return is_pure_base_model((actual_model or "").lower())

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -108,9 +108,13 @@ def build_model_device_controls(
     with gr.Row():
         available_models = dit_handler.get_available_acestep_v15_models()
         default_model = (
-            "acestep-v15-turbo"
-            if "acestep-v15-turbo" in available_models
-            else (available_models[0] if available_models else None)
+            "acestep-v15-xl-turbo"
+            if "acestep-v15-xl-turbo" in available_models
+            else (
+                "acestep-v15-turbo"
+                if "acestep-v15-turbo" in available_models
+                else (available_models[0] if available_models else None)
+            )
         )
         config_path = gr.Dropdown(
             label=t("service.model_path_label"),


### PR DESCRIPTION
## Summary
- Update default model selection in Gradio UI to prefer `acestep-v15-xl-turbo` over `acestep-v15-turbo`
- Falls back gracefully: xl-turbo -> turbo -> first available model
- Affects both `generation_service_config_rows.py` and `generation_defaults.py`

Fixes #1008

## Test plan
- [ ] Launch Gradio UI with XL turbo model available, verify it is selected by default
- [ ] Launch without XL turbo model, verify fallback to `acestep-v15-turbo`
- [ ] Launch with neither turbo model, verify fallback to first available model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default model selection logic to prioritize the turbo model variant when available, with automatic fallback to alternative options if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->