### PR TITLE
docs: clarify use_cot_lyrics is a CLI-layer gate (#1105)

### DIFF
--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -161,7 +161,7 @@ class GenerationParams:
     lm_negative_prompt: str = "NO USER INPUT"
     use_cot_metas: bool = True
     use_cot_caption: bool = True
-    use_cot_lyrics: bool = False  # TODO: not used yet
+    use_cot_lyrics: bool = False  # gate is read in cli.py; not consumed by inference (see cot_lyrics below)
     use_cot_language: bool = True
     use_constrained_decoding: bool = True
 


### PR DESCRIPTION
## Summary

- One-line comment fix on `acestep/inference.py:164`. The `use_cot_lyrics` field on `GenerationParams` was marked `# TODO: not used yet`, which is literally true inside `inference.py` but misleading because the flag IS consumed — just at the CLI layer (`cli.py`, ~20 refs), where it gates CoT lyric generation and then assigns the result to `params.cot_lyrics`. The new comment points readers at the actual consumer so the field stops looking like dead behavior.
- Closes part of #1105 (option 2 — conservative comment-only fix). Removing the field entirely (option 1) is still on the table for a follow-up if maintainers prefer it; not done here because it touches three cli.py call sites.

## Test plan

- [x] No runtime behavior change (comment-only edit)
- [x] `grep -rn use_cot_lyrics acestep/` confirms the field is only declared in inference.py; all reads happen in cli.py — unchanged by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation regarding feature flag behavior.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->