### PR TITLE
fix: support AAC/M4A source audio in remix/extract flows

### DIFF
--- a/acestep/core/generation/handler/io_audio.py
+++ b/acestep/core/generation/handler/io_audio.py
@@ -2,12 +2,58 @@
 
 import math
 import random
-from typing import Optional
-from pathlib import Path
+from typing import Optional, Tuple
 
+import numpy as np
 import torch
 import soundfile as sf
 from loguru import logger
+
+
+def _read_audio_file(audio_file: str) -> Tuple[np.ndarray, int]:
+    """Read an audio file, with torchaudio fallback for formats unsupported by soundfile.
+
+    soundfile (libsndfile) supports WAV/FLAC/OGG/MP3 etc. but NOT AAC/M4A/MP4.
+    When soundfile fails, we fall back to torchaudio.load() which uses torchcodec
+    and can handle virtually any format via FFmpeg.
+
+    Args:
+        audio_file: Path to the audio file.
+
+    Returns:
+        Tuple of (audio_np in float32 with shape [samples] or [samples, channels],
+        sample_rate).
+
+    Raises:
+        RuntimeError: If both soundfile and torchaudio fail to read the file.
+    """
+    # Fast path: try soundfile directly (no torchcodec/FFmpeg overhead)
+    sf_err = None
+    try:
+        audio_np, sr = sf.read(audio_file, dtype="float32")
+        return audio_np, sr
+    except Exception as exc:
+        sf_err = exc
+        logger.debug(
+            "[_read_audio_file] soundfile cannot read '{}': {}. Trying torchaudio fallback.",
+            audio_file, sf_err,
+        )
+
+    # Slow path: torchaudio (uses torchcodec -> FFmpeg under the hood)
+    try:
+        import torchaudio
+
+        waveform, sr = torchaudio.load(audio_file)
+        # torchaudio returns [channels, samples], convert to numpy [samples, channels]
+        audio_np = waveform.numpy().T  # -> [samples, channels]
+        if audio_np.shape[1] == 1:
+            audio_np = audio_np.squeeze(1)  # -> [samples] for mono
+        return audio_np.astype(np.float32), sr
+    except Exception as ta_err:
+        raise RuntimeError(
+            f"Cannot read '{audio_file}': soundfile ({sf_err}) "
+            f"and torchaudio ({ta_err}) both failed."
+        ) from ta_err
 
 
 class IoAudioMixin:
@@ -41,6 +87,13 @@ class IoAudioMixin:
 
         return torch.clamp(audio, -1.0, 1.0)
 
+    @staticmethod
+    def _numpy_to_channels_first(audio_np: np.ndarray) -> torch.Tensor:
+        """Convert numpy audio array to channels-first torch tensor."""
+        if audio_np.ndim == 1:
+            return torch.from_numpy(audio_np).unsqueeze(0)
+        return torch.from_numpy(audio_np.T)
+
     def process_target_audio(self, audio_file: Optional[str]) -> Optional[torch.Tensor]:
         """Load and normalize target audio file.
 
@@ -54,15 +107,10 @@ class IoAudioMixin:
             return None
 
         try:
-            import soundfile as sf
-
-            audio_np, sr = sf.read(audio_file, dtype="float32")
-            if audio_np.ndim == 1:
-                audio = torch.from_numpy(audio_np).unsqueeze(0)
-            else:
-                audio = torch.from_numpy(audio_np.T)
+            audio_np, sr = _read_audio_file(audio_file)
+            audio = self._numpy_to_channels_first(audio_np)
             return self._normalize_audio_to_stereo_48k(audio, sr)
-        except (OSError, RuntimeError, ValueError):
+        except Exception:
             logger.exception("[process_target_audio] Error processing target audio")
             return None
 
@@ -82,12 +130,8 @@ class IoAudioMixin:
             return None
 
         try:
-            # Use soundfile instead of torchaudio to avoid torchcodec dependency
-            audio_np, sr = sf.read(audio_file, dtype="float32")
-            if audio_np.ndim == 1:
-                audio = torch.from_numpy(audio_np).unsqueeze(0)
-            else:
-                audio = torch.from_numpy(audio_np.T)
+            audio_np, sr = _read_audio_file(audio_file)
+            audio = self._numpy_to_channels_first(audio_np)
 
             logger.debug(
                 f"[process_reference_audio] Reference audio shape: {audio.shape}"
@@ -125,7 +169,7 @@ class IoAudioMixin:
             back_audio = audio[:, back_start : back_start + segment_frames]
 
             return torch.cat([front_audio, middle_audio, back_audio], dim=-1)
-        except (OSError, RuntimeError, ValueError) as exc:
+        except Exception as exc:
             logger.warning(
                 f"[process_reference_audio] Invalid or unsupported reference audio: {exc}"
             )
@@ -144,13 +188,9 @@ class IoAudioMixin:
             return None
 
         try:
-            # Use soundfile instead of torchaudio to avoid torchcodec dependency
-            audio_np, sr = sf.read(audio_file, dtype="float32")
-            if audio_np.ndim == 1:
-                audio = torch.from_numpy(audio_np).unsqueeze(0)
-            else:
-                audio = torch.from_numpy(audio_np.T)
+            audio_np, sr = _read_audio_file(audio_file)
+            audio = self._numpy_to_channels_first(audio_np)
             return self._normalize_audio_to_stereo_48k(audio, sr)
-        except (OSError, RuntimeError, ValueError):
+        except Exception:
             logger.exception("[process_src_audio] Error processing source audio")
             return None

--- a/acestep/core/generation/handler/io_audio_test.py
+++ b/acestep/core/generation/handler/io_audio_test.py
@@ -1,14 +1,15 @@
 """Unit tests for audio IO mixin extraction."""
 
-import sys
+import os
+import tempfile
 import types
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import torch
 
-from acestep.core.generation.handler.io_audio import IoAudioMixin
+from acestep.core.generation.handler.io_audio import IoAudioMixin, _read_audio_file
 
 
 class _Host(IoAudioMixin):
@@ -19,12 +20,45 @@ class _Host(IoAudioMixin):
         return torch.all(audio.abs() < 1e-6).item()
 
 
-def _fake_torchaudio_module(load_fn):
-    """Create fake ``torchaudio`` module with minimal API used by tests."""
-    module = types.ModuleType("torchaudio")
-    module.load = load_fn
-    module.transforms = types.SimpleNamespace(Resample=lambda *_args, **_kwargs: (lambda x: x))
-    return module
+class ReadAudioFileTests(unittest.TestCase):
+    """Tests for the _read_audio_file fallback logic."""
+
+    def test_reads_wav_via_soundfile(self):
+        """WAV files should be read directly by soundfile."""
+        import soundfile as sf
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        try:
+            data = np.random.randn(48000).astype(np.float32)
+            sf.write(tmp.name, data, 48000)
+            audio_np, sr = _read_audio_file(tmp.name)
+            self.assertEqual(sr, 48000)
+            self.assertEqual(audio_np.shape[0], 48000)
+        finally:
+            os.unlink(tmp.name)
+
+    def test_falls_back_to_torchaudio_on_soundfile_failure(self):
+        """When soundfile fails, torchaudio.load should be tried."""
+        fake_waveform = torch.randn(1, 44100)
+
+        with patch("acestep.core.generation.handler.io_audio.sf") as mock_sf:
+            mock_sf.read.side_effect = Exception("Format not recognised")
+            with patch("torchaudio.load", return_value=(fake_waveform, 44100)) as mock_load:
+                audio_np, sr = _read_audio_file("test.aac")
+
+        self.assertEqual(sr, 44100)
+        self.assertEqual(audio_np.shape[0], 44100)
+        mock_load.assert_called_once_with("test.aac")
+
+    def test_raises_when_both_fail(self):
+        """Should raise RuntimeError when both soundfile and torchaudio fail."""
+        with patch("acestep.core.generation.handler.io_audio.sf") as mock_sf:
+            mock_sf.read.side_effect = Exception("sf fail")
+            with patch("torchaudio.load", side_effect=RuntimeError("ta fail")):
+                with self.assertRaises(RuntimeError) as ctx:
+                    _read_audio_file("bad.xyz")
+                self.assertIn("sf fail", str(ctx.exception))
+                self.assertIn("ta fail", str(ctx.exception))
 
 
 class IoAudioMixinTests(unittest.TestCase):
@@ -44,10 +78,8 @@ class IoAudioMixinTests(unittest.TestCase):
         """Target audio should be loaded and normalized through helper."""
         host = _Host()
         fake_np = np.array([0.1, -0.1, 0.2], dtype=np.float32)
-        fake_sf = types.ModuleType("soundfile")
-        fake_sf.read = lambda *_args, **_kwargs: (fake_np, 32000)
 
-        with patch.dict(sys.modules, {"soundfile": fake_sf}):
+        with patch("acestep.core.generation.handler.io_audio._read_audio_file", return_value=(fake_np, 48000)):
             with patch.object(host, "_normalize_audio_to_stereo_48k", return_value=torch.zeros(2, 3)) as norm:
                 result = host.process_target_audio("fake.wav")
 
@@ -57,17 +89,15 @@ class IoAudioMixinTests(unittest.TestCase):
     def test_process_src_audio_handles_load_error(self):
         """Source audio processing should return None on load failure."""
         host = _Host()
-        fake_ta = _fake_torchaudio_module(lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
-        with patch.dict(sys.modules, {"torchaudio": fake_ta}):
-            result = host.process_src_audio("bad.wav")
+        with patch("acestep.core.generation.handler.io_audio._read_audio_file", side_effect=RuntimeError("bad")):
+            result = host.process_src_audio("bad.aac")
         self.assertIsNone(result)
 
     def test_process_reference_audio_returns_none_for_silence(self):
         """Reference audio should short-circuit for silent input."""
         host = _Host()
-        silent = torch.zeros(2, 16, dtype=torch.float32)
-        fake_ta = _fake_torchaudio_module(lambda *_args, **_kwargs: (silent, 48000))
-        with patch.dict(sys.modules, {"torchaudio": fake_ta}):
+        silent_np = np.zeros((16, 2), dtype=np.float32)
+        with patch("acestep.core.generation.handler.io_audio._read_audio_file", return_value=(silent_np, 48000)):
             result = host.process_reference_audio("silent.wav")
         self.assertIsNone(result)
 
@@ -76,9 +106,10 @@ class IoAudioMixinTests(unittest.TestCase):
         host = _Host()
         base = torch.linspace(-1.0, 1.0, 1_800_000, dtype=torch.float32)
         audio = torch.stack([base, -base], dim=0)
-        fake_ta = _fake_torchaudio_module(lambda *_args, **_kwargs: (audio, 48000))
+        # _read_audio_file returns numpy in [samples, channels]
+        audio_np = audio.T.numpy()
 
-        with patch.dict(sys.modules, {"torchaudio": fake_ta}):
+        with patch("acestep.core.generation.handler.io_audio._read_audio_file", return_value=(audio_np, 48000)):
             with patch("acestep.core.generation.handler.io_audio.random.randint", side_effect=[10, 20, 30]):
                 result = host.process_reference_audio("ref.wav")
 
@@ -97,10 +128,26 @@ class IoAudioMixinTests(unittest.TestCase):
     def test_process_reference_audio_returns_none_on_load_error(self):
         """Reference audio processing should return None when loading fails."""
         host = _Host()
-        fake_ta = _fake_torchaudio_module(lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad")))
-        with patch.dict(sys.modules, {"torchaudio": fake_ta}):
-            result = host.process_reference_audio("bad.wav")
+        with patch("acestep.core.generation.handler.io_audio._read_audio_file", side_effect=RuntimeError("bad")):
+            result = host.process_reference_audio("bad.aac")
         self.assertIsNone(result)
+
+    def test_process_src_audio_returns_none_for_none_input(self):
+        """None input should return None without error."""
+        host = _Host()
+        result = host.process_src_audio(None)
+        self.assertIsNone(result)
+
+
+class ReadAudioFileIntegrationTest(unittest.TestCase):
+    """Integration test with real AAC file (requires ffmpeg on system)."""
+
+    @unittest.skipUnless(os.path.exists("/tmp/test_aac.aac"), "test AAC file not present")
+    def test_reads_aac_file(self):
+        """AAC file should be readable via torchaudio fallback."""
+        audio_np, sr = _read_audio_file("/tmp/test_aac.aac")
+        self.assertGreater(sr, 0)
+        self.assertGreater(audio_np.shape[0], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix "invalid source audio" error when users upload AAC/M4A files for remix/extract tasks
- Root cause: `soundfile.read()` (libsndfile) does not support AAC format, returns error, and the caller treats it as invalid audio
- Add `_read_audio_file()` helper with fallback chain: soundfile (fast, WAV/FLAC/OGG/MP3) → torchaudio.load() (torchcodec/FFmpeg, handles AAC/M4A/MP4 and virtually any format)
- All three audio loading methods (`process_src_audio`, `process_reference_audio`, `process_target_audio`) now use the shared helper

## Test plan

- [x] Unit tests: 11 tests pass including mock fallback tests
- [x] Integration test: real AAC file read successfully via torchaudio fallback
- [ ] Manual: upload AAC file as source audio for remix task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio file compatibility with broader format support through automatic fallback detection.

* **Bug Fixes**
  * Improved error handling and recovery in audio processing operations with more informative failure messages.

* **Tests**
  * Expanded test coverage for audio file reading, format fallback behavior, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->