### PR TITLE
fix: return error when cover/repaint/extract tasks lack source audio

### DIFF
--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -111,6 +111,7 @@ class GenerateMusicRequestMixin:
             refer_audios = [[torch.zeros(2, 30 * self.sample_rate)] for _ in range(actual_batch_size)]
 
         processed_src_audio = None
+        _src_audio_required_tasks = {"cover", "repaint", "lego", "extract"}
         if task_type == "text2music":
             if src_audio is not None:
                 logger.info("[generate_music] text2music task does not use src_audio, ignoring")
@@ -132,6 +133,17 @@ class GenerateMusicRequestMixin:
                         "success": False,
                         "error": "Invalid source audio",
                     }
+        elif task_type in _src_audio_required_tasks:
+            return None, None, {
+                "audios": [],
+                "status_message": (
+                    f"Task '{task_type}' requires source audio, but none was provided. "
+                    f"Please upload a source audio file."
+                ),
+                "extra_outputs": {},
+                "success": False,
+                "error": f"Task '{task_type}' requires source audio",
+            }
 
         return refer_audios, processed_src_audio, None
 

--- a/acestep/core/generation/handler/padding_utils.py
+++ b/acestep/core/generation/handler/padding_utils.py
@@ -80,8 +80,8 @@ class PaddingMixin:
                         # passed without LM auto-detection (see issue #929).
                         fallback_duration = 120.0
                         logger.warning(
-                            "[padding] No valid audio_duration provided (got %s); "
-                            "using fallback duration %.0fs.",
+                            "[padding] No valid audio_duration provided (got {}); "
+                            "using fallback duration {:.0f}s.",
                             audio_duration,
                             fallback_duration,
                         )


### PR DESCRIPTION
## Summary

- When `src_audio` is `None` for tasks that require it (cover, repaint, lego, extract), the handler now returns a standard error payload (`success=False`) instead of silently falling back to a 120s silence tensor with wrong output duration.
- Fix loguru format strings in `padding_utils.py` (`%s` → `{}`).

## Root cause

`_prepare_reference_and_source_audio` had no `else` branch for the case where `task_type` requires source audio but `src_audio is None`. The code silently continued with `processed_src_audio=None`, causing `padding_utils` to fall back to `create_target_wavs(120.0)` — producing output with wrong duration instead of reporting the missing input.

## Test plan

- [ ] `generate_music(task_type="cover", src_audio=None)` → error payload with `success=False`
- [ ] `generate_music(task_type="repaint", src_audio=None)` → same
- [ ] `generate_music(task_type="text2music", src_audio=None)` → works normally
- [ ] `generate_music(task_type="cover", src_audio="valid.mp3")` → works, output matches input length

https://claude.ai/code/session_01Jn77C6r8NovU9k6Lqju9eZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved validation and error handling for music generation. Certain tasks now properly check for required audio inputs and return clear error messages when they're missing, preventing incomplete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->