### PR TITLE
fix(llm): align CFG unconditional prompt with training dropout format

### DIFF
--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -80,6 +80,12 @@ class LLMHandler:
         self._mlx_model = None
         self._mlx_model_path = None
 
+        # A/B toggle: when True, use the pre-fix prompt format for CFG uncond
+        # (keeps caption+lyrics in uncond, closes the assistant turn with <|im_end|>
+        # before codes). Intended for manual comparison against the training-aligned
+        # format only.
+        self.use_legacy_cfg_prompt = False
+
     def _clear_accelerator_cache(self) -> None:
         """Release freed accelerator memory back to the driver.
 
@@ -1716,6 +1722,31 @@ class LLMHandler:
         """
         if self.llm_tokenizer is None:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
+
+        if self.use_legacy_cfg_prompt:
+            # Legacy (pre-fix) path kept for manual A/B comparison. Uncond keeps
+            # the caption+lyrics wrapper and the assistant turn is closed with
+            # <|im_end|> before codes are generated.
+            if is_negative_prompt:
+                has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
+                cot_for_prompt = "<think>\n</think>"
+                caption_for_prompt = negative_prompt if has_negative_prompt else caption
+            else:
+                cot_for_prompt = cot_text
+                caption_for_prompt = caption
+            user_prompt = f"# Caption\n{caption_for_prompt}\n\n# Lyric\n{lyrics}\n"
+            formatted = self.llm_tokenizer.apply_chat_template(
+                [
+                    {"role": "system", "content": f"# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n"},
+                    {"role": "user", "content": user_prompt},
+                    {"role": "assistant", "content": cot_for_prompt},
+                ],
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+            if not formatted.endswith('\n'):
+                formatted += '\n'
+            return formatted
 
         if is_negative_prompt:
             # Match training CFG-dropout format: user message is the raw negative prompt

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -1715,9 +1715,9 @@ class LLMHandler:
         if is_negative_prompt:
             # Match training CFG-dropout format: user message is the raw negative prompt
             # (the literal "NO USER INPUT" when no override), NOT wrapped in
-            # "# Caption\n...\n\n# Lyric\n...\n". Empty CoT also has no inner newlines.
+            # "# Caption\n...\n\n# Lyric\n...\n".
             has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-            cot_for_prompt = "<think></think>"
+            cot_for_prompt = "<think>\n</think>"
             user_prompt = negative_prompt if has_negative_prompt else "NO USER INPUT"
         else:
             cot_for_prompt = cot_text

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -375,15 +375,20 @@ class LLMHandler:
         """Build unconditional prompt for CFG based on generation phase and batch mode"""
         if is_batch or generation_phase == "codes":
             # Codes phase or batch mode: use empty CoT in unconditional prompt
-            return self.build_formatted_prompt_with_cot(
+            prompt = self.build_formatted_prompt_with_cot(
                 caption, lyrics, cot_text, is_negative_prompt=True, negative_prompt=negative_prompt
             )
         else:
             # CoT phase (single mode only): unconditional prompt
             # If negative_prompt is provided, use it as caption; otherwise remove caption and keep only lyrics
-            return self.build_formatted_prompt(
+            prompt = self.build_formatted_prompt(
                 caption, lyrics, is_negative_prompt=True, generation_phase="cot", negative_prompt=negative_prompt
             )
+        logger.info(
+            f"CFG unconditional prompt (phase={generation_phase}, is_batch={is_batch}, "
+            f"negative_prompt={negative_prompt!r}):\n{prompt}"
+        )
+        return prompt
 
     def _load_pytorch_model(self, model_path: str, device: str) -> Tuple[bool, str]:
         """Load PyTorch model from path and return (success, status_message)"""

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -1713,44 +1713,28 @@ class LLMHandler:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
 
         if is_negative_prompt:
-            # Unconditional prompt for codes phase
-            # Check if user provided a meaningful negative prompt
+            # Match training CFG-dropout format: user message is the raw negative prompt
+            # (the literal "NO USER INPUT" when no override), NOT wrapped in
+            # "# Caption\n...\n\n# Lyric\n...\n". Empty CoT also has no inner newlines.
             has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-
-            # Use empty CoT for unconditional
-            cot_for_prompt = "<think>\n</think>"
-
-            if has_negative_prompt:
-                # If negative prompt provided, use it as caption
-                caption_for_prompt = negative_prompt
-            else:
-                # No negative prompt: use original caption
-                caption_for_prompt = caption
+            cot_for_prompt = "<think></think>"
+            user_prompt = negative_prompt if has_negative_prompt else "NO USER INPUT"
         else:
-            # Conditional prompt: use the full CoT and original caption
             cot_for_prompt = cot_text
-            caption_for_prompt = caption
+            user_prompt = f"# Caption\n{caption}\n\n# Lyric\n{lyrics}\n"
 
-        # Build user prompt with caption and lyrics ONLY (no COT)
-        # COT should be in the assistant's message, not user's
-        user_prompt = f"# Caption\n{caption_for_prompt}\n\n# Lyric\n{lyrics}\n"
-
-        # Build the chat with assistant message containing the COT
-        # The model will continue generation after the COT
+        # Keep the assistant turn OPEN so the model continues inside it with audio
+        # codes, matching the training layout `<think>...</think>{codes}<|im_end|>`.
+        # Adding cot as a role="assistant" message would close the turn with <|im_end|>.
         formatted = self.llm_tokenizer.apply_chat_template(
             [
                 {"role": "system", "content": f"# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n"},
                 {"role": "user", "content": user_prompt},
-                {"role": "assistant", "content": cot_for_prompt},
             ],
             tokenize=False,
-            add_generation_prompt=False,  # Don't add generation prompt, COT is already in assistant
+            add_generation_prompt=True,
         )
-
-        # Add a newline after </think> so model generates audio codes on next line
-        if not formatted.endswith('\n'):
-            formatted += '\n'
-
+        formatted += cot_for_prompt
         return formatted
 
     def build_formatted_prompt_for_understanding(

--- a/acestep/ui/gradio/events/wiring/generation_service_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_service_wiring.py
@@ -48,6 +48,15 @@ def register_generation_service_handlers(
         outputs=[generation_section["language_dropdown"]],
     )
 
+    def _set_legacy_cfg_prompt(enabled):
+        llm_handler.use_legacy_cfg_prompt = bool(enabled)
+
+    generation_section["lm_use_legacy_cfg_prompt"].change(
+        fn=_set_legacy_cfg_prompt,
+        inputs=[generation_section["lm_use_legacy_cfg_prompt"]],
+        outputs=[],
+    )
+
     generation_section["config_path"].change(
         fn=gen_h.update_model_type_settings,
         inputs=[generation_section["config_path"], generation_section["generation_mode"]],

--- a/acestep/ui/gradio/i18n/en.json
+++ b/acestep/ui/gradio/i18n/en.json
@@ -196,6 +196,8 @@
     "cot_language_info": "When enabled, the LM auto-detects the vocal language during chain-of-thought reasoning. Useful when language is ambiguous or set to 'unknown'. Disable if you've explicitly set the vocal language.",
     "constrained_debug_label": "Constrained Decoding Debug",
     "constrained_debug_info": "Shows detailed logs of how the LM's output tokens are being filtered/constrained. Only useful for developers debugging token generation issues. Leave off for normal use.",
+    "lm_use_legacy_cfg_prompt_label": "LM CFG: Legacy Uncond Prompt",
+    "lm_use_legacy_cfg_prompt_info": "Debug A/B toggle. OFF (default): CFG uncond uses the training-aligned format (user='NO USER INPUT', open assistant turn). ON: uses the pre-fix format (keeps caption+lyrics in uncond, closes assistant turn). Only affects codes-phase CFG. Leave OFF for production.",
     "auto_score_label": "Auto Score",
     "auto_score_info": "Automatically calculates a quality score (0–1) for each generated audio using perplexity. Higher = better. Useful for comparing results in a batch to find the best one. Adds a few seconds per sample.",
     "auto_lrc_label": "Auto LRC",

--- a/acestep/ui/gradio/i18n/ja.json
+++ b/acestep/ui/gradio/i18n/ja.json
@@ -193,6 +193,8 @@
     "cot_language_info": "CoTで言語を生成(思考の連鎖)。",
     "constrained_debug_label": "制約付きデコーディングデバッグ",
     "constrained_debug_info": "制約付きデコーディングのデバッグログを有効化(チェックすると詳細ログを表示)。",
+    "lm_use_legacy_cfg_prompt_label": "LM CFG: 旧無条件プロンプトを使用",
+    "lm_use_legacy_cfg_prompt_info": "デバッグ用A/Bトグル。オフ(既定): CFG無条件は学習と整合した形式を使用(user='NO USER INPUT'、assistantターン未クローズ)。オン: 修正前の旧ロジックを使用(無条件分岐でcaption+lyricsを保持し、assistantターンを閉じる)。codes段階のCFGにのみ影響します。",
     "auto_score_label": "自動スコアリング",
     "auto_score_info": "生成されたすべてのオーディオの品質スコアを自動計算。",
     "auto_lrc_label": "自動 LRC",

--- a/acestep/ui/gradio/i18n/pt.json
+++ b/acestep/ui/gradio/i18n/pt.json
@@ -196,6 +196,8 @@
     "cot_language_info": "Quando ativado, o LM detecta automaticamente o idioma vocal durante o raciocínio em cadeia de pensamento. Útil quando o idioma é ambíguo ou definido como 'unknown'. Desative se você definiu explicitamente o idioma vocal.",
     "constrained_debug_label": "Depuração de Decodificação Restrita",
     "constrained_debug_info": "Exibe registros detalhados de como os tokens de saída do LM estão sendo filtrados/restringidos. Útil apenas para desenvolvedores depurando problemas de geração de tokens. Deixe desativado para uso normal.",
+    "lm_use_legacy_cfg_prompt_label": "LM CFG: Prompt Incondicional Legado",
+    "lm_use_legacy_cfg_prompt_info": "Alternância A/B de depuração. DESLIGADO (padrão): CFG incondicional usa o formato alinhado ao treino (user='NO USER INPUT', turn do assistant aberto). LIGADO: usa a lógica pré-correção (mantém caption+lyrics no incondicional, fecha o turn do assistant). Afeta apenas CFG da fase de codes.",
     "auto_score_label": "Pontuação Automática",
     "auto_score_info": "Calcula automaticamente uma pontuação de qualidade (0–1) para cada áudio gerado usando perplexidade. Maior = melhor. Útil para comparar resultados em um lote e encontrar o melhor. Adiciona alguns segundos por amostra.",
     "auto_lrc_label": "LRC Automático",

--- a/acestep/ui/gradio/i18n/zh.json
+++ b/acestep/ui/gradio/i18n/zh.json
@@ -193,6 +193,8 @@
     "cot_language_info": "在CoT中生成语言(思维链)。",
     "constrained_debug_label": "约束解码调试",
     "constrained_debug_info": "启用约束解码的调试日志(勾选以查看详细日志)。",
+    "lm_use_legacy_cfg_prompt_label": "LM CFG: 使用旧版无条件 Prompt",
+    "lm_use_legacy_cfg_prompt_info": "调试用 A/B 开关。关闭(默认): CFG 无条件分支使用与训练对齐的格式(user='NO USER INPUT'，assistant turn 保持开放)。开启: 使用修复前的旧逻辑(无条件分支保留 caption+lyrics，assistant turn 被关闭)。仅影响 codes 阶段 CFG。",
     "auto_score_label": "自动评分",
     "auto_score_info": "自动计算所有生成音频的质量分数。",
     "auto_lrc_label": "自动 LRC",

--- a/acestep/ui/gradio/interfaces/generation_advanced_primary_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_advanced_primary_controls.py
@@ -144,6 +144,14 @@ def build_lm_controls(service_mode: bool) -> dict[str, Any]:
                 scale=1,
                 interactive=not service_mode,
             )
+            lm_use_legacy_cfg_prompt = gr.Checkbox(
+                label=t("generation.lm_use_legacy_cfg_prompt_label"),
+                value=False,
+                info=t("generation.lm_use_legacy_cfg_prompt_info"),
+                scale=1,
+                interactive=not service_mode,
+                elem_classes=["has-info-container"],
+            )
         with gr.Row():
             allow_lm_batch = gr.Checkbox(
                 label=t("generation.parallel_thinking_label"),
@@ -171,4 +179,5 @@ def build_lm_controls(service_mode: bool) -> dict[str, Any]:
         "constrained_decoding_debug": constrained_decoding_debug,
         "allow_lm_batch": allow_lm_batch,
         "use_cot_caption": use_cot_caption,
+        "lm_use_legacy_cfg_prompt": lm_use_legacy_cfg_prompt,
     }


### PR DESCRIPTION
## Summary

- Fix the CFG uncond `user` content to equal the bare negative-prompt string (the literal `"NO USER INPUT"` when no override is supplied), matching the training-time dropout layout, instead of falling back to the original `caption` + `lyrics`.
- Switch from `apply_chat_template([sys, user, assistant=cot], add_generation_prompt=False)` to `apply_chat_template([sys, user], add_generation_prompt=True) + cot` so the assistant turn stays open and codes are generated inside the same turn (model emits `<|im_end|>` naturally as stop).
- Keep the empty unconditional CoT as `"<think>\n</think>"` (inner newline preserved) to match the 1.5 training format.
- Log the rendered uncond prompt in `_build_unconditional_prompt`, symmetric to the already-logged cond prompt, so both sides of CFG are visible when manually validating runs.
- Add a debug-only Gradio checkbox **LM CFG: Legacy Uncond Prompt** (Advanced LM settings, next to Constrained Decoding Debug). It flips `LLMHandler.use_legacy_cfg_prompt` at runtime via a `.change()` callback. Default OFF uses the training-aligned format; ON reverts to the pre-fix format for side-by-side A/B comparison. Not persisted to metadata or plumbed through the API — debug only.

Closes #1126

## Test plan

- [ ] Render both branches of `build_formatted_prompt_with_cot` through the real 1.5 tokenizer (`checkpoints/acestep-5Hz-lm-0.6B`) and confirm:
  - Uncond `user` message is bare `"NO USER INPUT"` (or the supplied negative prompt), no `# Caption\n…\n\n# Lyric\n…\n` wrapper.
  - Prompt ends at `<think>\n</think>` / `<think>\n{cot}\n</think>` with no trailing `<|im_end|>` before the generation point.
- [ ] Verify the Gradio A/B toggle mutates `llm_handler.use_legacy_cfg_prompt` at runtime and the logged uncond prompt matches the toggle state.
- [ ] Manual inference with `lm_cfg_scale=2.0`: the fixed format should track the user's caption/lyrics more faithfully than the legacy format; the legacy toggle reproduces the pre-fix behaviour for direct A/B.
- [ ] Existing `acestep/llm_inference_cfg_fixes_test.py` still passes (it mocks `build_formatted_prompt_with_cot`, so the body change is transparent).
- [ ] Phase 1 (CoT) unaffected — it is forced to `cfg_scale=1.0` and does not exercise the changed branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new LM CFG prompt formatting option in advanced generation controls, enabling users to configure formatting behavior.
  * Expanded multilingual interface support with complete localization of the new setting in English, Japanese, Portuguese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->