### PR TITLE
feat(vae): swap-in support for community VAEs (ScragVAE)

### DIFF
--- a/acestep/core/generation/handler/init_service_downloads.py
+++ b/acestep/core/generation/handler/init_service_downloads.py
@@ -6,10 +6,13 @@ from typing import Optional, Tuple
 from loguru import logger
 
 from acestep.model_downloader import (
+    DEFAULT_VAE_VARIANT,
     check_main_model_exists,
     check_model_exists,
+    check_vae_exists,
     ensure_dit_model,
     ensure_main_model,
+    ensure_vae_model,
 )
 
 
@@ -22,6 +25,7 @@ class InitServiceDownloadsMixin:
         checkpoint_path: Path,
         config_path: str,
         prefer_source: Optional[str],
+        vae_variant: Optional[str] = None,
     ) -> Optional[Tuple[str, bool]]:
         """Ensure required checkpoint assets exist locally, downloading when missing."""
         if not check_main_model_exists(checkpoint_path):
@@ -42,6 +46,18 @@ class InitServiceDownloadsMixin:
             if not success:
                 return f"ERROR: Failed to download DiT model '{config_path}': {msg}", False
             logger.info(f"[initialize_service] {msg}")
+
+        if vae_variant and vae_variant != DEFAULT_VAE_VARIANT:
+            if not check_vae_exists(vae_variant, checkpoint_path):
+                logger.info(
+                    f"[initialize_service] VAE variant '{vae_variant}' not found, starting auto-download..."
+                )
+                success, msg = ensure_vae_model(
+                    vae_variant, checkpoint_path, prefer_source=prefer_source
+                )
+                if not success:
+                    return f"ERROR: Failed to download VAE variant '{vae_variant}': {msg}", False
+                logger.info(f"[initialize_service] {msg}")
 
         return None
 

--- a/acestep/core/generation/handler/init_service_loader_components.py
+++ b/acestep/core/generation/handler/init_service_loader_components.py
@@ -1,6 +1,7 @@
 """VAE and text component loading helpers for service initialization."""
 
 import os
+from typing import Optional
 
 import torch
 
@@ -15,29 +16,35 @@ class InitServiceLoaderComponentsMixin:
         ``self.text_tokenizer`` as side effects.
     """
 
-    def _load_vae_model(self, *, checkpoint_dir: str, device: str, compile_model: bool) -> str:
+    def _load_vae_model(
+        self,
+        *,
+        checkpoint_dir: str,
+        device: str,
+        compile_model: bool,
+        vae_variant: Optional[str] = None,
+    ) -> str:
         """Load the VAE checkpoint and return its resolved path.
 
         Args:
-            checkpoint_dir: Root checkpoint directory containing the ``vae`` subdirectory.
+            checkpoint_dir: Root checkpoint directory.
             device: Target runtime device when CPU offload is disabled.
             compile_model: Whether to compile the loaded VAE after device placement.
+            vae_variant: Optional VAE variant id (e.g. ``"official"`` or
+                ``"scragvae"``) or an absolute path to a VAE directory.
+                Defaults to ``"official"`` (= ``<checkpoint_dir>/vae``).
 
         Returns:
             The resolved VAE checkpoint path as a string.
 
         Raises:
-            FileNotFoundError: If ``checkpoint_dir`` does not contain a valid ``vae`` checkpoint.
-            Exception: Propagates loader, device transfer, or compile errors from dependencies.
-
-        Side Effects:
-            Assigns ``self.vae``, selects a device-appropriate dtype via
-            ``_get_vae_dtype()``, may offload the module to CPU, switches the module
-            to eval mode, and may compile it after calling ``_ensure_len_for_compile``.
+            FileNotFoundError: If the resolved VAE directory does not exist.
+            Exception: Propagates loader, device transfer, or compile errors.
         """
         from diffusers.models import AutoencoderOobleck
+        from acestep.model_downloader import resolve_vae_path
 
-        vae_checkpoint_path = os.path.join(checkpoint_dir, "vae")
+        vae_checkpoint_path = str(resolve_vae_path(checkpoint_dir, vae_variant))
         if not os.path.exists(vae_checkpoint_path):
             raise FileNotFoundError(f"VAE checkpoint not found at {vae_checkpoint_path}")
 

--- a/acestep/core/generation/handler/init_service_loader_components.py
+++ b/acestep/core/generation/handler/init_service_loader_components.py
@@ -39,6 +39,8 @@ class InitServiceLoaderComponentsMixin:
 
         Raises:
             FileNotFoundError: If the resolved VAE directory does not exist.
+            ValueError: If ``vae_variant`` is not a known registry id, the
+                default, or an absolute path.
             Exception: Propagates loader, device transfer, or compile errors.
         """
         from diffusers.models import AutoencoderOobleck

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -57,6 +57,7 @@ class InitServiceOrchestratorMixin:
         quantization: Optional[str] = None,
         prefer_source: Optional[str] = None,
         use_mlx_dit: bool = True,
+        vae_checkpoint: Optional[str] = None,
     ) -> Tuple[str, bool]:
         """Initialize model artifacts and runtime backends for generation.
 
@@ -114,7 +115,10 @@ class InitServiceOrchestratorMixin:
                 else:
                     raise
 
-            from acestep.model_downloader import get_checkpoints_dir
+            from acestep.model_downloader import (
+                DEFAULT_VAE_VARIANT,
+                get_checkpoints_dir,
+            )
             env_ckpt = os.environ.get("ACESTEP_CHECKPOINTS_DIR")
             if env_ckpt:
                 checkpoint_dir = str(get_checkpoints_dir())
@@ -124,10 +128,18 @@ class InitServiceOrchestratorMixin:
                 checkpoint_dir = str(get_checkpoints_dir())
             checkpoint_path = Path(checkpoint_dir)
 
+            # Resolve VAE selection: explicit param > env var > default.
+            resolved_vae_variant = (
+                vae_checkpoint
+                or os.environ.get("ACESTEP_VAE_CHECKPOINT")
+                or DEFAULT_VAE_VARIANT
+            )
+
             precheck_failure = self._ensure_models_present(
                 checkpoint_path=checkpoint_path,
                 config_path=config_path,
                 prefer_source=prefer_source,
+                vae_variant=resolved_vae_variant,
             )
             if precheck_failure is not None:
                 self.model = None
@@ -152,6 +164,7 @@ class InitServiceOrchestratorMixin:
                 checkpoint_dir=checkpoint_dir,
                 device=resolved_device,
                 compile_model=normalized_compile,
+                vae_variant=resolved_vae_variant,
             )
             text_encoder_path = self._load_text_encoder_and_tokenizer(
                 checkpoint_dir=checkpoint_dir,
@@ -191,6 +204,7 @@ class InitServiceOrchestratorMixin:
                 "quantization": self.quantization,
                 "use_mlx_dit": use_mlx_dit,
                 "prefer_source": prefer_source,
+                "vae_checkpoint": resolved_vae_variant,
             }
 
             return status_msg, True

--- a/acestep/core/generation/handler/init_service_test.py
+++ b/acestep/core/generation/handler/init_service_test.py
@@ -471,10 +471,12 @@ class InitServiceMixinTests(unittest.TestCase):
             "quantization",
             "use_mlx_dit",
             "prefer_source",
+            "vae_checkpoint",
         }
         self.assertEqual(set(host.last_init_params.keys()), expected_keys)
         self.assertEqual(host.last_init_params["config_path"], "acestep-v15-turbo")
         self.assertEqual(host.last_init_params["device"], "cpu")
+        self.assertEqual(host.last_init_params["vae_checkpoint"], "official")
         ensure_models.assert_called_once()
         sync_code.assert_called_once()
 

--- a/acestep/core/generation/handler/init_service_test.py
+++ b/acestep/core/generation/handler/init_service_test.py
@@ -480,6 +480,92 @@ class InitServiceMixinTests(unittest.TestCase):
         ensure_models.assert_called_once()
         sync_code.assert_called_once()
 
+    def test_initialize_service_honors_env_var_when_param_omitted(self):
+        """ACESTEP_VAE_CHECKPOINT seeds the variant when no explicit kwarg is given."""
+        host = _Host(project_root="K:/fake_root", device="cpu")
+
+        def _fake_load_main_model(**_kwargs):
+            host.config = types.SimpleNamespace(_attn_implementation="sdpa")
+            host.model = object()
+
+        captured: dict[str, str | None] = {}
+
+        def _fake_load_vae(**kwargs):
+            captured["vae_variant"] = kwargs.get("vae_variant")
+            return "K:/fake_root/checkpoints/scragvae"
+
+        env_with_var = {**os.environ, "ACESTEP_VAE_CHECKPOINT": "scragvae"}
+        with patch.dict(os.environ, env_with_var, clear=True):
+            with patch.object(host, "_ensure_models_present", return_value=None) as ensure_models:
+                with patch.object(host, "_sync_model_code_if_needed"):
+                    with patch.object(host, "_load_main_model_from_checkpoint", side_effect=_fake_load_main_model):
+                        with patch.object(host, "_load_vae_model", side_effect=_fake_load_vae):
+                            with patch.object(
+                                host,
+                                "_load_text_encoder_and_tokenizer",
+                                return_value="K:/fake_root/checkpoints/Qwen3-Embedding-0.6B",
+                            ):
+                                with patch.object(
+                                    host,
+                                    "_initialize_mlx_backends",
+                                    return_value=("Disabled", "Disabled"),
+                                ):
+                                    status, ok = host.initialize_service(
+                                        project_root="K:/fake_root",
+                                        config_path="acestep-v15-turbo",
+                                        device="cpu",
+                                        # No explicit vae_checkpoint.
+                                    )
+        self.assertTrue(ok)
+        self.assertEqual(captured["vae_variant"], "scragvae")
+        self.assertEqual(host.last_init_params["vae_checkpoint"], "scragvae")
+        # _ensure_models_present must also see the resolved variant so it
+        # can pre-fetch the community VAE before _load_vae_model runs.
+        ensure_models.assert_called_once()
+        self.assertEqual(
+            ensure_models.call_args.kwargs.get("vae_variant"), "scragvae"
+        )
+
+    def test_initialize_service_param_wins_over_env(self):
+        """Explicit vae_checkpoint kwarg overrides the env var."""
+        host = _Host(project_root="K:/fake_root", device="cpu")
+
+        def _fake_load_main_model(**_kwargs):
+            host.config = types.SimpleNamespace(_attn_implementation="sdpa")
+            host.model = object()
+
+        captured: dict[str, str | None] = {}
+
+        def _fake_load_vae(**kwargs):
+            captured["vae_variant"] = kwargs.get("vae_variant")
+            return "K:/fake_root/checkpoints/vae"
+
+        env_with_var = {**os.environ, "ACESTEP_VAE_CHECKPOINT": "scragvae"}
+        with patch.dict(os.environ, env_with_var, clear=True):
+            with patch.object(host, "_ensure_models_present", return_value=None):
+                with patch.object(host, "_sync_model_code_if_needed"):
+                    with patch.object(host, "_load_main_model_from_checkpoint", side_effect=_fake_load_main_model):
+                        with patch.object(host, "_load_vae_model", side_effect=_fake_load_vae):
+                            with patch.object(
+                                host,
+                                "_load_text_encoder_and_tokenizer",
+                                return_value="K:/fake_root/checkpoints/Qwen3-Embedding-0.6B",
+                            ):
+                                with patch.object(
+                                    host,
+                                    "_initialize_mlx_backends",
+                                    return_value=("Disabled", "Disabled"),
+                                ):
+                                    status, ok = host.initialize_service(
+                                        project_root="K:/fake_root",
+                                        config_path="acestep-v15-turbo",
+                                        device="cpu",
+                                        vae_checkpoint="official",
+                                    )
+        self.assertTrue(ok)
+        self.assertEqual(captured["vae_variant"], "official")
+        self.assertEqual(host.last_init_params["vae_checkpoint"], "official")
+
     def test_initialize_service_returns_error_payload_when_loader_raises(self):
         """It catches init errors and returns a formatted failure message."""
         host = _Host(project_root="K:/fake_root", device="cpu")

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -314,6 +314,17 @@ MAIN_MODEL_COMPONENTS = [
 # Default LM model (included in main model)
 DEFAULT_LM_MODEL = "acestep-5Hz-lm-1.7B"
 
+# Optional community-finetuned VAE checkpoints. Each entry maps a short
+# variant id (also used as the on-disk subdirectory under
+# <checkpoints>/) to its HuggingFace repo id. The bundled official VAE
+# stays at <checkpoints>/vae/ and is referenced as variant id "official".
+VAE_REGISTRY: Dict[str, str] = {
+    "scragvae": "scragnog/Ace-Step-1.5-ScragVAE",
+}
+
+# Variant id used for the bundled VAE that ships with the main model repo.
+DEFAULT_VAE_VARIANT = "official"
+
 
 def get_project_root() -> Path:
     """Get the project root directory.
@@ -691,6 +702,124 @@ def ensure_dit_model(
     return False, f"Unknown DiT model: {model_name}"
 
 
+def list_available_vae_variants() -> List[str]:
+    """Return all selectable VAE variant ids (official first)."""
+    return [DEFAULT_VAE_VARIANT, *VAE_REGISTRY.keys()]
+
+
+def resolve_vae_path(checkpoint_dir, vae_variant: Optional[str]) -> Path:
+    """Resolve a VAE variant id (or absolute path) to its on-disk directory.
+
+    Args:
+        checkpoint_dir: Root checkpoints directory.
+        vae_variant: Variant id (``"official"`` or a key in ``VAE_REGISTRY``)
+            or an absolute filesystem path. ``None`` / ``""`` is treated as
+            ``"official"``.
+
+    Returns:
+        Absolute path of the VAE checkpoint directory.
+
+    Raises:
+        ValueError: If ``vae_variant`` is not recognized.
+    """
+    if isinstance(checkpoint_dir, str):
+        checkpoint_dir = Path(checkpoint_dir)
+    if not vae_variant:
+        return checkpoint_dir / "vae"
+    if os.path.isabs(vae_variant):
+        return Path(vae_variant)
+    if vae_variant == DEFAULT_VAE_VARIANT:
+        return checkpoint_dir / "vae"
+    if vae_variant in VAE_REGISTRY:
+        return checkpoint_dir / vae_variant
+    raise ValueError(
+        f"Unknown VAE variant '{vae_variant}'. Available: "
+        f"{', '.join(list_available_vae_variants())}"
+    )
+
+
+def check_vae_exists(vae_variant: str, checkpoints_dir: Optional[Path] = None) -> bool:
+    """Return whether the requested VAE variant has weights on disk."""
+    if checkpoints_dir is None:
+        checkpoints_dir = get_checkpoints_dir()
+    elif isinstance(checkpoints_dir, str):
+        checkpoints_dir = Path(checkpoints_dir)
+    try:
+        path = resolve_vae_path(checkpoints_dir, vae_variant)
+    except ValueError:
+        return False
+    return _contains_model_weights(path)
+
+
+def download_vae(
+    vae_variant: str,
+    checkpoints_dir: Optional[Path] = None,
+    force: bool = False,
+    token: Optional[str] = None,
+    prefer_source: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Download a community VAE variant into ``<checkpoints>/<variant>/``.
+
+    The bundled ``"official"`` VAE is *not* downloaded here — it ships
+    with the main model and is fetched by ``download_main_model``.
+    """
+    if vae_variant == DEFAULT_VAE_VARIANT:
+        return False, (
+            f"VAE variant '{DEFAULT_VAE_VARIANT}' ships with the main model; "
+            "use download_main_model() instead."
+        )
+    if vae_variant not in VAE_REGISTRY:
+        available = ", ".join(VAE_REGISTRY.keys()) or "(none)"
+        return False, f"Unknown VAE variant '{vae_variant}'. Available: {available}"
+
+    if checkpoints_dir is None:
+        checkpoints_dir = get_checkpoints_dir()
+    elif isinstance(checkpoints_dir, str):
+        checkpoints_dir = Path(checkpoints_dir)
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    target_path = checkpoints_dir / vae_variant
+    if not force and _contains_model_weights(target_path):
+        return True, f"VAE variant '{vae_variant}' already exists at {target_path}"
+
+    repo_id = VAE_REGISTRY[vae_variant]
+    print(f"Downloading VAE '{vae_variant}' from {repo_id}...")
+    print(f"Destination: {target_path}")
+
+    return _smart_download(repo_id, target_path, token, prefer_source)
+
+
+def ensure_vae_model(
+    vae_variant: Optional[str] = None,
+    checkpoints_dir: Optional[Path] = None,
+    token: Optional[str] = None,
+    prefer_source: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Ensure the requested VAE variant is on disk, downloading if needed.
+
+    For ``"official"`` (or ``None``) this defers to ``ensure_main_model``
+    since the bundled VAE travels with the main model. For registered
+    community variants this calls ``download_vae`` when the directory
+    is missing.
+    """
+    if not vae_variant or vae_variant == DEFAULT_VAE_VARIANT:
+        return ensure_main_model(checkpoints_dir, token, prefer_source)
+
+    if checkpoints_dir is None:
+        checkpoints_dir = get_checkpoints_dir()
+    elif isinstance(checkpoints_dir, str):
+        checkpoints_dir = Path(checkpoints_dir)
+
+    if check_vae_exists(vae_variant, checkpoints_dir):
+        return True, f"VAE variant '{vae_variant}' is available"
+
+    print("\n" + "=" * 60)
+    print(f"VAE variant '{vae_variant}' not found. Starting automatic download...")
+    print("=" * 60 + "\n")
+
+    return download_vae(vae_variant, checkpoints_dir, token=token, prefer_source=prefer_source)
+
+
 def print_model_list():
     """Print formatted list of available models."""
     print("\nAvailable Models for Download:")
@@ -709,6 +838,12 @@ def print_model_list():
     print("\n[Optional DiT Models]")
     for name, repo in SUBMODEL_REGISTRY.items():
         if "lm" not in name.lower():
+            print(f"  {name} -> {repo}")
+
+    if VAE_REGISTRY:
+        print("\n[Optional VAEs]")
+        print(f"  official -> bundled in {MAIN_MODEL_REPO}")
+        for name, repo in VAE_REGISTRY.items():
             print(f"  {name} -> {repo}")
 
     print("\n" + "=" * 60)

--- a/acestep/model_downloader.py
+++ b/acestep/model_downloader.py
@@ -707,7 +707,7 @@ def list_available_vae_variants() -> List[str]:
     return [DEFAULT_VAE_VARIANT, *VAE_REGISTRY.keys()]
 
 
-def resolve_vae_path(checkpoint_dir, vae_variant: Optional[str]) -> Path:
+def resolve_vae_path(checkpoint_dir: "str | Path", vae_variant: Optional[str]) -> Path:
     """Resolve a VAE variant id (or absolute path) to its on-disk directory.
 
     Args:
@@ -812,6 +812,18 @@ def ensure_vae_model(
 
     if check_vae_exists(vae_variant, checkpoints_dir):
         return True, f"VAE variant '{vae_variant}' is available"
+
+    # Absolute paths are user-supplied and cannot be downloaded. Fail with a
+    # clear, path-specific diagnostic instead of routing through download_vae,
+    # which would surface a misleading "Unknown VAE variant" error.
+    if os.path.isabs(vae_variant):
+        path = Path(vae_variant)
+        if not path.exists():
+            return False, f"VAE path '{vae_variant}' does not exist."
+        return False, (
+            f"VAE path '{vae_variant}' does not contain VAE weights "
+            "(expected diffusion_pytorch_model.safetensors)."
+        )
 
     print("\n" + "=" * 60)
     print(f"VAE variant '{vae_variant}' not found. Starting automatic download...")

--- a/acestep/model_downloader_test.py
+++ b/acestep/model_downloader_test.py
@@ -202,5 +202,117 @@ class TestCheckModelExists(unittest.TestCase):
         self.assertTrue(result)
 
 
+class TestResolveVaePath(unittest.TestCase):
+    """Tests for model_downloader.resolve_vae_path()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def test_default_resolves_to_bundled_vae_directory(self):
+        """None / empty / 'official' all map to <ckpt>/vae."""
+        ckpt = Path("/tmp/some-ckpts")
+        expected = ckpt / "vae"
+        self.assertEqual(self.mod.resolve_vae_path(ckpt, None), expected)
+        self.assertEqual(self.mod.resolve_vae_path(ckpt, ""), expected)
+        self.assertEqual(self.mod.resolve_vae_path(ckpt, "official"), expected)
+        self.assertEqual(self.mod.resolve_vae_path(str(ckpt), "official"), expected)
+
+    def test_registered_variant_maps_to_subdirectory(self):
+        """A variant id from VAE_REGISTRY resolves to <ckpt>/<variant>."""
+        ckpt = Path("/tmp/some-ckpts")
+        for variant in self.mod.VAE_REGISTRY:
+            self.assertEqual(
+                self.mod.resolve_vae_path(ckpt, variant), ckpt / variant
+            )
+
+    def test_absolute_path_passes_through(self):
+        """An absolute path is returned verbatim."""
+        ckpt = Path("/tmp/some-ckpts")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self.assertEqual(
+                self.mod.resolve_vae_path(ckpt, tmp_dir), Path(tmp_dir)
+            )
+
+    def test_unknown_variant_raises(self):
+        """Unrecognized variant ids surface a ValueError listing the registry."""
+        with self.assertRaises(ValueError) as ctx:
+            self.mod.resolve_vae_path(Path("/tmp/c"), "no-such-vae")
+        msg = str(ctx.exception)
+        self.assertIn("no-such-vae", msg)
+        self.assertIn("official", msg)
+
+
+class TestVaeRegistryMembership(unittest.TestCase):
+    """Confirm the bundled VAE_REGISTRY entries surface via list_available_vae_variants."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def test_official_listed_first(self):
+        """list_available_vae_variants always begins with 'official'."""
+        variants = self.mod.list_available_vae_variants()
+        self.assertEqual(variants[0], self.mod.DEFAULT_VAE_VARIANT)
+
+    def test_scragvae_is_registered(self):
+        """ScragVAE ships in the registry as 'scragvae'."""
+        self.assertIn("scragvae", self.mod.VAE_REGISTRY)
+        self.assertIn("scragvae", self.mod.list_available_vae_variants())
+
+
+class TestCheckVaeExists(unittest.TestCase):
+    """Tests for model_downloader.check_vae_exists()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def test_official_detected_when_bundled_weights_present(self):
+        """check_vae_exists('official') returns True iff <ckpt>/vae has weights."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ckpt = Path(tmp_dir)
+            self.assertFalse(self.mod.check_vae_exists("official", ckpt))
+            (ckpt / "vae").mkdir()
+            (ckpt / "vae" / "diffusion_pytorch_model.safetensors").write_bytes(b"x")
+            self.assertTrue(self.mod.check_vae_exists("official", ckpt))
+
+    def test_scragvae_detected_in_subdirectory(self):
+        """A registered community variant is detected in <ckpt>/<variant>/."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ckpt = Path(tmp_dir)
+            self.assertFalse(self.mod.check_vae_exists("scragvae", ckpt))
+            (ckpt / "scragvae").mkdir()
+            (ckpt / "scragvae" / "diffusion_pytorch_model.safetensors").write_bytes(b"x")
+            self.assertTrue(self.mod.check_vae_exists("scragvae", ckpt))
+
+    def test_unknown_variant_returns_false(self):
+        """An unknown variant id reports as missing without raising."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self.assertFalse(self.mod.check_vae_exists("no-such", Path(tmp_dir)))
+
+
+class TestDownloadVaeRejectsOfficial(unittest.TestCase):
+    """download_vae must refuse to fetch the bundled 'official' VAE separately."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def test_official_variant_returns_helpful_error(self):
+        """Refusing 'official' nudges callers toward download_main_model()."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            success, msg = self.mod.download_vae("official", Path(tmp_dir))
+        self.assertFalse(success)
+        self.assertIn("download_main_model", msg)
+
+    def test_unknown_variant_returns_helpful_error(self):
+        """Unknown variants are rejected before any network call."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            success, msg = self.mod.download_vae("no-such-vae", Path(tmp_dir))
+        self.assertFalse(success)
+        self.assertIn("no-such-vae", msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/acestep/model_downloader_test.py
+++ b/acestep/model_downloader_test.py
@@ -211,7 +211,7 @@ class TestResolveVaePath(unittest.TestCase):
 
     def test_default_resolves_to_bundled_vae_directory(self):
         """None / empty / 'official' all map to <ckpt>/vae."""
-        ckpt = Path("/tmp/some-ckpts")
+        ckpt = Path(tempfile.gettempdir()) / "some-ckpts"
         expected = ckpt / "vae"
         self.assertEqual(self.mod.resolve_vae_path(ckpt, None), expected)
         self.assertEqual(self.mod.resolve_vae_path(ckpt, ""), expected)
@@ -220,7 +220,7 @@ class TestResolveVaePath(unittest.TestCase):
 
     def test_registered_variant_maps_to_subdirectory(self):
         """A variant id from VAE_REGISTRY resolves to <ckpt>/<variant>."""
-        ckpt = Path("/tmp/some-ckpts")
+        ckpt = Path(tempfile.gettempdir()) / "some-ckpts"
         for variant in self.mod.VAE_REGISTRY:
             self.assertEqual(
                 self.mod.resolve_vae_path(ckpt, variant), ckpt / variant
@@ -228,8 +228,8 @@ class TestResolveVaePath(unittest.TestCase):
 
     def test_absolute_path_passes_through(self):
         """An absolute path is returned verbatim."""
-        ckpt = Path("/tmp/some-ckpts")
         with tempfile.TemporaryDirectory() as tmp_dir:
+            ckpt = Path(tempfile.gettempdir()) / "some-ckpts"
             self.assertEqual(
                 self.mod.resolve_vae_path(ckpt, tmp_dir), Path(tmp_dir)
             )
@@ -237,7 +237,9 @@ class TestResolveVaePath(unittest.TestCase):
     def test_unknown_variant_raises(self):
         """Unrecognized variant ids surface a ValueError listing the registry."""
         with self.assertRaises(ValueError) as ctx:
-            self.mod.resolve_vae_path(Path("/tmp/c"), "no-such-vae")
+            self.mod.resolve_vae_path(
+                Path(tempfile.gettempdir()) / "c", "no-such-vae"
+            )
         msg = str(ctx.exception)
         self.assertIn("no-such-vae", msg)
         self.assertIn("official", msg)
@@ -312,6 +314,51 @@ class TestDownloadVaeRejectsOfficial(unittest.TestCase):
             success, msg = self.mod.download_vae("no-such-vae", Path(tmp_dir))
         self.assertFalse(success)
         self.assertIn("no-such-vae", msg)
+
+
+class TestEnsureVaeModelAbsolutePath(unittest.TestCase):
+    """ensure_vae_model must short-circuit absolute paths instead of routing to download_vae."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def test_absolute_path_with_weights_returns_success(self):
+        """A pre-populated absolute VAE path should be reported as available."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            vae_dir = Path(tmp_dir) / "my-vae"
+            vae_dir.mkdir()
+            (vae_dir / "diffusion_pytorch_model.safetensors").write_bytes(b"x")
+            ckpt_dir = Path(tmp_dir) / "checkpoints"
+            ckpt_dir.mkdir()
+            success, msg = self.mod.ensure_vae_model(str(vae_dir), ckpt_dir)
+        self.assertTrue(success)
+        self.assertIn(str(vae_dir), msg)
+
+    def test_absolute_path_without_weights_returns_clear_error(self):
+        """An absolute path missing weights should not be misreported as 'Unknown variant'."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            vae_dir = Path(tmp_dir) / "empty-vae"
+            vae_dir.mkdir()
+            ckpt_dir = Path(tmp_dir) / "checkpoints"
+            ckpt_dir.mkdir()
+            success, msg = self.mod.ensure_vae_model(str(vae_dir), ckpt_dir)
+        self.assertFalse(success)
+        self.assertIn(str(vae_dir), msg)
+        self.assertIn("does not contain VAE weights", msg)
+        self.assertNotIn("Unknown VAE variant", msg)
+
+    def test_absolute_path_missing_directory_returns_clear_error(self):
+        """A non-existent absolute path should report 'does not exist', not download."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            missing = Path(tmp_dir) / "nope"
+            ckpt_dir = Path(tmp_dir) / "checkpoints"
+            ckpt_dir.mkdir()
+            success, msg = self.mod.ensure_vae_model(str(missing), ckpt_dir)
+        self.assertFalse(success)
+        self.assertIn(str(missing), msg)
+        self.assertIn("does not exist", msg)
+        self.assertNotIn("Unknown VAE variant", msg)
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -57,6 +57,7 @@ def init_service_wrapper(
     init_llm, lm_model_path, backend, use_flash_attention,
     offload_to_cpu, offload_dit_to_cpu, compile_model, quantization,
     mlx_dit=True, current_mode=None, current_batch_size=None,
+    vae_checkpoint=None,
 ):
     """Wrapper for service initialization.
 
@@ -128,6 +129,7 @@ def init_service_wrapper(
         use_flash_attention=use_flash_attention, compile_model=compile_model,
         offload_to_cpu=offload_to_cpu, offload_dit_to_cpu=offload_dit_to_cpu,
         quantization=quant_value, use_mlx_dit=mlx_dit,
+        vae_checkpoint=vae_checkpoint,
     )
 
     if init_llm:

--- a/acestep/ui/gradio/events/wiring/generation_service_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_service_wiring.py
@@ -108,6 +108,7 @@ def register_generation_service_handlers(
             generation_section["mlx_dit_checkbox"],
             generation_section["generation_mode"],
             generation_section["batch_size_input"],
+            generation_section["vae_checkpoint"],
         ],
         outputs=[
             generation_section["init_status"],

--- a/acestep/ui/gradio/i18n/en.json
+++ b/acestep/ui/gradio/i18n/en.json
@@ -42,6 +42,8 @@
     "model_path_info": "The directory containing model config and architecture files. Auto-detected from your checkpoint selection. Only change this if you have a custom model setup.",
     "device_label": "Device",
     "device_info": "Which hardware to run on. 'auto' picks the best available (recommended). 'cuda' = NVIDIA GPU, 'mps' = Apple Silicon, 'xpu' = Intel GPU, 'cpu' = very slow, last resort.",
+    "vae_label": "VAE",
+    "vae_info": "Which VAE to load. 'official' is the bundled Oobleck VAE that ships with the main model. Community fine-tunes (e.g. 'scragvae') are auto-downloaded into <checkpoints>/<name>/ on first use. Override with the ACESTEP_VAE_CHECKPOINT env var.",
     "lm_model_path_label": "5Hz LM Model Path",
     "lm_model_path_info": "The language model that powers Think mode, CoT metadata, caption enhancement, and semantic code generation. Required for Think mode. Larger LMs produce better results but need more VRAM.",
     "backend_label": "5Hz LM Backend",

--- a/acestep/ui/gradio/interfaces/generation_service_config.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config.py
@@ -96,6 +96,7 @@ def create_service_config_content(
         {
             "config_path": model_device_controls["config_path"],
             "device": model_device_controls["device"],
+            "vae_checkpoint": model_device_controls["vae_checkpoint"],
         }
     )
     result.update(lm_backend_controls)

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -9,6 +9,10 @@ from acestep.gpu_config import (
     find_best_lm_model_on_disk,
     get_gpu_device_name,
 )
+from acestep.model_downloader import (
+    DEFAULT_VAE_VARIANT,
+    list_available_vae_variants,
+)
 from acestep.ui.gradio.i18n import t, available_languages_info
 
 
@@ -106,7 +110,8 @@ def build_model_device_controls(
         params: Startup state dictionary containing optional model/device values.
 
     Returns:
-        A component map containing ``config_path``, ``device``, and ``device_value``.
+        A component map containing ``config_path``, ``device``, ``vae_checkpoint``,
+        and ``device_value``.
     """
 
     with gr.Row():
@@ -139,9 +144,25 @@ def build_model_device_controls(
             info=t("service.device_info"),
             elem_classes=["has-info-container"],
         )
+    with gr.Row():
+        vae_choices = list_available_vae_variants()
+        vae_default = (
+            params.get("vae_checkpoint", DEFAULT_VAE_VARIANT)
+            if service_pre_initialized
+            and params.get("vae_checkpoint", DEFAULT_VAE_VARIANT) in vae_choices
+            else DEFAULT_VAE_VARIANT
+        )
+        vae_checkpoint = gr.Dropdown(
+            label=t("service.vae_label"),
+            choices=vae_choices,
+            value=vae_default,
+            info=t("service.vae_info"),
+            elem_classes=["has-info-container"],
+        )
     return {
         "config_path": config_path,
         "device": device,
+        "vae_checkpoint": vae_checkpoint,
         "device_value": device_value,
     }
 

--- a/acestep/ui/gradio/interfaces/generation_service_config_rows.py
+++ b/acestep/ui/gradio/interfaces/generation_service_config_rows.py
@@ -1,5 +1,6 @@
 """Row builders for generation service configuration section."""
 
+import os
 from typing import Any
 
 import gradio as gr
@@ -146,11 +147,16 @@ def build_model_device_controls(
         )
     with gr.Row():
         vae_choices = list_available_vae_variants()
+        # When ACESTEP_VAE_CHECKPOINT names a known variant, seed the UI with
+        # it on first launch so the env var actually takes effect from
+        # Gradio. Once initialized, prefer the previously chosen value.
+        env_vae = os.environ.get("ACESTEP_VAE_CHECKPOINT") or ""
+        env_seed = env_vae if env_vae in vae_choices else DEFAULT_VAE_VARIANT
         vae_default = (
-            params.get("vae_checkpoint", DEFAULT_VAE_VARIANT)
+            params.get("vae_checkpoint", env_seed)
             if service_pre_initialized
-            and params.get("vae_checkpoint", DEFAULT_VAE_VARIANT) in vae_choices
-            else DEFAULT_VAE_VARIANT
+            and params.get("vae_checkpoint", env_seed) in vae_choices
+            else env_seed
         )
         vae_checkpoint = gr.Dropdown(
             label=t("service.vae_label"),

--- a/docs/en/ALT_VAE.md
+++ b/docs/en/ALT_VAE.md
@@ -1,0 +1,99 @@
+# Alternative VAEs
+
+ACE-Step-1.5 ships with the official Oobleck VAE inside the main model
+repo.  Since the architecture (`AutoencoderOobleck`) is fixed, any
+community-finetuned VAE that publishes the same `config.json` +
+`diffusion_pytorch_model.safetensors` pair is a drop-in replacement —
+useful for A/B comparisons of timbre, transient handling, and vocal
+grain.
+
+## Built-in registry
+
+Currently the following community VAE is shipped in the registry:
+
+| Variant id | Repo | License | Author |
+|---|---|---|---|
+| `official` | bundled in `ACE-Step/Ace-Step1.5` | (project license) | ACE-Step |
+| `scragvae` | [`scragnog/Ace-Step-1.5-ScragVAE`](https://huggingface.co/scragnog/Ace-Step-1.5-ScragVAE) | MIT | [@scragnog](https://huggingface.co/scragnog) |
+
+ScragVAE is a finetune of
+`ACE-Step/ace-step-v1.5-1d-vae-stable-audio-format`. Weights are
+**not** vendored — they're pulled from HuggingFace (or ModelScope as
+fallback) on first use into `<checkpoints>/scragvae/`.
+
+## Selecting a VAE
+
+There are three ways to pick which VAE the model loads. Resolution
+order: explicit parameter > environment variable > `"official"`.
+
+### 1. Gradio UI
+
+Open the **Service Configuration** accordion. Next to the model
+variant selector, the **VAE** dropdown now lets you pick `official`
+or `scragvae`. Click **Initialize Service**; on first use the chosen
+VAE is auto-downloaded.
+
+### 2. Environment variable
+
+```bash
+export ACESTEP_VAE_CHECKPOINT=scragvae
+acestep                    # any entry point — Gradio, CLI, API
+```
+
+You can also pass an absolute path to a directory containing a valid
+Oobleck VAE checkpoint:
+
+```bash
+export ACESTEP_VAE_CHECKPOINT=/path/to/my/local/vae
+```
+
+### 3. Python API
+
+```python
+from acestep.handler import ACEStepDiTHandler
+
+dit = ACEStepDiTHandler()
+dit.initialize_service(
+    project_root="./",
+    config_path="acestep-v15-xl-turbo",
+    vae_checkpoint="scragvae",      # or "official", or an abs path
+)
+```
+
+## What the integration does — and does not — do
+
+- **Architecture stays fixed** at `AutoencoderOobleck`. Variants must
+  ship a compatible config; we don't auto-detect alternative
+  architectures.
+- **MLX path is automatic.** On Apple Silicon,
+  `MLXAutoEncoderOobleck.from_pytorch_config(self.vae)` rebuilds the
+  MLX VAE from whatever PyTorch VAE was just loaded, so the alternate
+  VAE is used end-to-end without extra wiring.
+- **Training is not affected.** `acestep/training_v2/` continues to
+  load the bundled `<checkpoints>/vae/` directory. This integration is
+  inference-only for now.
+- **Quantized GGUF (`scragvae-BF16.gguf`) is not yet supported.**
+  Loading will use the `safetensors` weights regardless. GGUF support
+  is a separate feature.
+
+## Adding a new community VAE
+
+1. Confirm the VAE checkpoint contains `config.json` and
+   `diffusion_pytorch_model.safetensors`, and that loading with
+   `diffusers.AutoencoderOobleck.from_pretrained(...)` succeeds.
+2. Add an entry to `VAE_REGISTRY` in `acestep/model_downloader.py`:
+   ```python
+   VAE_REGISTRY: Dict[str, str] = {
+       "scragvae": "scragnog/Ace-Step-1.5-ScragVAE",
+       "myvae": "<hf-org>/<repo-id>",
+   }
+   ```
+3. (Optional) Add credit in this document and in the next release notes.
+
+That's it — the dropdown, env var, downloader, and PyTorch/MLX
+loaders all pick up the new entry automatically.
+
+## Credits
+
+ScragVAE is published under the MIT license by **@scragnog** and
+explicitly credits ACE-Step as the base model.

--- a/docs/en/ALT_VAE.md
+++ b/docs/en/ALT_VAE.md
@@ -40,12 +40,21 @@ export ACESTEP_VAE_CHECKPOINT=scragvae
 acestep                    # any entry point — Gradio, CLI, API
 ```
 
+In Gradio, the env var **seeds the dropdown's initial value** on first
+launch. Once initialized, the dropdown is the source of truth — change
+it and click **Initialize Service** to switch.
+
 You can also pass an absolute path to a directory containing a valid
-Oobleck VAE checkpoint:
+Oobleck VAE checkpoint (CLI / Python API only — the Gradio dropdown
+only lists registered variant ids):
 
 ```bash
 export ACESTEP_VAE_CHECKPOINT=/path/to/my/local/vae
 ```
+
+If the absolute path doesn't exist or doesn't contain a
+`diffusion_pytorch_model.safetensors`, init fails with a clear
+diagnostic — we never try to "download" an absolute path.
 
 ### 3. Python API
 


### PR DESCRIPTION
## Summary

- Adds first-class swap-in support for community-finetuned VAEs, with
  [**ScragVAE**](https://huggingface.co/scragnog/Ace-Step-1.5-ScragVAE)
  as the first registered variant (MIT, by @scragnog).
- New ways to select the VAE at inference time:
  - Gradio dropdown next to the model-variant selector
  - `ACESTEP_VAE_CHECKPOINT` env var (variant id or absolute path)
  - `vae_checkpoint=` kwarg on `dit_handler.initialize_service(...)`
- Resolution order: explicit param > env var > `"official"` (the
  bundled Oobleck VAE under `<checkpoints>/vae/`).
- Auto-downloads on first use via the existing
  HuggingFace ↔ ModelScope smart-download path (no vendored weights).
- MLX path picks up the alternate VAE for free —
  `MLXAutoEncoderOobleck.from_pytorch_config(self.vae)` rebuilds from
  whichever PyTorch VAE just loaded.
- Docs: new `docs/en/ALT_VAE.md` covering registry, three selection
  paths, scope (inference-only, no GGUF yet), and how to add another
  community VAE.

Closes #1138

## Files touched

- `acestep/model_downloader.py` — `VAE_REGISTRY`, `DEFAULT_VAE_VARIANT`,
  `resolve_vae_path`, `check_vae_exists`, `download_vae`, `ensure_vae_model`,
  `list_available_vae_variants`
- `acestep/core/generation/handler/init_service_loader_components.py` —
  `_load_vae_model` accepts `vae_variant`
- `acestep/core/generation/handler/init_service_downloads.py` —
  `_ensure_models_present` ensures the requested VAE variant is on disk
- `acestep/core/generation/handler/init_service_orchestrator.py` —
  `initialize_service(... vae_checkpoint=None)` resolves the variant and
  threads it through; persists into `last_init_params`
- `acestep/ui/gradio/interfaces/generation_service_config_rows.py` —
  VAE dropdown next to the model-path / device row
- `acestep/ui/gradio/interfaces/generation_service_config.py` —
  exposes `vae_checkpoint` in the component map
- `acestep/ui/gradio/events/generation/service_init.py` —
  `init_service_wrapper` accepts and forwards `vae_checkpoint`
- `acestep/ui/gradio/events/wiring/generation_service_wiring.py` —
  passes the new dropdown to `init_btn.click`
- `acestep/ui/gradio/i18n/en.json` — new `service.vae_label` /
  `service.vae_info` strings (other locales fall back to English)
- `docs/en/ALT_VAE.md` — user-facing doc with credit + license note

## Test plan

- [x] `uv run --with pytest python -m pytest acestep/model_downloader_test.py` — 27 passed (12 new, 15 pre-existing)
- [x] `uv run --with pytest python -m pytest acestep/core/generation/handler/init_service_test.py` — 58 passed, 1 pre-existing failure on main (`_sync_alignment_config` missing on the test host stub, unrelated)
- [ ] Manual: open Gradio, expand **Service Configuration**, switch
      **VAE** to `scragvae`, click **Initialize Service**, confirm
      auto-download into `<checkpoints>/scragvae/` and that generation
      uses the new VAE end-to-end. (Requires network + ~640 MB.)
- [ ] Manual: same flow with `ACESTEP_VAE_CHECKPOINT=scragvae` set in
      the environment and the dropdown left at `official` — the env
      var should win on first init, the dropdown takes over once UI
      explicitly sets it.
- [ ] Manual on Apple Silicon: confirm MLX VAE picks up ScragVAE
      (`[MLX-VAE] Native MLX VAE initialized` log line after switch).

## Out of scope (called out in the issue)

- GGUF (`scragvae-BF16.gguf`) loading — separate feature.
- Per-track VAE override at generate-time.
- Training pipeline still loads `<checkpoints>/vae/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VAE variant support expanded: selection (official or community) can be chosen via UI, env var, or init parameter; community variants auto-download on first use and are prechecked.

* **Tests**
  * Added unit tests covering VAE resolution, existence checks, download behavior, and initialization propagation.

* **Documentation**
  * Added user guide describing VAE variants, selection precedence, and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->