### PR TITLE
Fix printf specifiers for loguru logger

### DIFF
--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -136,7 +136,7 @@ class GenerateMusicRequestMixin:
         elif task_type in _src_audio_required_tasks:
             if self._has_non_empty_audio_codes(audio_code_string):
                 logger.info(
-                    "[generate_music] %s task: no src_audio but audio codes provided, proceeding with codes",
+                    "[generate_music] {} task: no src_audio but audio codes provided, proceeding with codes",
                     task_type,
                 )
             else:

--- a/acestep/core/generation/handler/service_generate_execute.py
+++ b/acestep/core/generation/handler/service_generate_execute.py
@@ -209,12 +209,12 @@ class ServiceGenerateExecuteMixin:
                         )
                         _tc = outputs.get("time_costs", {})
                         logger.info(
-                            "[service_generate] DiT diffusion complete via MLX (%.2fs total, %.3fs/step).",
+                            "[service_generate] DiT diffusion complete via MLX ({:.2f}s total, {:.3f}s/step).",
                             _tc.get("diffusion_time_cost", 0),
                             _tc.get("diffusion_per_step_time_cost", 0),
                         )
                     except Exception as exc:
-                        logger.warning("[service_generate] MLX diffusion failed (%s); falling back to PyTorch.", exc)
+                        logger.warning("[service_generate] MLX diffusion failed ({}); falling back to PyTorch.", exc)
                         outputs = self.model.generate_audio(**generate_kwargs)
                 else:
                     logger.info("[service_generate] DiT diffusion via PyTorch ({})...", self.device)

--- a/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
@@ -58,7 +58,7 @@ def maybe_compile(fn: Optional[F] = None, **compile_kwargs: Any) -> Any:
             import torch
             return torch.compile(func, **compile_kwargs)
         logger.info(
-            "Triton not available — skipping torch.compile for %s "
+            "Triton not available — skipping torch.compile for {} "
             "(inference will use native PyTorch kernels)",
             func.__qualname__,
         )


### PR DESCRIPTION
Loguru logger do not support printf-styled placeholders. You need to use `{}` instead. 
See https://loguru.readthedocs.io/en/stable/resources/migration.html#replacing-style-formatting-of-messages

Summary: Safe change, not affect or break anything. Just fix info which appear in console/logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal logging message formatting across core modules for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->