### PR TITLE
fix: silently lock duration to src_audio for cover/repaint/lego/extract

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -304,17 +304,11 @@ class GenerateMusicMixin:
             if audio_error is not None:
                 return audio_error
 
-            # For cover/repaint/extract tasks, the output duration must match
-            # the source audio — ignore any caller-supplied audio_duration.
-            if processed_src_audio is not None and task_type in ("cover", "repaint", "lego", "extract"):
-                src_duration = processed_src_audio.shape[-1] / self.sample_rate
-                if audio_duration is not None and audio_duration != src_duration:
-                    logger.info(
-                        "[generate_music] %s task: overriding audio_duration=%.1f "
-                        "with src_audio duration=%.1f",
-                        task_type, audio_duration, src_duration,
-                    )
-                audio_duration = src_duration
+            # Cover/repaint/lego/extract: lock duration to source audio.
+            if processed_src_audio is not None and task_type in (
+                "cover", "repaint", "lego", "extract",
+            ):
+                audio_duration = processed_src_audio.shape[-1] / self.sample_rate
 
             service_inputs = self._prepare_generate_music_service_inputs(
                 actual_batch_size=actual_batch_size,

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -603,6 +603,12 @@ def generate_music(
             logger.info(f"[generate_music] {params.task_type} task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")
             logger.info(f"[generate_music] Final inputs: dit_input_caption='{dit_input_caption}', dit_input_lyrics='{dit_input_lyrics}'")
 
+        # Cover/repaint/lego/extract: duration is locked to the source audio
+        # length.  Silently ignore whatever the caller passed — the handler
+        # will set audio_duration from the loaded waveform.
+        if params.task_type in ("cover", "repaint", "lego", "extract"):
+            audio_duration = None
+
         # Phase 2: DiT music generation
         # Use seed_for_generation (from config.seed or params.seed) instead of params.seed for actual generation
         dit_generate_kwargs = {


### PR DESCRIPTION
## Summary

Followup to #1031. For cover/repaint/lego/extract tasks, output duration must always match the source audio — silently ignore any caller-supplied value.

- **`inference.py`**: nullify `audio_duration` before passing to handler, so no stale UI/API value leaks through
- **`generate_music.py`**: set `audio_duration` from the actual `processed_src_audio` waveform length (also fixes #1031's loguru `%s` format bug by replacing verbose logging with a silent override)

## Changes

| Layer | What |
|---|---|
| `inference.py:606-611` | `audio_duration = None` for src-audio tasks |
| `generate_music.py:307-311` | `audio_duration = processed_src_audio.shape[-1] / self.sample_rate` |

## Test plan

- [x] 9 handler unit tests pass
- [x] 23 preference unit tests pass
- [ ] Manual: cover/repaint with any caller-supplied duration produces output matching src_audio length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duration handling for cover, repaint, lego, and extract tasks. These operations now consistently derive duration from the source audio waveform rather than user-provided values.

* **Refactor**
  * Simplified internal duration logic for improved code consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->