### PR TITLE
fix: allow cover/repaint tasks with audio codes but no src_audio

### DIFF
--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -134,16 +134,22 @@ class GenerateMusicRequestMixin:
                         "error": "Invalid source audio",
                     }
         elif task_type in _src_audio_required_tasks:
-            return None, None, {
-                "audios": [],
-                "status_message": (
-                    f"Task '{task_type}' requires source audio, but none was provided. "
-                    f"Please upload a source audio file."
-                ),
-                "extra_outputs": {},
-                "success": False,
-                "error": f"Task '{task_type}' requires source audio",
-            }
+            if self._has_non_empty_audio_codes(audio_code_string):
+                logger.info(
+                    "[generate_music] %s task: no src_audio but audio codes provided, proceeding with codes",
+                    task_type,
+                )
+            else:
+                return None, None, {
+                    "audios": [],
+                    "status_message": (
+                        f"Task '{task_type}' requires source audio, but none was provided. "
+                        f"Please upload a source audio file."
+                    ),
+                    "extra_outputs": {},
+                    "success": False,
+                    "error": f"Task '{task_type}' requires source audio",
+                }
 
         return refer_audios, processed_src_audio, None
 

--- a/acestep/core/generation/handler/generate_music_request_test.py
+++ b/acestep/core/generation/handler/generate_music_request_test.py
@@ -112,6 +112,46 @@ class GenerateMusicRequestMixinTests(unittest.TestCase):
         self.assertEqual(error["error"], "Invalid source audio")
 
 
+    def test_cover_no_src_audio_with_codes_succeeds(self):
+        """Cover task should succeed without src_audio when audio codes are provided."""
+        host = _Host()
+        _, processed_src_audio, error = host._prepare_reference_and_source_audio(
+            reference_audio=None,
+            src_audio=None,
+            audio_code_string="<|audio_code_42|>",
+            actual_batch_size=1,
+            task_type="cover",
+        )
+        self.assertIsNone(error)
+        self.assertIsNone(processed_src_audio)
+
+    def test_cover_no_src_audio_no_codes_errors(self):
+        """Cover task without src_audio and without audio codes should error."""
+        host = _Host()
+        _, _, error = host._prepare_reference_and_source_audio(
+            reference_audio=None,
+            src_audio=None,
+            audio_code_string="",
+            actual_batch_size=1,
+            task_type="cover",
+        )
+        self.assertIsNotNone(error)
+        self.assertFalse(error["success"])
+        self.assertIn("requires source audio", error["error"])
+
+    def test_repaint_no_src_audio_with_codes_succeeds(self):
+        """Repaint task should succeed without src_audio when audio codes are provided."""
+        host = _Host()
+        _, processed_src_audio, error = host._prepare_reference_and_source_audio(
+            reference_audio=None,
+            src_audio=None,
+            audio_code_string="<|audio_code_99|>",
+            actual_batch_size=1,
+            task_type="repaint",
+        )
+        self.assertIsNone(error)
+        self.assertIsNone(processed_src_audio)
+
     def test_should_return_intermediate_always_true(self):
         """Intermediate tensors must always be returned for LRC generation support."""
         host = _Host()


### PR DESCRIPTION
## Summary
- When using cover/repaint/lego/extract tasks with LM-generated audio codes or manually input codes, the system incorrectly required `src_audio` to be present, returning: `Task 'cover' requires source audio, but none was provided.`
- The fix checks for audio codes before requiring src_audio — if codes are provided, src_audio is not needed
- Added test coverage for both the happy path (codes present, no src_audio) and the error path (neither present)

## Test plan
- [x] `test_cover_no_src_audio_with_codes_succeeds` — cover with codes, no src_audio → success
- [x] `test_cover_no_src_audio_no_codes_errors` — cover without codes or src_audio → error
- [x] `test_repaint_no_src_audio_with_codes_succeeds` — repaint with codes, no src_audio → success
- [x] All 9 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cover, repaint, lego, and extract tasks now proceed without source audio when valid audio codes are provided, enabling more flexible workflows.

* **Tests**
  * Added unit tests validating audio processing behavior, success scenarios with audio codes, and error handling when source audio is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->