### PR TITLE
fix: add ACESTEP_SKIP_VRAM_PREFLIGHT env var + gc before preflight check

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -5,6 +5,7 @@ This module provides the public ``generate_music`` entry point extracted from
 """
 
 import gc
+import os
 import traceback
 from typing import Any, Dict, List, Optional, Union
 
@@ -386,13 +387,24 @@ class GenerateMusicMixin:
                 repainting_end=repainting_end,
                 chunk_mask_mode=chunk_mask_mode,
             )
-            vram_error = self._vram_preflight_check(
-                actual_batch_size=actual_batch_size,
-                audio_duration=audio_duration,
-                guidance_scale=guidance_scale,
-            )
-            if vram_error is not None:
-                return vram_error
+            gc.collect()
+            torch.cuda.empty_cache()
+            skip_preflight = os.environ.get(
+                "ACESTEP_SKIP_VRAM_PREFLIGHT", "",
+            ).lower() in ("1", "true", "yes")
+            if skip_preflight:
+                logger.debug(
+                    "[generate_music] VRAM pre-flight skipped "
+                    "(ACESTEP_SKIP_VRAM_PREFLIGHT=true)"
+                )
+            else:
+                vram_error = self._vram_preflight_check(
+                    actual_batch_size=actual_batch_size,
+                    audio_duration=audio_duration,
+                    guidance_scale=guidance_scale,
+                )
+                if vram_error is not None:
+                    return vram_error
 
             injection_ratio, resolved_cf_frames, resolved_wav_cf = (
                 _resolve_repaint_config(repaint_mode, repaint_strength)

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -387,25 +387,26 @@ class GenerateMusicMixin:
                 repainting_end=repainting_end,
                 chunk_mask_mode=chunk_mask_mode,
             )
-            gc.collect()
-            torch.cuda.empty_cache()
-            skip_preflight = os.environ.get(
-                "ACESTEP_SKIP_VRAM_PREFLIGHT", "",
-            ).lower() in ("1", "true", "yes")
-            if skip_preflight:
-                logger.warning(
-                    "[generate_music] VRAM pre-flight check skipped via "
-                    "ACESTEP_SKIP_VRAM_PREFLIGHT=1. If generation OOMs, "
-                    "unset this variable to re-enable the safety check."
-                )
-            else:
-                vram_error = self._vram_preflight_check(
-                    actual_batch_size=actual_batch_size,
-                    audio_duration=audio_duration,
-                    guidance_scale=guidance_scale,
-                )
-                if vram_error is not None:
-                    return vram_error
+            if torch.cuda.is_available():
+                gc.collect()
+                torch.cuda.empty_cache()
+                skip_preflight = os.environ.get(
+                    "ACESTEP_SKIP_VRAM_PREFLIGHT", "",
+                ).lower() in ("1", "true", "yes")
+                if skip_preflight:
+                    logger.warning(
+                        "[generate_music] VRAM pre-flight check skipped via "
+                        "ACESTEP_SKIP_VRAM_PREFLIGHT=1. If generation OOMs, "
+                        "unset this variable to re-enable the safety check."
+                    )
+                else:
+                    vram_error = self._vram_preflight_check(
+                        actual_batch_size=actual_batch_size,
+                        audio_duration=audio_duration,
+                        guidance_scale=guidance_scale,
+                    )
+                    if vram_error is not None:
+                        return vram_error
 
             injection_ratio, resolved_cf_frames, resolved_wav_cf = (
                 _resolve_repaint_config(repaint_mode, repaint_strength)

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -393,9 +393,10 @@ class GenerateMusicMixin:
                 "ACESTEP_SKIP_VRAM_PREFLIGHT", "",
             ).lower() in ("1", "true", "yes")
             if skip_preflight:
-                logger.debug(
-                    "[generate_music] VRAM pre-flight skipped "
-                    "(ACESTEP_SKIP_VRAM_PREFLIGHT=true)"
+                logger.warning(
+                    "[generate_music] VRAM pre-flight check skipped via "
+                    "ACESTEP_SKIP_VRAM_PREFLIGHT=1. If generation OOMs, "
+                    "unset this variable to re-enable the safety check."
                 )
             else:
                 vram_error = self._vram_preflight_check(

--- a/acestep/core/generation/handler/generate_music_test.py
+++ b/acestep/core/generation/handler/generate_music_test.py
@@ -292,6 +292,58 @@ class VramPreflightCheckTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class VramPreflightOrchestrationTests(unittest.TestCase):
+    """Verify CUDA cleanup and the explicit preflight escape hatch."""
+
+    _GM_MOD = GENERATE_MUSIC_MODULE
+
+    @patch.object(_GM_MOD.gc, "collect")
+    @patch.object(_GM_MOD.torch.cuda, "empty_cache")
+    @patch.object(_GM_MOD.torch.cuda, "is_available", return_value=True)
+    def test_generate_music_runs_preflight_by_default(
+        self, _mock_cuda, mock_empty_cache, mock_collect
+    ):
+        """The safety check stays enabled when no opt-out is requested."""
+        host = _Host()
+        with (
+            patch.dict(
+                self._GM_MOD.os.environ,
+                {"ACESTEP_SKIP_VRAM_PREFLIGHT": ""},
+            ),
+            patch.object(
+                host, "_vram_preflight_check", return_value=None
+            ) as mock_preflight,
+        ):
+            out = host.generate_music(captions="cap", lyrics="lyr")
+
+        self.assertEqual(out, host._final_payload)
+        mock_collect.assert_called_with()
+        mock_empty_cache.assert_called_once_with()
+        mock_preflight.assert_called_once()
+
+    @patch.object(_GM_MOD.gc, "collect")
+    @patch.object(_GM_MOD.torch.cuda, "empty_cache")
+    @patch.object(_GM_MOD.torch.cuda, "is_available", return_value=True)
+    def test_generate_music_skips_preflight_only_when_explicitly_requested(
+        self, _mock_cuda, mock_empty_cache, mock_collect
+    ):
+        """The documented environment flag bypasses only the safety check."""
+        host = _Host()
+        with (
+            patch.dict(
+                self._GM_MOD.os.environ,
+                {"ACESTEP_SKIP_VRAM_PREFLIGHT": "true"},
+            ),
+            patch.object(host, "_vram_preflight_check") as mock_preflight,
+        ):
+            out = host.generate_music(captions="cap", lyrics="lyr")
+
+        self.assertEqual(out, host._final_payload)
+        mock_collect.assert_called_with()
+        mock_empty_cache.assert_called_once_with()
+        mock_preflight.assert_not_called()
+
+
 class TurboGuidanceScaleTests(unittest.TestCase):
     """Verify turbo models force guidance_scale to 1.0 (issue #927)."""
 


### PR DESCRIPTION
### Summary
- Run `gc.collect()` + `torch.cuda.empty_cache()` before the VRAM pre-flight check so it measures actual free VRAM, not memory held by PyTorch's caching allocator
- Add `ACESTEP_SKIP_VRAM_PREFLIGHT=1` env var to bypass the check entirely for tight-VRAM setups

### Scope
- **File changed:** `acestep/core/generation/handler/generate_music.py`
- **Out of scope:** `_vram_preflight_check()` method itself is unchanged

### Risk and Compatibility
- **Target platform:** CUDA (shared-GPU setups with 24 GB cards where desktop compositor shares VRAM)
- **Non-target platforms unchanged:** CPU/MPS/XPU paths already return None before reaching the preflight check
- **Default behavior unchanged:** check runs as before unless the env var is explicitly set

### Why
On shared-GPU setups (e.g., 24 GB RTX 3090 with desktop compositor using 2-3 GB), the pre-flight check reports e.g. "1.3 GB free, needs 1.4 GB" and blocks generation, even though PyTorch's caching allocator can handle it via `expandable_segments:True`. The `gc.collect()` + `torch.cuda.empty_cache()` before the check reclaims fragmented allocator cache so the measurement reflects actual free memory. The env var provides an escape hatch for setups where even the corrected check is too conservative.

### Regression Checks
- Verified on RTX 3090 (24 GB) with desktop compositor (2.5 GB shared)
- Default path (no env var): check still runs, now with more accurate free VRAM measurement
- `ACESTEP_SKIP_VRAM_PREFLIGHT=1`: check skipped, debug log emitted
- Existing `_vram_preflight_check` unit tests pass (method unchanged)

### Reviewer Notes
- Follows existing env var convention: `ACESTEP_` prefix, boolean parsing via `.lower() in ("1", "true", "yes")`
- Similar pattern to `ACESTEP_VAE_ON_CPU` in `generate_music_decode.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded music generation with DCW configuration, cached repaint latents, retake seed and variance controls, and flow-edit parameters.
  * Added support for flow editing with source audio duration handling across supported generation modes.
  * Added an environment-driven option to bypass GPU VRAM preflight checks when needed.
* **Bug Fixes**
  * Improved default handling by resolving unspecified DCW settings from the loaded model.
  * Added warnings for unsupported flow-edit task types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->