### PR TITLE
docs: remove unreleased acestep-v15-turbo-rl from Model Zoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ See also the **LoRA Training** tab in Gradio UI for one-click training, or [Grad
 | `acestep-v15-base` | ✅ | ❌ | ❌ | ✅ | 50 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Medium | High | Easy | [Link](https://huggingface.co/ACE-Step/acestep-v15-base) |
 | `acestep-v15-sft` | ✅ | ✅ | ❌ | ✅ | 50 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | High | Medium | Easy | [Link](https://huggingface.co/ACE-Step/acestep-v15-sft) |
 | `acestep-v15-turbo` | ✅ | ✅ | ❌ | ❌ | 8 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | Very High | Medium | Medium | [Link](https://huggingface.co/ACE-Step/Ace-Step1.5) |
-| `acestep-v15-turbo-rl` | ✅ | ✅ | ✅ | ❌ | 8 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | Very High | Medium | Medium | To be released |
 
 ### XL (4B) DiT Models
 


### PR DESCRIPTION
## Summary
- Remove `acestep-v15-turbo-rl` entry (marked "To be released") from the DiT Models table in README
- This model will not be released

Fixes #1010

## Test plan
- [ ] Verify README Model Zoo table renders correctly without the removed row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a model entry from the available models list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->