### PR TITLE
Slightly better error handling when Triton is present but torch isn't…

### DIFF
--- a/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
@@ -67,7 +67,7 @@ def maybe_compile(fn: Optional[F] = None, **compile_kwargs: Any) -> Any:
                 )
                 return func
         logger.info(
-            "Triton not available — skipping torch.compile for %s "
+            "Triton not available — skipping torch.compile for {} "
             "(inference will use native PyTorch kernels)",
             func.__qualname__,
         )

--- a/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
+++ b/acestep/third_parts/nano-vllm/nanovllm/utils/compat.py
@@ -56,9 +56,18 @@ def maybe_compile(fn: Optional[F] = None, **compile_kwargs: Any) -> Any:
         """Inner decorator that performs the actual compile-or-skip logic."""
         if _HAS_TRITON:
             import torch
-            return torch.compile(func, **compile_kwargs)
+            try:
+                return torch.compile(func, **compile_kwargs)
+            except Exception as exc:
+                logger.warning(
+                    "torch.compile unavailable for {} ({}: {}) - using eager PyTorch kernels",
+                    func.__qualname__,
+                    type(exc).__name__,
+                    exc,
+                )
+                return func
         logger.info(
-            "Triton not available — skipping torch.compile for {} "
+            "Triton not available — skipping torch.compile for %s "
             "(inference will use native PyTorch kernels)",
             func.__qualname__,
         )


### PR DESCRIPTION
… compatible.

It is possible for Triton to be present but with an incompatible version of torch.   Rather then just 'sending it' when Triton is found, run an import check on each function and fall back to the non-compiled version when the import fails.

This prevents the situation where Ace-Step tells the user to install nano-vllm and they do, and then when they start ace-step again, it, again tells them to install nano-vllm but its already installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in compilation utilities when a specific accelerator is present: failures are now logged as warnings and the system falls back to normal execution instead of crashing, increasing stability and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->