### PR TITLE
Security: API key accepted from request body (`ai_token`) can leak via logs and intermediaries

### DIFF
--- a/acestep/api/http/auth.py
+++ b/acestep/api/http/auth.py
@@ -23,7 +23,7 @@ def set_api_key(key: Optional[str]) -> None:
 def verify_token_from_request(
     body: dict[str, Any], authorization: Optional[str] = None
 ) -> Optional[str]:
-    """Validate request auth from body ``ai_token`` or Authorization header.
+    """Validate request auth from Authorization header.
 
     Args:
         body: Parsed request payload dictionary.
@@ -39,19 +39,13 @@ def verify_token_from_request(
     if _api_key is None:
         return None
 
-    ai_token = body.get("ai_token") if body else None
-    if ai_token:
-        if ai_token == _api_key:
-            return ai_token
-        raise HTTPException(status_code=401, detail="Invalid ai_token")
-
     if authorization:
         token = authorization[7:] if authorization.startswith("Bearer ") else authorization
         if token == _api_key:
             return token
         raise HTTPException(status_code=401, detail="Invalid API key")
 
-    raise HTTPException(status_code=401, detail="Missing ai_token or Authorization header")
+    raise HTTPException(status_code=401, detail="Missing Authorization header")
 
 
 async def verify_api_key(authorization: Optional[str] = Header(None)) -> None:


### PR DESCRIPTION
## Problem

The authentication helper accepts credentials from `body['ai_token']` in addition to the `Authorization` header. Tokens in JSON bodies are more likely to be logged by application middleware, error handlers, or upstream gateways, and are not handled by standard auth-header redaction rules. This increases the risk of secret disclosure.

**Severity**: `medium`
**File**: `acestep/api/http/auth.py`

## Solution

Prefer `Authorization: Bearer <token>` exclusively for API authentication. If backward compatibility is required, gate body-token support behind an explicit legacy flag and ensure body fields containing secrets are redacted from logs.

## Changes

- `acestep/api/http/auth.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Authentication now requires credentials exclusively via the `Authorization` header; the alternative request body method is no longer supported.
  * Updated error messaging to reflect that only the `Authorization` header is required for authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->