### PR TITLE
fix: use src_audio duration for cover/repaint instead of caller-supplied value

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -304,6 +304,18 @@ class GenerateMusicMixin:
             if audio_error is not None:
                 return audio_error
 
+            # For cover/repaint/extract tasks, the output duration must match
+            # the source audio — ignore any caller-supplied audio_duration.
+            if processed_src_audio is not None and task_type in ("cover", "repaint", "lego", "extract"):
+                src_duration = processed_src_audio.shape[-1] / self.sample_rate
+                if audio_duration is not None and audio_duration != src_duration:
+                    logger.info(
+                        "[generate_music] %s task: overriding audio_duration=%.1f "
+                        "with src_audio duration=%.1f",
+                        task_type, audio_duration, src_duration,
+                    )
+                audio_duration = src_duration
+
             service_inputs = self._prepare_generate_music_service_inputs(
                 actual_batch_size=actual_batch_size,
                 processed_src_audio=processed_src_audio,


### PR DESCRIPTION
## Summary

- For cover/repaint/extract/lego tasks, override `audio_duration` with the actual source audio length
- Previously a caller-supplied `audio_duration` (e.g. 120s default) would flow into metadata conditioning and padding, causing output truncated to that value instead of matching the source audio
- Example: 3:45 source audio → remix output was exactly 2:00 (120s) because `audio_duration=120` was used

## Changes

### `acestep/core/generation/handler/generate_music.py`
- After `_prepare_reference_and_source_audio`, when `processed_src_audio` exists and task is cover/repaint/lego/extract, override `audio_duration` with `processed_src_audio.shape[-1] / sample_rate`

## Test plan

- [x] 15 handler unit tests pass
- [ ] Manual: cover task with 3:45 source audio should produce 3:45 output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio duration handling for cover, repaint, lego, and extract operations. The system now automatically computes duration from source audio and logs information when user-provided values differ from calculated duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->