### PR TITLE
Fix user preference persistence for Gradio UI

### DIFF
--- a/acestep/ui/gradio/interfaces/generation_advanced_output_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_advanced_output_controls.py
@@ -1,5 +1,7 @@
 """Output and automation controls for generation advanced settings."""
 
+import html
+import json
 from typing import Any
 
 import gradio as gr
@@ -9,6 +11,7 @@ from acestep.ui.gradio.i18n import t
 
 _MP3_BITRATE_CHOICES = [("128 kbps", "128k"), ("192 kbps", "192k"), ("256 kbps", "256k"), ("320 kbps", "320k")]
 _MP3_SAMPLE_RATE_CHOICES = [("48 kHz", 48000), ("44.1 kHz", 44100)]
+_AUDIO_FORMAT_CHOICES = [("FLAC", "flac"), ("MP3", "mp3"), ("Opus", "opus"), ("AAC", "aac"), ("WAV (16-bit)", "wav"), ("WAV (32-bit Float)", "wav32")]
 
 
 def _update_mp3_control_visibility(audio_format: str, service_mode: bool = False):
@@ -45,14 +48,7 @@ def build_output_controls(
         with gr.Row():
             with gr.Column(scale=1):
                 audio_format = gr.Dropdown(
-                    choices=[
-                        ("FLAC", "flac"),
-                        ("MP3", "mp3"),
-                        ("Opus", "opus"),
-                        ("AAC", "aac"),
-                        ("WAV (16-bit)", "wav"),
-                        ("WAV (32-bit Float)", "wav32"),
-                    ],
+                    choices=_AUDIO_FORMAT_CHOICES,
                     value=initial_audio_format,
                     label=t("generation.audio_format_label"),
                     info=t("generation.audio_format_info"),
@@ -62,12 +58,7 @@ def build_output_controls(
                 )
                 with gr.Row(visible=initial_mp3_visible) as mp3_controls_row:
                     mp3_bitrate = gr.Dropdown(
-                        choices=[
-                            ("128 kbps", "128k"),
-                            ("192 kbps", "192k"),
-                            ("256 kbps", "256k"),
-                            ("320 kbps", "320k"),
-                        ],
+                        choices=_MP3_BITRATE_CHOICES,
                         value=params.get("mp3_bitrate", "128k"),
                         label=t("generation.mp3_bitrate_label"),
                         info=t("generation.mp3_bitrate_info"),
@@ -78,10 +69,7 @@ def build_output_controls(
                         scale=1,
                     )
                     mp3_sample_rate = gr.Dropdown(
-                        choices=[
-                            ("48 kHz", 48000),
-                            ("44.1 kHz", 44100),
-                        ],
+                        choices=_MP3_SAMPLE_RATE_CHOICES,
                         value=params.get("mp3_sample_rate", 48000),
                         label=t("generation.mp3_sample_rate_label"),
                         info=t("generation.mp3_sample_rate_info"),
@@ -109,6 +97,16 @@ def build_output_controls(
             inputs=[audio_format],
             outputs=[mp3_controls_row, mp3_bitrate, mp3_sample_rate],
         )
+        dropdowns = [
+            (audio_format, _AUDIO_FORMAT_CHOICES),
+            (mp3_bitrate, _MP3_BITRATE_CHOICES),
+            (mp3_sample_rate, _MP3_SAMPLE_RATE_CHOICES),
+        ]
+        for dd, choices in dropdowns:
+            safe_json = html.escape(json.dumps(choices))
+            gr.HTML(
+                f'<div id="{dd.elem_id}-maps" data-maps="{safe_json}" style="display: none;"></div>'
+            )
         with gr.Row():
             enable_normalization = gr.Checkbox(
                 label=t("generation.enable_normalization"),

--- a/acestep/ui/gradio/interfaces/generation_advanced_output_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_advanced_output_controls.py
@@ -56,7 +56,7 @@ def build_output_controls(
                     elem_classes=["has-info-container"],
                     interactive=not service_mode,
                 )
-                with gr.Row(visible=initial_mp3_visible) as mp3_controls_row:
+                with gr.Row(visible=initial_mp3_visible, elem_id="acestep-mp3-controls-row") as mp3_controls_row:
                     mp3_bitrate = gr.Dropdown(
                         choices=_MP3_BITRATE_CHOICES,
                         value=params.get("mp3_bitrate", "128k"),

--- a/acestep/ui/gradio/interfaces/user_preferences.js
+++ b/acestep/ui/gradio/interfaces/user_preferences.js
@@ -98,7 +98,24 @@
 
     // ── Save (debounced) ─────────────────────────────────────────────
 
+    const syncMp3Row = () => {
+        const row = document.getElementById("acestep-mp3-controls-row");
+        if (!row) return;
+        const val = readValue("audio_format");
+        if (val === undefined) return;
+        const show = val === "mp3";
+        row.style.display = show ? "" : "none";
+        for (const id of ["acestep-mp3-bitrate", "acestep-mp3-sample-rate"]) {
+            const el = document.getElementById(id);
+            if (el) {
+                el.style.display = show ? "" : "none";
+                el.classList.toggle("hidden", !show);
+            }
+        }
+    };
+
     const scheduleSave = () => {
+        syncMp3Row();
         if (saveTimer !== null) {
             clearTimeout(saveTimer);
         }
@@ -151,6 +168,7 @@
                 }
             }
         }
+        syncMp3Row();
     };
 
     // ── MutationObserver – re-wire after Gradio re-renders ───────────

--- a/acestep/ui/gradio/interfaces/user_preferences.js
+++ b/acestep/ui/gradio/interfaces/user_preferences.js
@@ -75,6 +75,19 @@
         const el = findInput(spec.elemId, spec.type);
         if (!el) return undefined;
 
+        if (spec.type === "dropdown") {
+            const maps = document.getElementById(spec.elemId + "-maps");
+            if (maps) {
+                try {
+                    const mapsData = JSON.parse(maps.dataset.maps);
+                    const value = el.value;
+                    const pair = mapsData.find(item => item[0] === value);
+                    if (pair !== undefined) return pair[1];
+                } catch (e) {
+                    console.warn(`[UserPreferences] Failed to parse mapping for ${spec.elemId}:`, e);
+                }
+            }
+        }
         if (spec.type === "checkbox") return el.checked;
         if (spec.type === "slider" || spec.type === "number") {
             const v = Number(el.value);

--- a/acestep/ui/gradio/interfaces/user_preferences.js
+++ b/acestep/ui/gradio/interfaces/user_preferences.js
@@ -121,10 +121,35 @@
         for (const key of Object.keys(PREFS)) {
             const spec = PREFS[key];
             const el = findInput(spec.elemId, spec.type);
-            if (!el || wiredElements.has(el)) continue;
-            wiredElements.add(el);
-            el.addEventListener("input", scheduleSave, { passive: true });
-            el.addEventListener("change", scheduleSave, { passive: true });
+            if (el && !wiredElements.has(el)) {
+                wiredElements.add(el);
+                el.addEventListener("input", scheduleSave, { passive: true });
+                el.addEventListener("change", scheduleSave, { passive: true });
+                
+                if (spec.type === "dropdown") {
+                    const nativeInputValue = Object.getOwnPropertyDescriptor(
+                        window.HTMLInputElement.prototype, 
+                        "value"
+                    );
+
+                    if (!nativeInputValue || !nativeInputValue.set || !nativeInputValue.get) continue;
+
+                    try {
+                        Object.defineProperty(el, "value", {
+                            configurable: true,
+                            get: function() {
+                                return nativeInputValue.get.call(this);
+                            },
+                            set: function(val) {
+                                nativeInputValue.set.call(this, val);
+                                scheduleSave();
+                            }
+                        });
+                    } catch (e) {
+                        console.warn(`[UserPreferences] Could not hook value for ${spec.elemId}:`, e);
+                    }
+                }
+            }
         }
     };
 

--- a/acestep/ui/gradio/interfaces/user_preferences.py
+++ b/acestep/ui/gradio/interfaces/user_preferences.py
@@ -186,7 +186,6 @@ def restore_preferences(
     ``syncMp3Row()``; this function only sets component *values*.
     """
     import gradio as gr
-    import json as _json
 
     noop = tuple(gr.update() for _ in range(_num_outputs))
 
@@ -194,7 +193,7 @@ def restore_preferences(
         return noop
 
     try:
-        data = _json.loads(values[0])
+        data = json.loads(values[0])
     except (TypeError, ValueError):
         return noop
 

--- a/acestep/ui/gradio/interfaces/user_preferences.py
+++ b/acestep/ui/gradio/interfaces/user_preferences.py
@@ -2,13 +2,15 @@
 
 Save side:  A ``<script>`` injected via ``Blocks(head=…)`` listens for DOM
 changes and writes the current preference values to ``localStorage``.
+It also keeps MP3-specific control visibility in sync with the selected
+audio format via direct DOM toggling (``syncMp3Row()``), since Gradio
+does not fire ``.change()`` for values set at load time.
 
 Restore side:  ``wire_preference_restore`` attaches a ``demo.load()`` handler
-whose *js* parameter reads ``localStorage`` on page load and feeds the saved
-values straight into the Gradio component outputs.  Because Gradio itself
-applies the updates through its own Svelte reactivity, every component type
-(dropdown, slider, checkbox, number) is updated correctly—no fragile DOM
-hacking required.
+whose *js* parameter reads ``localStorage`` on page load and passes the
+saved values as a JSON string through a hidden dummy Textbox input.
+The Python side deserialises the string and feeds the values into Gradio
+component outputs, where Svelte reactivity applies them correctly.
 """
 
 from __future__ import annotations
@@ -74,21 +76,25 @@ def get_user_preferences_head() -> str:
 # ── Restore-side: Gradio .load() wiring ─────────────────────────────────
 
 
-def _build_restore_js(num_outputs: int) -> str:
+def _build_restore_js() -> str:
     """Build the client-side JS that reads localStorage and returns values.
 
     The returned function is passed as the ``js`` parameter to
-    ``demo.load()``.  It returns an array whose element order matches
-    ``PREF_KEYS`` (and therefore the *outputs* list).
+    ``demo.load()``.  It reads saved preferences from localStorage,
+    serialises them as a JSON string, and returns a single-element array
+    ``[json_string]`` so Gradio maps it to the dummy Textbox input.
+    The Python side (``restore_preferences``) deserialises the string
+    and produces one output value per ``PREF_KEYS`` entry.
 
     When localStorage has no saved preferences (first visit, cleared
-    storage, private browsing), the function returns an array of ``null``
-    sentinels so the Python side can skip the update and preserve whatever
-    values were already rendered from ``init_params``.
+    storage, private browsing), the function returns ``[null]`` so the
+    Python side receives a falsy value and emits ``gr.update()`` for
+    every output, preserving whatever was already rendered from
+    ``init_params``.
 
-    Args:
-        num_outputs: Total number of output components (preference keys
-            plus any extra outputs like ``mp3_controls_row``).
+    MP3 control visibility is **not** handled here; it is managed by
+    ``syncMp3Row()`` in the save-side JS (``user_preferences.js``),
+    which toggles the DOM directly on page load and on format changes.
     """
     keys_json = json.dumps(PREF_KEYS)
     # Build a type map so the restore JS can validate each value.
@@ -109,8 +115,8 @@ def _build_restore_js(num_outputs: int) -> str:
     # Sentinel array returned when there is nothing to restore.  Using null
     # lets the Python fn detect "no stored prefs" and return gr.update()
     # for every output, preserving the values already rendered on the page.
-    skip_sentinel = f"new Array({num_outputs}).fill(null)"
-    return f"""() => {{
+    skip_sentinel = f"[null]"
+    return f"""(_dummy) => {{
         const STORAGE_KEY = {json.dumps(_STORAGE_KEY)};
         const SCHEMA_VERSION = {_SCHEMA_VERSION};
         const KEYS = {keys_json};
@@ -149,15 +155,7 @@ def _build_restore_js(num_outputs: int) -> str:
             }});
             // If none of the keys had stored values, skip entirely.
             if (result.every(v => v === null)) return SKIP;
-            // Compute mp3 control visibility from audio_format (index 0).
-            // Push 3 extra values: mp3_controls_row, mp3_bitrate, mp3_sample_rate
-            // matching the outputs of _update_mp3_control_visibility().
-            // When audioFormat is null (no stored value), push nulls so Python
-            // emits gr.update() and preserves whatever init_params set.
-            const audioFormat = result[0];
-            const mp3 = audioFormat === null ? null : audioFormat === "mp3";
-            result.push(mp3, mp3, mp3);
-            return result;
+            return [JSON.stringify(result)];
         }} catch (_e) {{
             return SKIP;
         }}
@@ -169,38 +167,53 @@ def restore_preferences(
 ) -> tuple[Any, ...]:
     """Map JS restore results into Gradio output values.
 
-    The JS function reads localStorage and produces an array:
-      - First ``len(PREF_KEYS)`` elements are preference values (or null).
-      - Next 3 elements are mp3 visibility booleans (or null):
-        [mp3_controls_row, mp3_bitrate, mp3_sample_rate].
+    The JS function serialises a ``PREF_KEYS``-ordered array into a JSON
+    string and passes it through a hidden dummy Textbox.  This function
+    receives that string as ``values[0]``, deserialises it, and returns
+    one Gradio-compatible value per output component.
 
-    ``None`` (JSON ``null``) → ``gr.update()`` (no-op, preserves current).
-    Booleans beyond PREF_KEYS → visibility/interactivity updates matching
-    ``_update_mp3_control_visibility()`` from the output controls module.
+    Individual elements may be ``null`` (when a key was absent from
+    localStorage); these become ``gr.update()`` (no-op, preserves
+    the current component value).
 
-    When the JS side returns no values (e.g. certain Gradio versions do not
-    forward the JS return value to the Python ``fn`` when ``inputs=None``),
-    ``_num_outputs`` is used to produce the correct number of no-op updates
-    so Gradio does not raise a ``ValueError`` about mismatched output count.
+    When the JS side returns ``[null]`` (no stored preferences) or
+    the function is called with no arguments (edge-case Gradio
+    versions), ``_num_outputs`` is used to produce the correct number
+    of no-op updates so Gradio does not raise a ``ValueError`` about
+    mismatched output count.
+
+    MP3 control visibility is handled on the JS side by
+    ``syncMp3Row()``; this function only sets component *values*.
     """
     import gradio as gr
+    import json as _json
 
-    if not values:
-        return tuple(gr.update() for _ in range(_num_outputs))
+    noop = tuple(gr.update() for _ in range(_num_outputs))
+
+    if not values or not values[0]:
+        return noop
+
+    try:
+        data = _json.loads(values[0])
+    except (TypeError, ValueError):
+        return noop
+
+    if not isinstance(data, list) or all(v is None for v in data):
+        return noop
 
     n_prefs = len(PREF_KEYS)
     results: list[Any] = []
-    for i, v in enumerate(values):
+    for i, v in enumerate(data):
+        if i >= n_prefs:
+            break
         if v is None:
             results.append(gr.update())
-        elif i == n_prefs and isinstance(v, bool):
-            # mp3_controls_row: visibility only.
-            results.append(gr.update(visible=v))
-        elif i > n_prefs and isinstance(v, bool):
-            # mp3_bitrate, mp3_sample_rate: visibility + interactivity.
-            results.append(gr.update(visible=v, interactive=v))
         else:
             results.append(v)
+
+    while len(results) < _num_outputs:
+        results.append(gr.update())
+
     return tuple(results)
 
 
@@ -229,6 +242,8 @@ def wire_preference_restore(
     if service_mode:
         return
 
+    import gradio as gr
+
     outputs = []
     for key in PREF_KEYS:
         component = generation_section.get(key)
@@ -239,20 +254,12 @@ def wire_preference_restore(
             )
         outputs.append(component)
 
-    # Also update mp3 control visibility so it stays in sync when the
-    # restored audio_format differs from the server-rendered default.
-    # Gradio does not fire .change() for load-time value assignments, so
-    # without this the MP3 row and its children could be visible/hidden
-    # incorrectly.  The three extra outputs mirror the return of
-    # _update_mp3_control_visibility(): [row, bitrate, sample_rate].
-    for mp3_key in ("mp3_controls_row", "mp3_bitrate", "mp3_sample_rate"):
-        comp = generation_section.get(mp3_key)
-        if comp is not None:
-            outputs.append(comp)
+    # Dummy input — creates a channel for JS → Python
+    dummy = gr.Textbox(value="", visible=False, elem_id="acestep-prefs-restore-dummy")
 
     demo.load(
         fn=partial(restore_preferences, _num_outputs=len(outputs)),
-        inputs=None,
+        inputs=[dummy],
         outputs=outputs,
-        js=_build_restore_js(num_outputs=len(outputs)),
+        js=_build_restore_js(),
     )

--- a/acestep/ui/gradio/interfaces/user_preferences.py
+++ b/acestep/ui/gradio/interfaces/user_preferences.py
@@ -115,7 +115,7 @@ def _build_restore_js() -> str:
     # Sentinel array returned when there is nothing to restore.  Using null
     # lets the Python fn detect "no stored prefs" and return gr.update()
     # for every output, preserving the values already rendered on the page.
-    skip_sentinel = f"[null]"
+    skip_sentinel = "[null]"
     return f"""(_dummy) => {{
         const STORAGE_KEY = {json.dumps(_STORAGE_KEY)};
         const SCHEMA_VERSION = {_SCHEMA_VERSION};

--- a/acestep/ui/gradio/interfaces/user_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/user_preferences_test.py
@@ -165,7 +165,6 @@ class RestoreTests(unittest.TestCase):
 
     def test_restore_preferences_with_values(self):
         """Values arrive as a JSON string from the dummy Textbox."""
-        import json
         data = ["flac", "192k", 44100, 0.7, False, -2.0, 0.5, 0.5, 0.1, 1.1, 4]
         result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
         self.assertEqual(result[0], "flac")
@@ -185,7 +184,6 @@ class RestoreTests(unittest.TestCase):
         self.assertEqual(len(result), len(PREF_KEYS))
 
     def test_restore_preferences_partial_nulls(self):
-        import json
         data = ["opus", None, None, 0.5, True, -1.0, 0.0, 0.0, 0.0, 1.0, 8]
         result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
         self.assertEqual(result[0], "opus")
@@ -197,7 +195,6 @@ class RestoreTests(unittest.TestCase):
         # indices 1, 2 should be gr.update()
 
     def test_restore_preferences_all_nulls(self):
-        import json
         data = [None] * len(PREF_KEYS)
         result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
         self.assertEqual(len(result), len(PREF_KEYS))

--- a/acestep/ui/gradio/interfaces/user_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/user_preferences_test.py
@@ -112,26 +112,26 @@ class SaveScriptTests(unittest.TestCase):
         self.assertEqual(script_1, script_2)
 
 
-_NUM_OUTPUTS = len(PREF_KEYS) + 3  # +3 for mp3_controls_row, mp3_bitrate, mp3_sample_rate
+_NUM_OUTPUTS = len(PREF_KEYS)
 
 
 class RestoreTests(unittest.TestCase):
     """Tests for the Gradio-native restore mechanism."""
 
     def test_restore_js_returns_valid_javascript(self):
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         self.assertIn("localStorage", js)
         self.assertIn("SCHEMA_VERSION", js)
         self.assertIn("acestep.ui.user_preferences", js)
 
     def test_restore_js_includes_all_pref_keys(self):
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         for key in PREF_KEYS:
             self.assertIn(f'"{key}"', js, f"Missing key in restore JS: {key}")
 
     def test_restore_js_only_resets_on_downgrade(self):
         """Version check should only discard prefs from future (higher) versions."""
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         self.assertIn("_version", js)
         self.assertIn("prefs._version > SCHEMA_VERSION", js)
         self.assertNotIn("prefs._version !== SCHEMA_VERSION", js)
@@ -139,84 +139,89 @@ class RestoreTests(unittest.TestCase):
     def test_restore_js_coerces_numeric_dropdown_values(self):
         """Dropdown values stored as strings in localStorage must be coerced
         back to numbers when the Gradio component expects integers."""
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         self.assertIn("NUMERIC_COERCE_KEYS", js)
         self.assertIn("Number(v)", js)
 
     def test_restore_js_validates_value_types(self):
         """Restore JS must include per-key type validation."""
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         self.assertIn("TYPE_MAP", js)
         self.assertIn("typeof v !== expected", js)
 
     def test_restore_js_returns_null_sentinel_when_no_stored_prefs(self):
         """When localStorage is empty the JS must return nulls so the Python
         side can skip updates and preserve init_params."""
-        js = _build_restore_js(_NUM_OUTPUTS)
+        js = _build_restore_js()
         self.assertIn("SKIP", js)
-        self.assertIn("fill(null)", js)
+        self.assertIn("[null]", js)
         # Should NOT contain DEFAULTS as a fallback for empty storage.
         self.assertNotIn("DEFAULTS", js)
 
-    def test_restore_js_includes_mp3_visibility_computation(self):
-        """Restore JS should compute mp3_controls_row visibility from
-        the restored audio_format and append it."""
-        js = _build_restore_js(_NUM_OUTPUTS)
-        self.assertIn("audioFormat", js)
-        self.assertIn('result.push(', js)
-        self.assertIn('"mp3"', js)
+    def test_restore_js_returns_json_string(self):
+        """Restore JS should return a JSON string."""
+        js = _build_restore_js()
+        self.assertIn("JSON.stringify", js)
 
-    def test_restore_preferences_passes_through_values(self):
-        """Non-None values are passed through unchanged."""
-        values = ("flac", "320k", 44100, 0.8, False, -3.0, 0.5, 1.0, 0.05, 0.95, 4, True)
-        result = restore_preferences(*values)
-        # First 11 values are direct pass-through, last is visibility.
-        for i in range(len(PREF_KEYS)):
-            self.assertEqual(result[i], values[i])
+    def test_restore_preferences_with_values(self):
+        """Values arrive as a JSON string from the dummy Textbox."""
+        import json
+        data = ["flac", "192k", 44100, 0.7, False, -2.0, 0.5, 0.5, 0.1, 1.1, 4]
+        result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
+        self.assertEqual(result[0], "flac")
+        self.assertEqual(result[3], 0.7)
 
-    def test_restore_preferences_converts_none_to_gr_update(self):
-        """None values from JS should become gr.update() (no-op)."""
-        values = (None, None, None, None, None, None, None, None, None, None, None, None)
-        result = restore_preferences(*values)
+    def test_restore_preferences_empty(self):
+        result = restore_preferences(_num_outputs=len(PREF_KEYS))
+        self.assertEqual(len(result), len(PREF_KEYS))
         for v in result:
-            self.assertIsInstance(v, dict, "None should be converted to gr.update()")
+            self.assertIsInstance(v, dict)
             self.assertEqual(v["__type__"], "update")
+        # all should be gr.update()
 
-    def test_restore_preferences_converts_visibility_bools(self):
-        """The trailing booleans for mp3 controls should become
-        gr.update(visible=...) not raw bools."""
-        # 11 pref values + 3 mp3 visibility bools
-        values = ("mp3", "128k", 48000, 0.5, True, -1.0, 0.0, 0.0, 0.0, 1.0, 8, True, True, True)
-        result = restore_preferences(*values)
-        # mp3_controls_row (index 11): visible only
-        row_update = result[11]
-        self.assertIsInstance(row_update, dict)
-        self.assertTrue(row_update["visible"])
-        self.assertNotIn("interactive", row_update)
-        # mp3_bitrate (index 12): visible + interactive
-        bitrate_update = result[12]
-        self.assertIsInstance(bitrate_update, dict)
-        self.assertTrue(bitrate_update["visible"])
-        self.assertTrue(bitrate_update["interactive"])
-        # mp3_sample_rate (index 13): visible + interactive
-        sr_update = result[13]
-        self.assertIsInstance(sr_update, dict)
-        self.assertTrue(sr_update["visible"])
-        self.assertTrue(sr_update["interactive"])
+    def test_restore_preferences_null_string(self):
+        """Null input → noop."""
+        result = restore_preferences(None, _num_outputs=len(PREF_KEYS))
+        self.assertEqual(len(result), len(PREF_KEYS))
 
-    def test_restore_preferences_empty_values_returns_noop_updates(self):
-        """When called with no values (JS did not forward args), the function
-        should return ``_num_outputs`` gr.update() no-ops instead of crashing."""
-        result = restore_preferences(_num_outputs=_NUM_OUTPUTS)
-        self.assertEqual(len(result), _NUM_OUTPUTS)
+    def test_restore_preferences_partial_nulls(self):
+        import json
+        data = ["opus", None, None, 0.5, True, -1.0, 0.0, 0.0, 0.0, 1.0, 8]
+        result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
+        self.assertEqual(result[0], "opus")
+        self.assertIsInstance(result[1], dict)
+        self.assertEqual(result[1]["__type__"], "update")
+        self.assertIsInstance(result[2], dict)
+        self.assertEqual(result[2]["__type__"], "update")
+        self.assertEqual(result[3], 0.5)
+        # indices 1, 2 should be gr.update()
+
+    def test_restore_preferences_all_nulls(self):
+        import json
+        data = [None] * len(PREF_KEYS)
+        result = restore_preferences(json.dumps(data), _num_outputs=len(PREF_KEYS))
+        self.assertEqual(len(result), len(PREF_KEYS))
         for v in result:
             self.assertIsInstance(v, dict)
             self.assertEqual(v["__type__"], "update")
 
-    def test_restore_preferences_empty_values_no_num_outputs(self):
-        """With no values and no _num_outputs hint, return empty tuple."""
-        result = restore_preferences()
-        self.assertEqual(len(result), 0)
+    def test_build_restore_js_has_dummy_param(self):
+        js = _build_restore_js()
+        self.assertTrue(js.strip().startswith("(_dummy)"))
+
+    def test_build_restore_js_returns_json_string(self):
+        js = _build_restore_js()
+        self.assertIn("JSON.stringify", js)
+
+    def test_build_restore_js_skip_sentinel(self):
+        js = _build_restore_js()
+        self.assertIn("[null]", js)
+        self.assertNotIn("fill(null)", js)
+
+    def test_restore_preferences_invalid_json(self):
+        """Garbage string → noop."""
+        result = restore_preferences("not-json{}", _num_outputs=len(PREF_KEYS))
+        self.assertEqual(len(result), len(PREF_KEYS))
 
     def test_pref_keys_match_defaults(self):
         """Every PREF_KEY must have a corresponding default."""
@@ -224,8 +229,8 @@ class RestoreTests(unittest.TestCase):
             self.assertIn(key, _DEFAULTS, f"Key {key!r} missing from _DEFAULTS")
 
     def test_restore_js_generation_is_stable(self):
-        js_1 = _build_restore_js(_NUM_OUTPUTS)
-        js_2 = _build_restore_js(_NUM_OUTPUTS)
+        js_1 = _build_restore_js()
+        js_2 = _build_restore_js()
         self.assertEqual(js_1, js_2)
 
 

--- a/acestep/ui/gradio/interfaces/user_preferences_test.py
+++ b/acestep/ui/gradio/interfaces/user_preferences_test.py
@@ -50,6 +50,11 @@ class SaveScriptTests(unittest.TestCase):
         script_asset = _load_preferences_script()
         self.assertTrue(script_asset)
 
+    def test_external_script_contains_mapping_logic(self):
+        script_asset = _load_preferences_script()
+        self.assertIn("dataset.maps", script_asset)
+        self.assertIn("JSON.parse", script_asset)
+
     def test_script_contains_localstorage_persistence(self):
         script = get_user_preferences_head()
         self.assertIn("<script>", script)


### PR DESCRIPTION
Fix save and restore of user preferences via localStorage. Previously, dropdown values were saved as display labels instead of choice values, dropdown changes via Gradio's programmatic value setter were not detected, and restored preferences were silently discarded on page reload because Gradio does not forward JS return values to Python when `inputs=None`.

This PR fixes all three issues: dropdown save now maps labels to values using embedded choice data, a value property wrapper catches programmatic updates, and restore uses a hidden dummy Textbox as a data channel. MP3 control visibility is moved to client-side DOM sync since Gradio does not fire `.change()` for load-time assignments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More deterministic preference restore and wiring; restored payloads are parsed as a single JSON payload and MP3 visibility is synced from the save-side.
  * Centralized dropdown metadata and consistent MP3 control visibility handling.

* **Bug Fixes**
  * Fixed syncing and show/hide behavior for MP3 bitrate/sample-rate controls and made dropdown mapping parsing more resilient.

* **Tests**
  * Expanded tests for dropdown mappings, restore behavior, invalid payloads, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->