### PR TITLE
fix: validate Gradio dropdown values against choices to prevent errors

### DIFF
--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -116,10 +116,13 @@ def build_model_device_controls(
                 else (available_models[0] if available_models else None)
             )
         )
+        config_value = params.get("config_path", default_model) if service_pre_initialized else default_model
+        if config_value not in available_models:
+            config_value = default_model
         config_path = gr.Dropdown(
             label=t("service.model_path_label"),
             choices=available_models,
-            value=params.get("config_path", default_model) if service_pre_initialized else default_model,
+            value=config_value,
             info=t("service.model_path_info"),
             elem_classes=["has-info-container"],
         )
@@ -165,10 +168,13 @@ def build_lm_backend_controls(
     with gr.Row():
         all_lm_models = llm_handler.get_available_5hz_lm_models()
         default_lm_model = find_best_lm_model_on_disk(recommended_lm, all_lm_models)
+        lm_value = params.get("lm_model_path", default_lm_model) if service_pre_initialized else default_lm_model
+        if lm_value not in all_lm_models:
+            lm_value = default_lm_model
         lm_model_path = gr.Dropdown(
             label=t("service.lm_model_path_label"),
             choices=all_lm_models,
-            value=params.get("lm_model_path", default_lm_model) if service_pre_initialized else default_lm_model,
+            value=lm_value,
             info=t("service.lm_model_path_info")
             + (
                 f" (Recommended: {recommended_lm})"
@@ -177,9 +183,12 @@ def build_lm_backend_controls(
             ),
             elem_classes=["has-info-container"],
         )
+        backend_value = params.get("backend", recommended_backend) if service_pre_initialized else recommended_backend
+        if backend_value not in available_backends:
+            backend_value = recommended_backend
         backend_dropdown = gr.Dropdown(
             choices=available_backends,
-            value=params.get("backend", recommended_backend) if service_pre_initialized else recommended_backend,
+            value=backend_value,
             label=t("service.backend_label"),
             info=t("service.backend_info")
             + (

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -77,10 +77,14 @@ def build_checkpoint_controls(dit_handler: Any, service_pre_initialized: bool, p
 
     with gr.Row(equal_height=True):
         with gr.Column(scale=4):
+            available_checkpoints = dit_handler.get_available_checkpoints()
+            checkpoint_value = params.get("checkpoint") if service_pre_initialized else None
+            if checkpoint_value is not None and checkpoint_value not in available_checkpoints:
+                checkpoint_value = None
             checkpoint_dropdown = gr.Dropdown(
                 label=t("service.checkpoint_label"),
-                choices=dit_handler.get_available_checkpoints(),
-                value=params.get("checkpoint") if service_pre_initialized else None,
+                choices=available_checkpoints,
+                value=checkpoint_value,
                 info=t("service.checkpoint_info"),
                 elem_classes=["has-info-container"],
             )

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -130,9 +130,12 @@ def build_model_device_controls(
             info=t("service.model_path_info"),
             elem_classes=["has-info-container"],
         )
+        allowed_devices = ["auto", "cuda", "mps", "xpu", "cpu"]
         device_value = params.get("device", "auto") if service_pre_initialized else "auto"
+        if device_value not in allowed_devices:
+            device_value = "auto"
         device = gr.Dropdown(
-            choices=["auto", "cuda", "mps", "xpu", "cpu"],
+            choices=allowed_devices,
             value=device_value,
             label=t("service.device_label"),
             info=t("service.device_info"),


### PR DESCRIPTION
## Summary

- Validate all service-config dropdown values against their choices lists before passing to `gr.Dropdown`, falling back to computed defaults when the value is unavailable
- Fixes 4 dropdowns: `lm_model_path`, `config_path`, `backend`, and `checkpoint` in `generation_service_config_rows.py`
- Prevents Gradio validation crash when a pre-initialized or GPU-tier-recommended model is not present on disk

## Test plan

- [ ] Launch Gradio UI with only `acestep-5Hz-lm-1.7B` on disk on a tier3/tier4 GPU (recommends 0.6B) — dropdown should show 1.7B instead of crashing
- [ ] Launch with `--init_service --lm_model_path acestep-5Hz-lm-0.6B` when only 1.7B is available — should gracefully fall back
- [ ] Launch normally with matching models on disk — behavior unchanged
- [ ] Verify all 4 dropdown types (checkpoint, config_path, lm_model_path, backend) work correctly

Fixes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown validation and defaulting for generation settings. Prefilled values for checkpoint, model path, device, language-model path, and backend are now validated against available options when the service is initialized; invalid or unavailable selections are reset to sensible defaults (e.g., automatic device or recommended backend) to prevent inconsistent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->