### PR TITLE
fix: sync mp3 child control visibility on preference restore

### DIFF
--- a/acestep/ui/gradio/interfaces/user_preferences.py
+++ b/acestep/ui/gradio/interfaces/user_preferences.py
@@ -148,11 +148,14 @@ def _build_restore_js(num_outputs: int) -> str:
             }});
             // If none of the keys had stored values, skip entirely.
             if (result.every(v => v === null)) return SKIP;
-            // Compute mp3_controls_row visibility from audio_format (index 0).
-            // When audioFormat is null (no stored value), push null so Python
+            // Compute mp3 control visibility from audio_format (index 0).
+            // Push 3 extra values: mp3_controls_row, mp3_bitrate, mp3_sample_rate
+            // matching the outputs of _update_mp3_control_visibility().
+            // When audioFormat is null (no stored value), push nulls so Python
             // emits gr.update() and preserves whatever init_params set.
             const audioFormat = result[0];
-            result.push(audioFormat === null ? null : audioFormat === "mp3");
+            const mp3 = audioFormat === null ? null : audioFormat === "mp3";
+            result.push(mp3, mp3, mp3);
             return result;
         }} catch (_e) {{
             return SKIP;
@@ -163,13 +166,14 @@ def _build_restore_js(num_outputs: int) -> str:
 def restore_preferences(*values: Any) -> tuple[Any, ...]:
     """Map JS restore results into Gradio output values.
 
-    The JS function reads localStorage and produces an array.  Values
-    that are ``None`` (JSON ``null``) mean "no stored preference for this
-    key" -- we return ``gr.update()`` so Gradio leaves the component
-    unchanged, preserving whatever ``init_params`` set.
+    The JS function reads localStorage and produces an array:
+      - First ``len(PREF_KEYS)`` elements are preference values (or null).
+      - Next 3 elements are mp3 visibility booleans (or null):
+        [mp3_controls_row, mp3_bitrate, mp3_sample_rate].
 
-    The last element (beyond ``PREF_KEYS``) is the mp3_controls_row
-    visibility boolean -- converted to ``gr.update(visible=...)``.
+    ``None`` (JSON ``null``) → ``gr.update()`` (no-op, preserves current).
+    Booleans beyond PREF_KEYS → visibility/interactivity updates matching
+    ``_update_mp3_control_visibility()`` from the output controls module.
     """
     import gradio as gr
 
@@ -178,9 +182,12 @@ def restore_preferences(*values: Any) -> tuple[Any, ...]:
     for i, v in enumerate(values):
         if v is None:
             results.append(gr.update())
-        elif i >= n_prefs and isinstance(v, bool):
-            # Extra outputs beyond PREF_KEYS are visibility flags.
+        elif i == n_prefs and isinstance(v, bool):
+            # mp3_controls_row: visibility only.
             results.append(gr.update(visible=v))
+        elif i > n_prefs and isinstance(v, bool):
+            # mp3_bitrate, mp3_sample_rate: visibility + interactivity.
+            results.append(gr.update(visible=v, interactive=v))
         else:
             results.append(v)
     return tuple(results)
@@ -221,13 +228,16 @@ def wire_preference_restore(
             )
         outputs.append(component)
 
-    # Also update mp3_controls_row visibility so it stays in sync when the
+    # Also update mp3 control visibility so it stays in sync when the
     # restored audio_format differs from the server-rendered default.
     # Gradio does not fire .change() for load-time value assignments, so
-    # without this the MP3 row could be visible/hidden incorrectly.
-    mp3_row = generation_section.get("mp3_controls_row")
-    if mp3_row is not None:
-        outputs.append(mp3_row)
+    # without this the MP3 row and its children could be visible/hidden
+    # incorrectly.  The three extra outputs mirror the return of
+    # _update_mp3_control_visibility(): [row, bitrate, sample_rate].
+    for mp3_key in ("mp3_controls_row", "mp3_bitrate", "mp3_sample_rate"):
+        comp = generation_section.get(mp3_key)
+        if comp is not None:
+            outputs.append(comp)
 
     demo.load(
         fn=restore_preferences,

--- a/acestep/ui/gradio/interfaces/user_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/user_preferences_test.py
@@ -107,7 +107,7 @@ class SaveScriptTests(unittest.TestCase):
         self.assertEqual(script_1, script_2)
 
 
-_NUM_OUTPUTS = len(PREF_KEYS) + 1  # +1 for mp3_controls_row
+_NUM_OUTPUTS = len(PREF_KEYS) + 3  # +3 for mp3_controls_row, mp3_bitrate, mp3_sample_rate
 
 
 class RestoreTests(unittest.TestCase):
@@ -177,16 +177,27 @@ class RestoreTests(unittest.TestCase):
             self.assertIsInstance(v, dict, "None should be converted to gr.update()")
             self.assertEqual(v["__type__"], "update")
 
-    def test_restore_preferences_converts_visibility_bool(self):
-        """The trailing boolean for mp3_controls_row should become
-        gr.update(visible=...) not a raw bool."""
-        values = ("mp3", "128k", 48000, 0.5, True, -1.0, 0.0, 0.0, 0.0, 1.0, 8, True)
+    def test_restore_preferences_converts_visibility_bools(self):
+        """The trailing booleans for mp3 controls should become
+        gr.update(visible=...) not raw bools."""
+        # 11 pref values + 3 mp3 visibility bools
+        values = ("mp3", "128k", 48000, 0.5, True, -1.0, 0.0, 0.0, 0.0, 1.0, 8, True, True, True)
         result = restore_preferences(*values)
-        last = result[-1]
-        # Should NOT be a raw bool; should be a gr.update(visible=True) dict.
-        self.assertIsInstance(last, dict)
-        self.assertEqual(last["__type__"], "update")
-        self.assertTrue(last["visible"])
+        # mp3_controls_row (index 11): visible only
+        row_update = result[11]
+        self.assertIsInstance(row_update, dict)
+        self.assertTrue(row_update["visible"])
+        self.assertNotIn("interactive", row_update)
+        # mp3_bitrate (index 12): visible + interactive
+        bitrate_update = result[12]
+        self.assertIsInstance(bitrate_update, dict)
+        self.assertTrue(bitrate_update["visible"])
+        self.assertTrue(bitrate_update["interactive"])
+        # mp3_sample_rate (index 13): visible + interactive
+        sr_update = result[13]
+        self.assertIsInstance(sr_update, dict)
+        self.assertTrue(sr_update["visible"])
+        self.assertTrue(sr_update["interactive"])
 
     def test_pref_keys_match_defaults(self):
         """Every PREF_KEY must have a corresponding default."""


### PR DESCRIPTION
## Summary
Follow-up to #1025. Codex re-review found that restoring `audio_format=mp3` only updated `mp3_controls_row` visibility but left the child dropdowns (`mp3_bitrate`, `mp3_sample_rate`) hidden/disabled.

- Include `mp3_bitrate` and `mp3_sample_rate` as extra restore outputs alongside `mp3_controls_row`
- JS pushes 3 visibility booleans (row, bitrate, sample_rate) matching `_update_mp3_control_visibility()`
- Python maps row → `gr.update(visible=...)`, children → `gr.update(visible=..., interactive=...)`

## Test plan
- [x] All 21 unit tests pass
- [ ] Manual: save prefs with FLAC, reload — MP3 row and children should be hidden
- [ ] Manual: save prefs with MP3, reload — MP3 row and children should be visible and interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MP3 audio format preferences with improved control over bitrate and sample rate visibility and interactivity during preference restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->