### PR TITLE
feat: make MLX VAE decode chunk size configurable with auto-tuning

### DIFF
--- a/acestep/core/generation/handler/mlx_vae_decode_native.py
+++ b/acestep/core/generation/handler/mlx_vae_decode_native.py
@@ -87,9 +87,7 @@ class MlxVaeDecodeNativeMixin:
             decode_fn = self._resolve_mlx_decode_fn()
 
         latent_frames = z_nlc.shape[1]
-        # Smaller chunks reduce peak memory on unified-memory Apple Silicon.
-        # 512 produces byte-identical output to 2048 with ~56% less peak GPU.
-        mlx_chunk = 512
+        mlx_chunk = max(192, getattr(self, "mlx_vae_chunk_size", 512))
         mlx_overlap = 64
 
         if latent_frames <= mlx_chunk:

--- a/acestep/core/generation/handler/mlx_vae_native_test.py
+++ b/acestep/core/generation/handler/mlx_vae_native_test.py
@@ -168,6 +168,51 @@ class MlxVaeNativeMixinTests(unittest.TestCase):
         self.assertIsInstance(out, torch.Tensor)
         self.assertEqual(tuple(out.shape), (2, 1, 600))
 
+    def test_mlx_decode_single_respects_custom_chunk_size(self):
+        """It uses self.mlx_vae_chunk_size when set on the host instance."""
+        host = _Host()
+        # Set a small chunk size so tiling is triggered on a moderately long sequence
+        host.mlx_vae_chunk_size = 256
+        fake_mx_core = _fake_mx_core_module()
+        fake_mlx_pkg = types.ModuleType("mlx")
+        fake_mlx_pkg.__path__ = []
+        # 512 frames > 256 chunk size, so tiling should activate
+        z_nlc = np.ones((1, 512, 1), dtype=np.float32)
+        decode_calls = []
+
+        def tracking_decode_fn(chunk):
+            """Track chunk sizes passed to decode and expand by factor two."""
+            decode_calls.append(chunk.shape[1])
+            return np.repeat(chunk, 2, axis=1)
+
+        with patch.dict(sys.modules, {"mlx": fake_mlx_pkg, "mlx.core": fake_mx_core}):
+            out = host._mlx_decode_single(z_nlc, decode_fn=tracking_decode_fn)
+        # Tiling was used: multiple decode calls were made
+        self.assertGreater(len(decode_calls), 1)
+        # Output length should match input * upsample factor
+        self.assertEqual(tuple(out.shape), (1, 1024, 1))
+
+    def test_mlx_decode_single_no_tiling_with_large_chunk_size(self):
+        """It skips tiling when mlx_vae_chunk_size exceeds the latent length."""
+        host = _Host()
+        host.mlx_vae_chunk_size = 2048
+        fake_mx_core = _fake_mx_core_module()
+        fake_mlx_pkg = types.ModuleType("mlx")
+        fake_mlx_pkg.__path__ = []
+        z_nlc = np.ones((1, 256, 1), dtype=np.float32)
+        decode_calls = []
+
+        def tracking_decode_fn(chunk):
+            """Track decode calls and expand latent time axis by factor two."""
+            decode_calls.append(chunk.shape[1])
+            return np.repeat(chunk, 2, axis=1)
+
+        with patch.dict(sys.modules, {"mlx": fake_mlx_pkg, "mlx.core": fake_mx_core}):
+            out = host._mlx_decode_single(z_nlc, decode_fn=tracking_decode_fn)
+        # No tiling: single decode call
+        self.assertEqual(len(decode_calls), 1)
+        self.assertEqual(tuple(out.shape), (1, 512, 1))
+
     def test_mlx_decode_single_raises_when_mlx_vae_missing(self):
         """It raises a clear runtime error when decode is requested without MLX VAE."""
         host = _Host()

--- a/acestep/gpu_config.py
+++ b/acestep/gpu_config.py
@@ -799,13 +799,14 @@ def _auto_mlx_vae_chunk_size(mem_gb: Optional[float] = None) -> int:
     if mem_gb is None:
         mem_gb = get_gpu_memory_gb()
     if mem_gb <= 16:
-        return 256
+        size = 256
     elif mem_gb <= 36:
-        return 512
+        size = 512
     elif mem_gb <= 64:
-        return 1024
+        size = 1024
     else:
-        return 2048
+        size = 2048
+    return max(192, size)
 
 
 def get_gpu_config(gpu_memory_gb: Optional[float] = None) -> GPUConfig:

--- a/acestep/gpu_config.py
+++ b/acestep/gpu_config.py
@@ -788,12 +788,13 @@ def _auto_mlx_vae_chunk_size(mem_gb: Optional[float] = None) -> int:
             via :func:`get_gpu_memory_gb`.
 
     Returns:
-        Chunk size as a positive integer (minimum 64).
+        Chunk size as a positive integer (minimum 192, to keep
+        ``stride = chunk - 2 * overlap`` positive with overlap=64).
     """
     env_val = os.environ.get("ACESTEP_MLX_VAE_CHUNK")
     if env_val is not None:
         try:
-            return max(64, int(env_val))
+            return max(192, int(env_val))
         except ValueError:
             pass
     if mem_gb is None:

--- a/acestep/gpu_config.py
+++ b/acestep/gpu_config.py
@@ -262,6 +262,13 @@ class GPUConfig:
     # Controlled via ACESTEP_SAVE_MEMORY=1 environment variable.
     save_memory_mode: bool = False
 
+    # MLX VAE decode chunk size (Apple Silicon only).
+    # Controls the maximum number of latent frames decoded in a single pass.
+    # Larger values decode faster but use more memory.
+    # Auto-detected based on available unified memory; overridable via
+    # ACESTEP_MLX_VAE_CHUNK environment variable.
+    mlx_vae_chunk_size: int = 512
+
 
 def _apply_lm_backend_compatibility_overrides(config: GPUConfig) -> GPUConfig:
     """Apply runtime hardware overrides for LM backend selection."""
@@ -769,6 +776,38 @@ def get_gpu_tier(gpu_memory_gb: float) -> str:
         return "unlimited"
 
 
+def _auto_mlx_vae_chunk_size(mem_gb: Optional[float] = None) -> int:
+    """Select MLX VAE decode chunk size based on available unified memory.
+
+    The ``ACESTEP_MLX_VAE_CHUNK`` environment variable takes highest
+    priority.  Otherwise the chunk size is chosen from a memory-based
+    heuristic targeting Apple Silicon unified-memory configurations.
+
+    Args:
+        mem_gb: GPU/unified memory in GB.  When ``None``, auto-detected
+            via :func:`get_gpu_memory_gb`.
+
+    Returns:
+        Chunk size as a positive integer (minimum 64).
+    """
+    env_val = os.environ.get("ACESTEP_MLX_VAE_CHUNK")
+    if env_val is not None:
+        try:
+            return max(64, int(env_val))
+        except ValueError:
+            pass
+    if mem_gb is None:
+        mem_gb = get_gpu_memory_gb()
+    if mem_gb <= 16:
+        return 256
+    elif mem_gb <= 36:
+        return 512
+    elif mem_gb <= 64:
+        return 1024
+    else:
+        return 2048
+
+
 def get_gpu_config(gpu_memory_gb: Optional[float] = None) -> GPUConfig:
     """
     Get GPU configuration based on detected or provided GPU memory.
@@ -842,6 +881,10 @@ def get_gpu_config(gpu_memory_gb: Optional[float] = None) -> GPUConfig:
         if _mps
         else config.get("compile_model_default", True),
         lm_memory_gb=config["lm_memory_gb"],
+        # MPS: auto-tune MLX VAE decode chunk size based on unified memory
+        mlx_vae_chunk_size=_auto_mlx_vae_chunk_size(gpu_memory_gb)
+        if _mps
+        else 512,
     )
     return _apply_lm_backend_compatibility_overrides(config)
 
@@ -1503,6 +1546,9 @@ def get_gpu_config_for_tier(tier: str) -> GPUConfig:
         if _mps
         else config.get("compile_model_default", True),
         lm_memory_gb=config["lm_memory_gb"],
+        mlx_vae_chunk_size=_auto_mlx_vae_chunk_size(real_gpu_memory)
+        if _mps
+        else 512,
     )
     return _apply_lm_backend_compatibility_overrides(config)
 

--- a/acestep/gpu_config_test.py
+++ b/acestep/gpu_config_test.py
@@ -32,5 +32,55 @@ class GpuConfigLegacyCudaTests(unittest.TestCase):
         self.assertEqual("vllm", resolve_lm_backend("vllm", config))
 
 
+class AutoMlxVaeChunkSizeTests(unittest.TestCase):
+    """Tests for memory-based MLX VAE chunk size selection."""
+
+    def test_low_memory_returns_256(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 256)
+
+    def test_mid_memory_returns_512(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=36), 512)
+
+    def test_high_memory_returns_1024(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=64), 1024)
+
+    def test_very_high_memory_returns_2048(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=128), 2048)
+
+    def test_env_var_override(self):
+        import os
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        with patch.dict(os.environ, {"ACESTEP_MLX_VAE_CHUNK": "1024"}):
+            self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 1024)
+
+    def test_env_var_clamps_to_minimum(self):
+        import os
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        with patch.dict(os.environ, {"ACESTEP_MLX_VAE_CHUNK": "32"}):
+            self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 64)
+
+    def test_invalid_env_var_falls_back_to_memory(self):
+        import os
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        with patch.dict(os.environ, {"ACESTEP_MLX_VAE_CHUNK": "not_a_number"}):
+            self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 256)
+
+    def test_boundary_17gb(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=17), 512)
+
+    def test_boundary_37gb(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=37), 1024)
+
+    def test_boundary_65gb(self):
+        from acestep.gpu_config import _auto_mlx_vae_chunk_size
+        self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=65), 2048)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/acestep/gpu_config_test.py
+++ b/acestep/gpu_config_test.py
@@ -61,7 +61,7 @@ class AutoMlxVaeChunkSizeTests(unittest.TestCase):
         import os
         from acestep.gpu_config import _auto_mlx_vae_chunk_size
         with patch.dict(os.environ, {"ACESTEP_MLX_VAE_CHUNK": "32"}):
-            self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 64)
+            self.assertEqual(_auto_mlx_vae_chunk_size(mem_gb=16), 192)
 
     def test_invalid_env_var_falls_back_to_memory(self):
         import os

--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -14,6 +14,7 @@ from typing import Optional
 import torch
 import warnings
 
+from acestep.gpu_config import get_global_gpu_config as _get_gpu_cfg
 from acestep.core.generation.handler import (
     AudioCodesMixin,
     BatchPrepMixin,
@@ -171,6 +172,5 @@ class AceStepHandler(
         self.use_mlx_vae = False
         # MLX VAE decode chunk size — auto-detected from gpu_config,
         # overridable via the Gradio UI slider or ACESTEP_MLX_VAE_CHUNK env var.
-        from acestep.gpu_config import get_global_gpu_config as _get_gpu_cfg
         self.mlx_vae_chunk_size = _get_gpu_cfg().mlx_vae_chunk_size
 

--- a/acestep/handler.py
+++ b/acestep/handler.py
@@ -169,4 +169,8 @@ class AceStepHandler(
         # MLX VAE acceleration (macOS Apple Silicon only)
         self.mlx_vae = None
         self.use_mlx_vae = False
+        # MLX VAE decode chunk size — auto-detected from gpu_config,
+        # overridable via the Gradio UI slider or ACESTEP_MLX_VAE_CHUNK env var.
+        from acestep.gpu_config import get_global_gpu_config as _get_gpu_cfg
+        self.mlx_vae_chunk_size = _get_gpu_cfg().mlx_vae_chunk_size
 

--- a/acestep/ui/gradio/events/wiring/generation_service_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_service_wiring.py
@@ -149,6 +149,12 @@ def register_generation_service_handlers(
         outputs=[generation_section["lora_status"]],
     )
 
+    # ========== MLX VAE Chunk Size ==========
+    generation_section["mlx_vae_chunk_size"].change(
+        fn=lambda val: setattr(dit_handler, "mlx_vae_chunk_size", int(val)),
+        inputs=[generation_section["mlx_vae_chunk_size"]],
+    )
+
     # ========== Auto Checkbox Handlers ==========
     auto_field_map = {
         "bpm_auto": ("bpm", "bpm"),

--- a/acestep/ui/gradio/interfaces/generation_advanced_dit_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_advanced_dit_controls.py
@@ -139,7 +139,7 @@ def build_dit_controls(ui_config: dict[str, Any]) -> dict[str, Any]:
         _show_mlx_chunk = is_mps_platform()
         with gr.Row(visible=_show_mlx_chunk):
             mlx_vae_chunk_size = gr.Slider(
-                minimum=64,
+                minimum=192,
                 maximum=2048,
                 value=_gpu_config.mlx_vae_chunk_size,
                 step=64,

--- a/acestep/ui/gradio/interfaces/generation_advanced_dit_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_advanced_dit_controls.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import gradio as gr
 
+from acestep.gpu_config import get_global_gpu_config, is_mps_platform
 from acestep.ui.gradio.help_content import create_help_button
 from acestep.ui.gradio.i18n import t
 
@@ -134,6 +135,18 @@ def build_dit_controls(ui_config: dict[str, Any]) -> dict[str, Any]:
                     info=t("generation.random_seed_info"),
                     elem_classes=["has-info-container"],
                 )
+        _gpu_config = get_global_gpu_config()
+        _show_mlx_chunk = is_mps_platform()
+        with gr.Row(visible=_show_mlx_chunk):
+            mlx_vae_chunk_size = gr.Slider(
+                minimum=64,
+                maximum=2048,
+                value=_gpu_config.mlx_vae_chunk_size,
+                step=64,
+                label="MLX VAE Chunk Size",
+                info="Larger = faster decode but more memory. Auto-detected based on your system.",
+                elem_classes=["has-info-container"],
+            )
     return {
         "inference_steps": inference_steps,
         "guidance_scale": guidance_scale,
@@ -148,4 +161,5 @@ def build_dit_controls(ui_config: dict[str, Any]) -> dict[str, Any]:
         "cfg_interval_end": cfg_interval_end,
         "seed": seed,
         "random_seed_checkbox": random_seed_checkbox,
+        "mlx_vae_chunk_size": mlx_vae_chunk_size,
     }


### PR DESCRIPTION
## Summary

Closes #1058

- Add auto-detection of optimal MLX VAE chunk size based on unified memory (256/512/1024/2048 for ≤16GB/≤36GB/≤64GB/>64GB)
- Support `ACESTEP_MLX_VAE_CHUNK` env var override (highest priority)
- Add Gradio UI slider for runtime adjustment (visible only on MPS/Apple Silicon)
- Integrate `mlx_vae_chunk_size` into `GPUConfig` dataclass and MPS overrides

**Files changed (6 files, +125/-1):**
- `acestep/gpu_config.py` — `_auto_mlx_vae_chunk_size()` function + `mlx_vae_chunk_size` field in GPUConfig
- `acestep/core/generation/handler/mlx_vae_decode_native.py` — read chunk size from handler/config instead of hardcoded
- `acestep/handler.py` — initialize `mlx_vae_chunk_size` from gpu_config
- `acestep/ui/gradio/interfaces/generation_advanced_dit_controls.py` — MLX VAE Chunk Size slider
- `acestep/ui/gradio/events/wiring/generation_service_wiring.py` — wire slider to handler
- `acestep/core/generation/handler/mlx_vae_native_test.py` — 2 new tests for custom chunk size

## Priority chain

1. `ACESTEP_MLX_VAE_CHUNK` env var
2. Gradio UI slider
3. Auto-detected from unified memory at init

## Test plan

- [x] 2 new unit tests: custom chunk triggers tiling, large chunk skips tiling
- [ ] Manual test on Apple Silicon with different chunk sizes
- [ ] Verify env var override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable MLX VAE decode chunk size with automatic GPU-memory-based tuning and env var override
  * UI slider (shown on Apple Silicon / MPS) to adjust MLX VAE chunk size at runtime
* **Behavior**
  * MLX VAE decoding now respects the configured chunk size, affecting tiling, segmenting, and number of decode calls
* **Tests**
  * Added unit tests covering chunk-size selection and decode-tiling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->