### PR TITLE
fix: replace Bash 4.0+ uppercase syntax for macOS compatibility

### DIFF
--- a/check_update.sh
+++ b/check_update.sh
@@ -102,7 +102,7 @@ if [[ -z "$REMOTE_COMMIT" ]]; then
     echo
 
     read -rp "  Switch to main branch? (Y/N): " SWITCH_BRANCH
-    if [[ "${SWITCH_BRANCH^^}" == "Y" ]]; then
+    if [[ "$SWITCH_BRANCH" == "Y" || "$SWITCH_BRANCH" == "y" ]]; then
         echo
         echo "  Switching to main branch..."
         if "$GIT_PATH" checkout main; then
@@ -145,7 +145,7 @@ if "$GIT_PATH" merge-base --is-ancestor HEAD "origin/$CURRENT_BRANCH" 2>/dev/nul
     echo
 
     read -rp "Do you want to update now? (Y/N): " UPDATE_CHOICE
-    if [[ "${UPDATE_CHOICE^^}" != "Y" ]]; then
+    if [[ "$UPDATE_CHOICE" != "Y" && "$UPDATE_CHOICE" != "y" ]]; then
         echo
         echo "Update skipped."
         exit 0
@@ -204,7 +204,7 @@ if "$GIT_PATH" merge-base --is-ancestor HEAD "origin/$CURRENT_BRANCH" 2>/dev/nul
             echo
 
             read -rp "Continue with update? (Y/N): " CONFLICT_CHOICE
-            if [[ "${CONFLICT_CHOICE^^}" != "Y" ]]; then
+            if [[ "$CONFLICT_CHOICE" != "Y" && "$CONFLICT_CHOICE" != "y" ]]; then
                 echo
                 echo "Update cancelled. Your backup remains at: $BACKUP_DIR"
                 exit 0
@@ -217,7 +217,7 @@ if "$GIT_PATH" merge-base --is-ancestor HEAD "origin/$CURRENT_BRANCH" 2>/dev/nul
             echo
 
             read -rp "Stash your changes and continue? (Y/N): " STASH_CHOICE
-            if [[ "${STASH_CHOICE^^}" == "Y" ]]; then
+            if [[ "$STASH_CHOICE" == "Y" || "$STASH_CHOICE" == "y" ]]; then
                 echo "Stashing changes..."
                 "$GIT_PATH" stash push -m "Auto-stash before update - $(date)"
             else
@@ -255,7 +255,7 @@ if "$GIT_PATH" merge-base --is-ancestor HEAD "origin/$CURRENT_BRANCH" 2>/dev/nul
             echo
 
             read -rp "Stash untracked files before updating? (Y/N): " STASH_UNTRACKED_CHOICE
-            if [[ "${STASH_UNTRACKED_CHOICE^^}" != "Y" ]]; then
+            if [[ "$STASH_UNTRACKED_CHOICE" != "Y" && "$STASH_UNTRACKED_CHOICE" != "y" ]]; then
                 echo
                 echo "Update cancelled. Please move or remove the conflicting files manually."
                 exit 1


### PR DESCRIPTION
## Summary

- Fix `check_update.sh` crashing on macOS with `bad substitution` error
- Replace all 5 occurrences of `${VAR^^}` (Bash 4.0+ only) with explicit `Y`/`y` comparisons
- Ensures compatibility with macOS default Bash 3.2

Fixes #1060

## Root Cause

macOS ships with Bash 3.2 due to GPLv3 licensing. The `${VAR^^}` uppercase parameter expansion was introduced in Bash 4.0 and is not available on the default macOS shell.

## Changes

Replaced all `${VAR^^}` patterns with explicit case checks:
```bash
# Before
if [[ "${UPDATE_CHOICE^^}" == "Y" ]]; then

# After  
if [[ "$UPDATE_CHOICE" == "Y" || "$UPDATE_CHOICE" == "y" ]]; then
```

Affected lines (5 total): 105, 148, 207, 220, 258

## Test plan

- [ ] Verify script runs without error on macOS with Bash 3.2
- [ ] Verify both `Y` and `y` inputs are accepted at all prompts
- [ ] Verify `N`/`n` and other inputs are correctly rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-input handling in the update script to accept lowercase 'y' in addition to uppercase 'Y' for all confirmation prompts, including branch switching, update confirmation, conflict detection handling, and file stashing operations, enhancing overall usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->