### PR TITLE
fix(llm): add missing \n\n separator after </think> in CFG codes prompt

### DIFF
--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -1752,8 +1752,14 @@ class LLMHandler:
             # Match training CFG-dropout format: user message is the raw negative prompt
             # (the literal "NO USER INPUT" when no override), NOT wrapped in
             # "# Caption\n...\n\n# Lyric\n...\n".
+            #
+            # Empty reasoning is "<think>\n\n</think>" (not "<think>\n</think>"),
+            # because Qwen's chat template renders assistant messages containing a
+            # </think> tag through the pattern `<think>\n{reasoning.strip('\n')}\n
+            # </think>`, so empty reasoning produces the extra inner newline that the
+            # model actually saw during training.
             has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-            cot_for_prompt = "<think>\n</think>"
+            cot_for_prompt = "<think>\n\n</think>"
             user_prompt = negative_prompt if has_negative_prompt else "NO USER INPUT"
         else:
             cot_for_prompt = cot_text

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -1724,12 +1724,18 @@ class LLMHandler:
             raise ValueError("LLM tokenizer is not initialized. Call initialize() first.")
 
         if self.use_legacy_cfg_prompt:
-            # Legacy (pre-fix) path kept for manual A/B comparison. Uncond keeps
-            # the caption+lyrics wrapper and the assistant turn is closed with
-            # <|im_end|> before codes are generated.
+            # Isolated-variable A/B path: uncond keeps the `# Caption\n...\n\n#
+            # Lyric\n...\n` wrapper (the pre-fix design choice, where CFG only
+            # amplifies the CoT-metadata direction because caption/lyrics are
+            # identical on both sides). Structural details (open assistant turn,
+            # `<think>\n\n</think>` for empty reasoning, `\n\n` separator before
+            # the first code) match the training-aligned path below so the only
+            # thing that differs between toggle states is the uncond user
+            # content — enabling a clean manual comparison of that single design
+            # decision.
             if is_negative_prompt:
                 has_negative_prompt = self._has_meaningful_negative_prompt(negative_prompt)
-                cot_for_prompt = "<think>\n</think>"
+                cot_for_prompt = "<think>\n\n</think>"
                 caption_for_prompt = negative_prompt if has_negative_prompt else caption
             else:
                 cot_for_prompt = cot_text
@@ -1739,13 +1745,11 @@ class LLMHandler:
                 [
                     {"role": "system", "content": f"# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n"},
                     {"role": "user", "content": user_prompt},
-                    {"role": "assistant", "content": cot_for_prompt},
                 ],
                 tokenize=False,
-                add_generation_prompt=False,
+                add_generation_prompt=True,
             )
-            if not formatted.endswith('\n'):
-                formatted += '\n'
+            formatted += cot_for_prompt + "\n\n"
             return formatted
 
         if is_negative_prompt:

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -1760,8 +1760,13 @@ class LLMHandler:
             user_prompt = f"# Caption\n{caption}\n\n# Lyric\n{lyrics}\n"
 
         # Keep the assistant turn OPEN so the model continues inside it with audio
-        # codes, matching the training layout `<think>...</think>{codes}<|im_end|>`.
-        # Adding cot as a role="assistant" message would close the turn with <|im_end|>.
+        # codes, matching the training layout `<think>...</think>\n\n{codes}<|im_end|>`.
+        # Qwen's chat template inserts `\n\n` between `</think>` and the content
+        # following it when rendering a full assistant message; reproduce that
+        # separator here so training and inference see the same prefix just before
+        # the first code token. Adding cot as a role="assistant" message would
+        # close the turn with <|im_end|>, which the model treats as end-of-turn
+        # rather than "codes go here".
         formatted = self.llm_tokenizer.apply_chat_template(
             [
                 {"role": "system", "content": f"# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n"},
@@ -1770,7 +1775,7 @@ class LLMHandler:
             tokenize=False,
             add_generation_prompt=True,
         )
-        formatted += cot_for_prompt
+        formatted += cot_for_prompt + "\n\n"
         return formatted
 
     def build_formatted_prompt_for_understanding(

--- a/acestep/ui/gradio/i18n/en.json
+++ b/acestep/ui/gradio/i18n/en.json
@@ -197,7 +197,7 @@
     "constrained_debug_label": "Constrained Decoding Debug",
     "constrained_debug_info": "Shows detailed logs of how the LM's output tokens are being filtered/constrained. Only useful for developers debugging token generation issues. Leave off for normal use.",
     "lm_use_legacy_cfg_prompt_label": "LM CFG: Legacy Uncond Prompt",
-    "lm_use_legacy_cfg_prompt_info": "Debug A/B toggle. OFF (default): CFG uncond uses the training-aligned format (user='NO USER INPUT', open assistant turn). ON: uses the pre-fix format (keeps caption+lyrics in uncond, closes assistant turn). Only affects codes-phase CFG. Leave OFF for production.",
+    "lm_use_legacy_cfg_prompt_info": "Debug A/B toggle. OFF (default): CFG uncond user is bare 'NO USER INPUT' (training-aligned, truly unconditional). ON: uncond keeps caption+lyrics (pre-fix design — uncond still carries conditioning, so CFG mostly amplifies the CoT-metadata direction). Byte-level structure (open assistant turn, separator newlines, empty-reasoning rendering) is identical in both states, so the toggle isolates just this one design variable. Only affects codes-phase CFG. Leave OFF for production.",
     "auto_score_label": "Auto Score",
     "auto_score_info": "Automatically calculates a quality score (0–1) for each generated audio using perplexity. Higher = better. Useful for comparing results in a batch to find the best one. Adds a few seconds per sample.",
     "auto_lrc_label": "Auto LRC",

--- a/acestep/ui/gradio/i18n/ja.json
+++ b/acestep/ui/gradio/i18n/ja.json
@@ -194,7 +194,7 @@
     "constrained_debug_label": "制約付きデコーディングデバッグ",
     "constrained_debug_info": "制約付きデコーディングのデバッグログを有効化(チェックすると詳細ログを表示)。",
     "lm_use_legacy_cfg_prompt_label": "LM CFG: 旧無条件プロンプトを使用",
-    "lm_use_legacy_cfg_prompt_info": "デバッグ用A/Bトグル。オフ(既定): CFG無条件は学習と整合した形式を使用(user='NO USER INPUT'、assistantターン未クローズ)。オン: 修正前の旧ロジックを使用(無条件分岐でcaption+lyricsを保持し、assistantターンを閉じる)。codes段階のCFGにのみ影響します。",
+    "lm_use_legacy_cfg_prompt_info": "デバッグ用A/Bトグル。オフ(既定): CFG無条件のuserは裸の'NO USER INPUT'(学習と整合した、真の無条件)。オン: 無条件でcaption+lyricsを保持(修正前の設計——無条件でも条件を含むため、CFGは主にCoTメタデータ方向のみ増幅)。バイトレベルの構造(assistantターン未クローズ、区切り改行、空reasoningのレンダリング)は両状態で同一なので、トグルはこの1つの設計変数のみを分離します。codes段階のCFGにのみ影響。",
     "auto_score_label": "自動スコアリング",
     "auto_score_info": "生成されたすべてのオーディオの品質スコアを自動計算。",
     "auto_lrc_label": "自動 LRC",

--- a/acestep/ui/gradio/i18n/pt.json
+++ b/acestep/ui/gradio/i18n/pt.json
@@ -197,7 +197,7 @@
     "constrained_debug_label": "Depuração de Decodificação Restrita",
     "constrained_debug_info": "Exibe registros detalhados de como os tokens de saída do LM estão sendo filtrados/restringidos. Útil apenas para desenvolvedores depurando problemas de geração de tokens. Deixe desativado para uso normal.",
     "lm_use_legacy_cfg_prompt_label": "LM CFG: Prompt Incondicional Legado",
-    "lm_use_legacy_cfg_prompt_info": "Alternância A/B de depuração. DESLIGADO (padrão): CFG incondicional usa o formato alinhado ao treino (user='NO USER INPUT', turn do assistant aberto). LIGADO: usa a lógica pré-correção (mantém caption+lyrics no incondicional, fecha o turn do assistant). Afeta apenas CFG da fase de codes.",
+    "lm_use_legacy_cfg_prompt_info": "Alternância A/B de depuração. DESLIGADO (padrão): user do CFG incondicional é 'NO USER INPUT' puro (alinhado ao treino, verdadeiramente incondicional). LIGADO: incondicional mantém caption+lyrics (design pré-correção — incondicional ainda carrega condicionamento, então CFG amplia principalmente a direção dos metadados do CoT). A estrutura em nível de byte (turn do assistant aberto, quebras de linha separadoras, renderização de reasoning vazio) é idêntica em ambos os estados, então a alternância isola apenas esta variável de design. Afeta apenas CFG da fase de codes.",
     "auto_score_label": "Pontuação Automática",
     "auto_score_info": "Calcula automaticamente uma pontuação de qualidade (0–1) para cada áudio gerado usando perplexidade. Maior = melhor. Útil para comparar resultados em um lote e encontrar o melhor. Adiciona alguns segundos por amostra.",
     "auto_lrc_label": "LRC Automático",

--- a/acestep/ui/gradio/i18n/zh.json
+++ b/acestep/ui/gradio/i18n/zh.json
@@ -194,7 +194,7 @@
     "constrained_debug_label": "约束解码调试",
     "constrained_debug_info": "启用约束解码的调试日志(勾选以查看详细日志)。",
     "lm_use_legacy_cfg_prompt_label": "LM CFG: 使用旧版无条件 Prompt",
-    "lm_use_legacy_cfg_prompt_info": "调试用 A/B 开关。关闭(默认): CFG 无条件分支使用与训练对齐的格式(user='NO USER INPUT'，assistant turn 保持开放)。开启: 使用修复前的旧逻辑(无条件分支保留 caption+lyrics，assistant turn 被关闭)。仅影响 codes 阶段 CFG。",
+    "lm_use_legacy_cfg_prompt_info": "调试用 A/B 开关。关闭(默认): CFG 无条件分支 user 为裸 'NO USER INPUT'(训练对齐，真正的无条件)。开启: 无条件分支保留 caption+lyrics(修复前的设计——无条件仍带着条件，CFG 只能放大 CoT 元数据方向)。两种状态下字节级结构(assistant turn 开放、分隔换行、空 reasoning 渲染)完全一致，开关只隔离这一个设计变量。仅影响 codes 阶段 CFG。",
     "auto_score_label": "自动评分",
     "auto_score_info": "自动计算所有生成音频的质量分数。",
     "auto_lrc_label": "自动 LRC",


### PR DESCRIPTION
## Summary

Follow-up to #1127.

When #1127 switched from `apply_chat_template([sys, user, assistant=cot], add_generation_prompt=False)` to `apply_chat_template([sys, user], add_generation_prompt=True) + cot` to keep the assistant turn open, it dropped the `\n\n` that Qwen's chat template inserts between `</think>` and the post-reasoning content.

Concretely, the Qwen3 template's assistant branch renders:

```jinja
'<|im_start|>' + role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n')
```

so a training sample with `assistant_content = "<think>\n{cot}\n</think>{codes}"` actually tokenizes as `...<|im_start|>assistant\n<think>\n{cot}\n</think>\n\n{codes}<|im_end|>\n` — i.e., **the model was trained to emit the first audio code token conditioned on a prefix ending at `\n\n`, not at `</think>`**.

The fix appends `"\n\n"` after `cot_for_prompt` so the inference prefix matches the training prefix byte-for-byte right at the generation point.

Confirmed against a real training-data sample (assistant content rendered through the same tokenizer): training has `</think>\n\n<|audio_code_xxx|>...<|im_end|>`.

## Test plan

- [x] Dumped `build_formatted_prompt_with_cot` output through the real 1.5 tokenizer (`checkpoints/acestep-5Hz-lm-0.6B`) and verified both cond and uncond now end with `</think>\n\n`.
- [x] Cross-checked against a training-data sample rendered through the same tokenizer: the `</think>\n\n{first code}` structure matches.
- [ ] Manual inference run to confirm audible/behavioural parity (or improvement) vs the post-#1127 baseline.
- [ ] Existing `acestep/llm_inference_cfg_fixes_test.py` still passes (mocks `build_formatted_prompt_with_cot`, so insensitive to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt formatting to ensure consistent separators and spacing before generated code, reducing stray blank lines and producing cleaner code/chat outputs.

* **Documentation**
  * Clarified the UI help text for the "LM CFG: Legacy Uncond Prompt" toggle in English, Japanese, Portuguese, and Chinese, explaining default vs. legacy behavior and scope of impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->