### PR TITLE
Fixing an issue where a Python library is not recognized in the portable version

### DIFF
--- a/docs/en/INSTALL.md
+++ b/docs/en/INSTALL.md
@@ -283,7 +283,7 @@ merge_config.bat                    ./merge_config.sh
 For Windows users, we provide a portable package with pre-installed dependencies:
 
 1. Download and extract: [ACE-Step-1.5.7z](https://files.acemusic.ai/acemusic/win/ACE-Step-1.5.7z)
-2. The package includes `python_embedded` with all dependencies pre-installed
+2. The package includes `python_embeded` with all dependencies pre-installed
 3. **Requirements:** CUDA 12.8
 
 ### Quick Start Scripts
@@ -351,7 +351,7 @@ Features: 10s timeout protection, smart conflict detection & backup, automatic r
 
 ### Environment Detection Priority
 
-1. `python_embedded\python.exe` (if exists)
+1. `python_embeded\python.exe` (if exists)
 2. `uv run acestep` (if uv is installed)
 3. Auto-install uv via winget or PowerShell
 

--- a/quick_test.bat
+++ b/quick_test.bat
@@ -30,13 +30,13 @@ if !ERRORLEVEL! EQU 0 (
 )
 echo.
 
-REM Test 3: Check python_embedded
-echo [Test 3] Checking python_embedded...
-if exist "%~dp0python_embedded\python.exe" (
-    echo [PASS] python_embedded found
-    "%~dp0python_embedded\python.exe" --version
+REM Test 3: Check python_embeded
+echo [Test 3] Checking python_embeded...
+if exist "%~dp0python_embeded\python.exe" (
+    echo [PASS] python_embeded found
+    "%~dp0python_embeded\python.exe" --version
 ) else (
-    echo [INFO] python_embedded not found
+    echo [INFO] python_embeded not found
 )
 echo.
 
@@ -76,8 +76,8 @@ echo.
 REM Determine which environment will be used
 set ENV_FOUND=0
 
-if exist "%~dp0python_embedded\python.exe" (
-    echo [RESULT] Will use: python_embedded
+if exist "%~dp0python_embeded\python.exe" (
+    echo [RESULT] Will use: python_embeded
     echo No additional setup needed!
     set ENV_FOUND=1
 )

--- a/start_api_server.bat
+++ b/start_api_server.bat
@@ -121,11 +121,11 @@ echo API Documentation: http://%HOST%:%PORT%/docs
 echo.
 
 REM Auto-detect Python environment
-if exist "%~dp0python_embedded\python.exe" (
+if exist "%~dp0python_embeded\python.exe" (
     echo [Environment] Using embedded Python...
 
     REM Build command with optional parameters
-    set "PYTHON_EXE=%~dp0python_embedded\python.exe"
+    set "PYTHON_EXE=%~dp0python_embeded\python.exe"
     set "SCRIPT_PATH=%~dp0acestep\api_server.py"
     set "CMD=--host %HOST% --port %PORT%"
     if not "%API_KEY%"=="" set "CMD=!CMD! %API_KEY%"
@@ -145,7 +145,7 @@ if exist "%~dp0python_embedded\python.exe" (
         echo ========================================
         echo.
         echo ACE-Step requires either:
-        echo   1. python_embedded directory ^(portable package^)
+        echo   1. python_embeded directory ^(portable package^)
         echo   2. uv package manager
         echo.
         echo Would you like to install uv now? ^(Recommended^)

--- a/start_api_server_macos.sh
+++ b/start_api_server_macos.sh
@@ -139,23 +139,23 @@ echo "API Documentation: http://${HOST}:${PORT}/docs"
 echo
 
 # ==================== Auto-detect Python environment ====================
-# Priority: python_embedded (portable package) > uv
-if [[ -f "$SCRIPT_DIR/python_embedded/bin/python3.11" ]]; then
-    echo "[Environment] Found embedded Python, verifying..."
+# Priority: python_embeded (portable package) > uv
+if [[ -f "$SCRIPT_DIR/python_embeded/bin/python3.11" ]]; then
+    echo "[Environment] Found embeded Python, verifying..."
 
     # Proactively fix permissions and Gatekeeper BEFORE any execution attempt.
     # On macOS Sequoia, running a quarantined binary triggers a blocking popup,
     # so we must strip attributes and re-sign first.
-    chmod +x "$SCRIPT_DIR/python_embedded/bin/"* 2>/dev/null || true
+    chmod +x "$SCRIPT_DIR/python_embeded/bin/"* 2>/dev/null || true
     echo "[Setup] Removing quarantine attributes..."
-    xattr -cr "$SCRIPT_DIR/python_embedded" 2>/dev/null || true
+    xattr -cr "$SCRIPT_DIR/python_embeded" 2>/dev/null || true
     echo "[Setup] Re-signing binaries (ad-hoc)..."
-    find "$SCRIPT_DIR/python_embedded" -type f \( -name "*.dylib" -o -name "*.so" -o -perm +111 \) \
+    find "$SCRIPT_DIR/python_embeded" -type f \( -name "*.dylib" -o -name "*.so" -o -perm +111 \) \
         -exec codesign --force --sign - {} \; 2>/dev/null || true
 
-    if "$SCRIPT_DIR/python_embedded/bin/python3.11" -c "pass" 2>/dev/null; then
-        echo "[Environment] Using embedded Python."
-        PYTHON_EXE="$SCRIPT_DIR/python_embedded/bin/python3.11"
+    if "$SCRIPT_DIR/python_embeded/bin/python3.11" -c "pass" 2>/dev/null; then
+        echo "[Environment] Using embeded Python."
+        PYTHON_EXE="$SCRIPT_DIR/python_embeded/bin/python3.11"
         SCRIPT_PATH="$SCRIPT_DIR/acestep/api_server.py"
 
         # On Apple Silicon, verify MLX packages work with this macOS version.

--- a/start_api_server_macos.sh
+++ b/start_api_server_macos.sh
@@ -159,7 +159,7 @@ if [[ -f "$SCRIPT_DIR/python_embeded/bin/python3.11" ]]; then
         SCRIPT_PATH="$SCRIPT_DIR/acestep/api_server.py"
 
         # On Apple Silicon, verify MLX packages work with this macOS version.
-        # python_embedded may ship wheels built for a different macOS; pip
+        # python_embeded may ship wheels built for a different macOS; pip
         # reinstall fetches the correct platform wheel automatically.
         if [[ "$ARCH" == "arm64" ]]; then
             _need_mlx_fix=0

--- a/start_gradio_ui.bat
+++ b/start_gradio_ui.bat
@@ -138,11 +138,11 @@ echo Server will be available at: http://%SERVER_NAME%:%PORT%
 echo.
 
 REM Auto-detect Python environment
-if exist "%~dp0python_embedded\python.exe" (
+if exist "%~dp0python_embeded\python.exe" (
     echo [Environment] Using embedded Python...
 
     REM Build command with optional parameters
-    set "PYTHON_EXE=%~dp0python_embedded\python.exe"
+    set "PYTHON_EXE=%~dp0python_embeded\python.exe"
     set "SCRIPT_PATH=%~dp0acestep\acestep_v15_pipeline.py"
     set "CMD=--port %PORT% --server-name %SERVER_NAME% --language %LANGUAGE%"
     if not "%SHARE%"=="" set "CMD=!CMD! %SHARE%"
@@ -171,7 +171,7 @@ if exist "%~dp0python_embedded\python.exe" (
         echo ========================================
         echo.
         echo ACE-Step requires either:
-        echo   1. python_embedded directory ^(portable package^)
+        echo   1. python_embeded directory ^(portable package^)
         echo   2. uv package manager
         echo.
         echo Would you like to install uv now? ^(Recommended^)

--- a/start_gradio_ui_macos.sh
+++ b/start_gradio_ui_macos.sh
@@ -234,22 +234,22 @@ echo
 
 # ==================== Auto-detect Python environment ====================
 # Priority: python_embedded (portable package) > uv
-if [[ -f "$SCRIPT_DIR/python_embedded/bin/python3.11" ]]; then
-    echo "[Environment] Found embedded Python, verifying..."
+if [[ -f "$SCRIPT_DIR/python_embeded/bin/python3.11" ]]; then
+    echo "[Environment] Found embeded Python, verifying..."
 
     # Proactively fix permissions and Gatekeeper BEFORE any execution attempt.
     # On macOS Sequoia, running a quarantined binary triggers a blocking popup,
     # so we must strip attributes and re-sign first.
-    chmod +x "$SCRIPT_DIR/python_embedded/bin/"* 2>/dev/null || true
+    chmod +x "$SCRIPT_DIR/python_embeded/bin/"* 2>/dev/null || true
     echo "[Setup] Removing quarantine attributes..."
-    xattr -cr "$SCRIPT_DIR/python_embedded" 2>/dev/null || true
+    xattr -cr "$SCRIPT_DIR/python_embeded" 2>/dev/null || true
     echo "[Setup] Re-signing binaries (ad-hoc)..."
-    find "$SCRIPT_DIR/python_embedded" -type f \( -name "*.dylib" -o -name "*.so" -o -perm +111 \) \
+    find "$SCRIPT_DIR/python_embeded" -type f \( -name "*.dylib" -o -name "*.so" -o -perm +111 \) \
         -exec codesign --force --sign - {} \; 2>/dev/null || true
 
-    if "$SCRIPT_DIR/python_embedded/bin/python3.11" -c "pass" 2>/dev/null; then
-        echo "[Environment] Using embedded Python."
-        PYTHON_EXE="$SCRIPT_DIR/python_embedded/bin/python3.11"
+    if "$SCRIPT_DIR/python_embeded/bin/python3.11" -c "pass" 2>/dev/null; then
+        echo "[Environment] Using embeded Python."
+        PYTHON_EXE="$SCRIPT_DIR/python_embeded/bin/python3.11"
         SCRIPT_PATH="$SCRIPT_DIR/acestep/acestep_v15_pipeline.py"
 
         # On Apple Silicon, verify MLX packages work with this macOS version.

--- a/start_gradio_ui_manual.bat
+++ b/start_gradio_ui_manual.bat
@@ -143,11 +143,11 @@ echo Server will be available at: http://%SERVER_NAME%:%PORT%
 echo.
 
 REM Auto-detect Python environment
-if exist "%~dp0python_embedded\python.exe" (
+if exist "%~dp0python_embeded\python.exe" (
     echo [Environment] Using embedded Python...
 
     REM Build command with optional parameters
-    set "PYTHON_EXE=%~dp0python_embedded\python.exe"
+    set "PYTHON_EXE=%~dp0python_embeded\python.exe"
     set "SCRIPT_PATH=%~dp0acestep\acestep_v15_pipeline.py"
     set "CMD=--port %PORT% --server-name %SERVER_NAME% --language %LANGUAGE%"
     if not "%SHARE%"=="" set "CMD=!CMD! %SHARE%"
@@ -176,7 +176,7 @@ if exist "%~dp0python_embedded\python.exe" (
         echo ========================================
         echo.
         echo ACE-Step requires either:
-        echo   1. python_embedded directory ^(portable package^)
+        echo   1. python_embeded directory ^(portable package^)
         echo   2. uv package manager
         echo.
         echo Would you like to install uv now? ^(Recommended^)

--- a/test_env_detection.bat
+++ b/test_env_detection.bat
@@ -60,7 +60,7 @@ if exist "%~dp0python_embeded\python.exe" (
         echo [RESULT] Will use: uv package manager
         echo Command: uv run acestep
     ) else (
-        echo [ERROR] Neither python_embedded nor uv found!
+        echo [ERROR] Neither python_embeded nor uv found!
         echo Please install uv or extract the portable package.
     )
 )

--- a/test_env_detection.bat
+++ b/test_env_detection.bat
@@ -8,16 +8,16 @@ echo ACE-Step Environment Detection Test
 echo ========================================
 echo.
 
-REM Test 1: Check if python_embedded exists
-echo [Test 1] Checking for python_embedded...
-if exist "%~dp0python_embedded\python.exe" (
-    echo [PASS] python_embedded detected
-    echo Location: %~dp0python_embedded\python.exe
+REM Test 1: Check if python_embeded exists
+echo [Test 1] Checking for python_embeded...
+if exist "%~dp0python_embeded\python.exe" (
+    echo [PASS] python_embeded detected
+    echo Location: %~dp0python_embeded\python.exe
 
     REM Get Python version
-    "%~dp0python_embedded\python.exe" --version
+    "%~dp0python_embeded\python.exe" --version
 ) else (
-    echo [INFO] python_embedded not found
+    echo [INFO] python_embeded not found
 )
 echo.
 
@@ -51,9 +51,9 @@ echo.
 
 REM Test 4: Determine which environment will be used
 echo [Test 4] Environment selection logic...
-if exist "%~dp0python_embedded\python.exe" (
-    echo [RESULT] Will use: Embedded Python ^(python_embedded^)
-    echo Command: python_embedded\python.exe acestep\acestep_v15_pipeline.py
+if exist "%~dp0python_embeded\python.exe" (
+    echo [RESULT] Will use: Embedded Python ^(python_embeded^)
+    echo Command: python_embeded\python.exe acestep\acestep_v15_pipeline.py
 ) else (
     where uv >nul 2>&1
     if !ERRORLEVEL! EQU 0 (


### PR DESCRIPTION
Fixing an issue where a Python library is not recognized in the portable version
There is a typo of python_embedded instead of python_embeded, it's actually an extra letter d.
I fixed it. Please note that there may be additional errors. Fix this throughout the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with corrected embedded Python directory structure references

* **Chores**
  * Synchronized embedded Python directory path references across all startup scripts and testing utilities to ensure consistent environment detection and accurate user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->