### PR TITLE
fix: validate dropdown values and remove ffmpeg -abr flag

### DIFF
--- a/acestep/audio_utils.py
+++ b/acestep/audio_utils.py
@@ -172,7 +172,6 @@ class AudioSaver:
                 '-codec:a', 'libmp3lame',
                 '-ar', str(int(target_sample_rate)),
                 '-b:a', bitrate,
-                '-abr', '0',
                 str(output_path),
             ]
             subprocess.run(cmd, check=True, capture_output=True, timeout=120)

--- a/acestep/audio_utils_test.py
+++ b/acestep/audio_utils_test.py
@@ -144,8 +144,7 @@ class AudioSaverFormatTests(unittest.TestCase):
             self.assertIn('libmp3lame', cmd)
             self.assertIn('128k', cmd)
             self.assertIn('48000', cmd)
-            self.assertIn('-abr', cmd)
-            self.assertIn('0', cmd)
+            self.assertNotIn('-abr', cmd)
 
     def test__save_mp3_uses_custom_bitrate_and_sample_rate(self):
         """MP3 export should honor explicit bitrate/sample-rate overrides."""

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -79,8 +79,12 @@ def build_checkpoint_controls(dit_handler: Any, service_pre_initialized: bool, p
         with gr.Column(scale=4):
             checkpoint_dropdown = gr.Dropdown(
                 label=t("service.checkpoint_label"),
-                choices=dit_handler.get_available_checkpoints(),
-                value=params.get("checkpoint") if service_pre_initialized else None,
+                choices=(ckpt_choices := dit_handler.get_available_checkpoints()),
+                value=(
+                    params.get("checkpoint")
+                    if service_pre_initialized and params.get("checkpoint") in ckpt_choices
+                    else (ckpt_choices[0] if ckpt_choices else None)
+                ),
                 info=t("service.checkpoint_info"),
                 elem_classes=["has-info-container"],
             )
@@ -119,7 +123,11 @@ def build_model_device_controls(
         config_path = gr.Dropdown(
             label=t("service.model_path_label"),
             choices=available_models,
-            value=params.get("config_path", default_model) if service_pre_initialized else default_model,
+            value=(
+                params.get("config_path", default_model)
+                if service_pre_initialized and params.get("config_path", default_model) in available_models
+                else default_model
+            ),
             info=t("service.model_path_info"),
             elem_classes=["has-info-container"],
         )
@@ -168,7 +176,11 @@ def build_lm_backend_controls(
         lm_model_path = gr.Dropdown(
             label=t("service.lm_model_path_label"),
             choices=all_lm_models,
-            value=params.get("lm_model_path", default_lm_model) if service_pre_initialized else default_lm_model,
+            value=(
+                params.get("lm_model_path", default_lm_model)
+                if service_pre_initialized and params.get("lm_model_path", default_lm_model) in all_lm_models
+                else default_lm_model
+            ),
             info=t("service.lm_model_path_info")
             + (
                 f" (Recommended: {recommended_lm})"
@@ -179,7 +191,11 @@ def build_lm_backend_controls(
         )
         backend_dropdown = gr.Dropdown(
             choices=available_backends,
-            value=params.get("backend", recommended_backend) if service_pre_initialized else recommended_backend,
+            value=(
+                params.get("backend", recommended_backend)
+                if service_pre_initialized and params.get("backend", recommended_backend) in available_backends
+                else recommended_backend
+            ),
             label=t("service.backend_label"),
             info=t("service.backend_info")
             + (


### PR DESCRIPTION
## Summary
- **Fixes #1064**: Dropdown controls now validate that pre-initialized param values exist in the choices list before using them, falling back to the best available option. Prevents Gradio validation crashes when a GPU-tier-recommended model is not downloaded.
- **Fixes #1021**: Remove the `-abr 0` ffmpeg flag from MP3 export. Some ffmpeg builds (especially on Windows) don't recognize this option. The flag is unnecessary when using CBR mode with `-b:a`.

## Test plan
- [x] All 34 existing `audio_utils_test.py` tests pass
- [ ] Launch Gradio UI with a model recommendation that isn't on disk — dropdown should fall back gracefully
- [ ] Export MP3 on Windows with stock ffmpeg — should succeed without `-abr` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adjusted MP3 audio export transcoding configuration to optimize codec settings for better audio processing behavior and efficiency.
  * Improved UI dropdown menu initialization to properly handle pre-configured service settings across checkpoint, model, backend, and language model selections, with intelligent fallback mechanisms that automatically select suitable defaults when configured values are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->