### PR TITLE
fix: handle empty values in restore_preferences to prevent Gradio crash on load

### DIFF
--- a/acestep/ui/gradio/interfaces/user_preferences.py
+++ b/acestep/ui/gradio/interfaces/user_preferences.py
@@ -14,6 +14,7 @@ hacking required.
 from __future__ import annotations
 
 import json
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -163,7 +164,9 @@ def _build_restore_js(num_outputs: int) -> str:
     }}"""
 
 
-def restore_preferences(*values: Any) -> tuple[Any, ...]:
+def restore_preferences(
+    *values: Any, _num_outputs: int = 0
+) -> tuple[Any, ...]:
     """Map JS restore results into Gradio output values.
 
     The JS function reads localStorage and produces an array:
@@ -174,8 +177,16 @@ def restore_preferences(*values: Any) -> tuple[Any, ...]:
     ``None`` (JSON ``null``) → ``gr.update()`` (no-op, preserves current).
     Booleans beyond PREF_KEYS → visibility/interactivity updates matching
     ``_update_mp3_control_visibility()`` from the output controls module.
+
+    When the JS side returns no values (e.g. certain Gradio versions do not
+    forward the JS return value to the Python ``fn`` when ``inputs=None``),
+    ``_num_outputs`` is used to produce the correct number of no-op updates
+    so Gradio does not raise a ``ValueError`` about mismatched output count.
     """
     import gradio as gr
+
+    if not values:
+        return tuple(gr.update() for _ in range(_num_outputs))
 
     n_prefs = len(PREF_KEYS)
     results: list[Any] = []
@@ -240,7 +251,7 @@ def wire_preference_restore(
             outputs.append(comp)
 
     demo.load(
-        fn=restore_preferences,
+        fn=partial(restore_preferences, _num_outputs=len(outputs)),
         inputs=None,
         outputs=outputs,
         js=_build_restore_js(num_outputs=len(outputs)),

--- a/acestep/ui/gradio/interfaces/user_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/user_preferences_test.py
@@ -199,6 +199,20 @@ class RestoreTests(unittest.TestCase):
         self.assertTrue(sr_update["visible"])
         self.assertTrue(sr_update["interactive"])
 
+    def test_restore_preferences_empty_values_returns_noop_updates(self):
+        """When called with no values (JS did not forward args), the function
+        should return ``_num_outputs`` gr.update() no-ops instead of crashing."""
+        result = restore_preferences(_num_outputs=_NUM_OUTPUTS)
+        self.assertEqual(len(result), _NUM_OUTPUTS)
+        for v in result:
+            self.assertIsInstance(v, dict)
+            self.assertEqual(v["__type__"], "update")
+
+    def test_restore_preferences_empty_values_no_num_outputs(self):
+        """With no values and no _num_outputs hint, return empty tuple."""
+        result = restore_preferences()
+        self.assertEqual(len(result), 0)
+
     def test_pref_keys_match_defaults(self):
         """Every PREF_KEY must have a corresponding default."""
         for key in PREF_KEYS:


### PR DESCRIPTION
## Summary

Fixes #1029

- `restore_preferences` now accepts a `_num_outputs` keyword argument (passed via `functools.partial`) so it can return the correct number of `gr.update()` no-ops when Gradio calls it with zero arguments
- This happens when certain Gradio versions don't forward JS return values to the Python `fn` when `inputs=None` is used with `demo.load()`
- Added 2 new unit tests covering the empty-values edge case

## Test plan

- [x] All 23 existing + new unit tests pass (`user_preferences_test.py`)
- [ ] Launch Gradio UI and verify no crash on page load
- [ ] Verify preferences still restore correctly from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user preference restoration to gracefully handle cases where preferences cannot be loaded, preventing application failures.

* **Tests**
  * Added test coverage for preference restoration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->