### PR TITLE
feat: add cover-nofsq task type (FSQ bypass for raw VAE covers)

### DIFF
--- a/acestep/api/job_generation_runtime.py
+++ b/acestep/api/job_generation_runtime.py
@@ -42,7 +42,7 @@ def run_generation_with_optional_sequential_cover_mode(
     """
 
     sequential_runs = 1
-    if req.task_type == "cover" and handler_device == "mps":
+    if req.task_type in ("cover", "cover-nofsq") and handler_device == "mps":
         if config.batch_size is not None and config.batch_size > 1:
             sequential_runs = int(config.batch_size)
             config.batch_size = 1

--- a/acestep/api/llm_generation_inputs.py
+++ b/acestep/api/llm_generation_inputs.py
@@ -72,7 +72,7 @@ def prepare_llm_generation_inputs(
     use_cot_language = bool(req.use_cot_language)
     full_analysis_only = bool(req.full_analysis_only)
 
-    if req.task_type == "cover" and selected_handler_device == "mps":
+    if req.task_type in ("cover", "cover-nofsq") and selected_handler_device == "mps":
         if getattr(app_state, "_llm_initialized", False) and getattr(
             llm_handler, "llm_initialized", False
         ):

--- a/acestep/constants.py
+++ b/acestep/constants.py
@@ -71,20 +71,20 @@ VALID_TIME_SIGNATURES = [2, 3, 4, 6]
 # ==============================================================================
 
 # All supported generation tasks across different model variants
-TASK_TYPES = ["text2music", "repaint", "cover", "extract", "lego", "complete"]
+TASK_TYPES = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
 
 # Task types available for turbo models (optimized subset for speed)
 # - text2music: Generate from text descriptions
 # - repaint: Selective audio editing/regeneration  
 # - cover: Style transfer using reference audio
-TASK_TYPES_TURBO = ["text2music", "repaint", "cover"]
+TASK_TYPES_TURBO = ["text2music", "repaint", "cover", "cover-nofsq"]
 
 # Task types available for base models (full feature set)
 # Additional tasks requiring more computational resources:
 # - extract: Separate individual tracks/stems from audio
 # - lego: Multi-track generation (add layers)
 # - complete: Automatic completion of partial audio
-TASK_TYPES_BASE = ["text2music", "repaint", "cover", "extract", "lego", "complete"]
+TASK_TYPES_BASE = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
 
 
 # ==============================================================================
@@ -92,16 +92,17 @@ TASK_TYPES_BASE = ["text2music", "repaint", "cover", "extract", "lego", "complet
 # ==============================================================================
 
 # Default modes for turbo and SFT models (restricted set)
-GENERATION_MODES_TURBO = ["Simple", "Custom", "Remix", "Repaint"]
+GENERATION_MODES_TURBO = ["Simple", "Custom", "Remix", "Remix (Raw)", "Repaint"]
 
 # Extended modes for pure base models only — adds Extract/Lego/Complete
-GENERATION_MODES_BASE = ["Simple", "Custom", "Remix", "Repaint", "Extract", "Lego", "Complete"]
+GENERATION_MODES_BASE = ["Simple", "Custom", "Remix", "Remix (Raw)", "Repaint", "Extract", "Lego", "Complete"]
 
 # Mapping from generation mode to task_type value
 MODE_TO_TASK_TYPE = {
     "Simple": "text2music",
     "Custom": "text2music",
     "Remix": "cover",
+    "Remix (Raw)": "cover-nofsq",
     "Repaint": "repaint",
     "Extract": "extract",
     "Lego": "lego",
@@ -127,6 +128,7 @@ TASK_INSTRUCTIONS = {
     "text2music": "Fill the audio semantic mask based on the given conditions:",
     "repaint": "Repaint the mask area based on the given conditions:",
     "cover": "Generate audio semantic tokens based on the given conditions:",
+    "cover-nofsq": "Generate audio semantic tokens based on the given conditions:",
     "extract": "Extract the {TRACK_NAME} track from the audio:",
     "extract_default": "Extract the track from the audio:",
     "lego": "Generate the {TRACK_NAME} track based on the audio context:",

--- a/acestep/core/generation/handler/conditioning_batch.py
+++ b/acestep/core/generation/handler/conditioning_batch.py
@@ -35,6 +35,7 @@ class ConditioningBatchMixin:
         audio_cover_strength: float = 1.0,
         cover_noise_strength: float = 0.0,
         chunk_mask_modes: Optional[List[str]] = None,
+        task_type: str = "",
     ) -> Dict[str, Any]:
         """Prepare model-ready conditioning batch tensors and metadata.
 
@@ -91,6 +92,7 @@ class ConditioningBatchMixin:
             repainting_end,
             silence_latent_tiled,
             chunk_mask_modes=chunk_mask_modes,
+            task_type=task_type,
         )
         precomputed_lm_hints_25hz = self._prepare_precomputed_lm_hints(
             batch_size, audio_code_hints, max_latent_length, silence_latent_tiled

--- a/acestep/core/generation/handler/conditioning_masks.py
+++ b/acestep/core/generation/handler/conditioning_masks.py
@@ -4,11 +4,6 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 
-# Phrase unique to lego task instructions — used to detect lego items from instruction text.
-# Matches both TASK_INSTRUCTIONS["lego"] and TASK_INSTRUCTIONS["lego_default"].
-_LEGO_INSTRUCTION_MARKER = "based on the audio context"
-
-
 class ConditioningMaskMixin:
     """Mixin containing repaint mask/span and source-latent builders.
 
@@ -28,6 +23,7 @@ class ConditioningMaskMixin:
         repainting_end: Optional[List[float]],
         silence_latent_tiled: torch.Tensor,
         chunk_mask_modes: Optional[List[str]] = None,
+        task_type: str = "",
     ) -> Tuple[
         torch.Tensor,
         List[Tuple[str, int, int]],
@@ -71,12 +67,7 @@ class ConditioningMaskMixin:
 
             chunk_masks.append(torch.ones(max_latent_length, dtype=torch.bool, device=self.device))
             spans.append(("full", 0, max_latent_length))
-            instruction_i = instructions[i] if instructions and i < len(instructions) else ""
-            instruction_lower = instruction_i.lower()
-            is_cover = (
-                "generate audio semantic tokens" in instruction_lower
-                and "based on the given conditions" in instruction_lower
-            ) or has_code_hint
+            is_cover = (task_type == "cover") or has_code_hint
             is_covers.append(is_cover)
 
         chunk_masks_tensor = torch.stack(chunk_masks)
@@ -94,8 +85,7 @@ class ConditioningMaskMixin:
                 if i in repainting_ranges:
                     src_latent = target_latents[i].clone()
                     start_latent, end_latent = repainting_ranges[i]
-                    instruction_i = instructions[i] if instructions and i < len(instructions) else ""
-                    is_lego = _LEGO_INSTRUCTION_MARKER in instruction_i.lower()
+                    is_lego = (task_type == "lego")
                     if not is_lego:
                         src_latent[start_latent:end_latent] = silence_latent_tiled[start_latent:end_latent]
                     src_latents_list.append(src_latent)

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -306,7 +306,7 @@ class GenerateMusicMixin:
 
             # Cover/repaint/lego/extract: lock duration to source audio.
             if processed_src_audio is not None and task_type in (
-                "cover", "repaint", "lego", "extract",
+                "cover", "cover-nofsq", "repaint", "lego", "extract",
             ):
                 audio_duration = processed_src_audio.shape[-1] / self.sample_rate
 
@@ -362,6 +362,7 @@ class GenerateMusicMixin:
                 velocity_ema_factor=velocity_ema_factor,
                 repaint_crossfade_frames=resolved_cf_frames,
                 repaint_injection_ratio=injection_ratio,
+                task_type=task_type,
             )
             outputs = service_run["outputs"]
             infer_steps_for_progress = service_run["infer_steps_for_progress"]

--- a/acestep/core/generation/handler/generate_music_execute.py
+++ b/acestep/core/generation/handler/generate_music_execute.py
@@ -38,6 +38,7 @@ class GenerateMusicExecuteMixin:
         velocity_ema_factor: float = 0.0,
         repaint_crossfade_frames: int = 10,
         repaint_injection_ratio: float = 0.5,
+        task_type: str = "",
     ) -> Dict[str, Any]:
         """Invoke ``service_generate`` while maintaining background progress estimation.
 
@@ -91,6 +92,7 @@ class GenerateMusicExecuteMixin:
                     chunk_mask_modes=service_inputs.get("chunk_mask_modes_batch"),
                     repaint_crossfade_frames=repaint_crossfade_frames,
                     repaint_injection_ratio=repaint_injection_ratio,
+                    task_type=task_type,
                 )
             except Exception as exc:
                 _error["exc"] = exc

--- a/acestep/core/generation/handler/service_generate.py
+++ b/acestep/core/generation/handler/service_generate.py
@@ -50,6 +50,7 @@ class ServiceGenerateMixin:
         sampler_mode: str = "euler",
         velocity_norm_threshold: float = 0.0,
         velocity_ema_factor: float = 0.0,
+        task_type: str = "",
     ) -> Dict[str, Any]:
         """Generate music latents and metadata from text/audio conditioning inputs.
 
@@ -121,6 +122,7 @@ class ServiceGenerateMixin:
             audio_cover_strength=audio_cover_strength,
             cover_noise_strength=cover_noise_strength,
             chunk_mask_modes=chunk_mask_modes,
+            task_type=task_type,
         )
         payload = self._unpack_service_processed_data(self.preprocess_batch(batch))
         seed_param = self._resolve_service_seed_param(normalized["seed_list"])

--- a/acestep/core/generation/handler/task_utils.py
+++ b/acestep/core/generation/handler/task_utils.py
@@ -75,6 +75,8 @@ class TaskUtilsMixin:
             return TASK_INSTRUCTIONS["repaint"]
         if task_type == "cover":
             return TASK_INSTRUCTIONS["cover"]
+        if task_type == "cover-nofsq":
+            return TASK_INSTRUCTIONS["cover"]
         if task_type == "extract":
             return (
                 TASK_INSTRUCTIONS["extract"].format(TRACK_NAME=track_name.upper())
@@ -100,7 +102,7 @@ class TaskUtilsMixin:
         """Compute task-mode booleans for downstream generation logic."""
         is_repaint_task = task_type == "repaint"
         is_lego_task = task_type == "lego"
-        is_cover_task = task_type == "cover"
+        is_cover_task = task_type in ("cover", "cover-nofsq")
 
         if isinstance(audio_code_string, list):
             has_codes = any((c or "").strip() for c in audio_code_string)

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -413,7 +413,7 @@ def generate_music(
         # and don't need LM to generate audio codes or metadata.
         # For extract tasks, LLM-generated captions can conflict with the extract instruction
         # and cause the DiT model to reconstruct input audio instead of extracting stems.
-        skip_lm_tasks = {"cover", "repaint", "extract"}
+        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract"}
         
         # Determine if we should use LLM
         # LLM is needed for:
@@ -597,7 +597,7 @@ def generate_music(
                 dit_input_vocal_language = lm_generated_metadata.get("vocal_language", dit_input_vocal_language)
 
         # Repaint/cover/extract: no LM run, so conditioning must come from params (caption + lyrics from GUI).
-        if params.task_type in ("repaint", "cover", "extract"):
+        if params.task_type in ("repaint", "cover", "cover-nofsq", "extract"):
             dit_input_caption = params.caption or dit_input_caption
             dit_input_lyrics = params.lyrics if params.lyrics is not None else dit_input_lyrics
             logger.info(f"[generate_music] {params.task_type} task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")
@@ -606,7 +606,7 @@ def generate_music(
         # Cover/repaint/lego/extract: duration is locked to the source audio
         # length.  Silently ignore whatever the caller passed — the handler
         # will set audio_duration from the loaded waveform.
-        if params.task_type in ("cover", "repaint", "lego", "extract"):
+        if params.task_type in ("cover", "cover-nofsq", "repaint", "lego", "extract"):
             audio_duration = None
 
         # Phase 2: DiT music generation

--- a/acestep/openrouter_models.py
+++ b/acestep/openrouter_models.py
@@ -94,7 +94,7 @@ class ChatCompletionRequest(BaseModel):
     use_cot_language: bool = Field(default=True, description="Use CoT for language detection")
 
     # Task type
-    task_type: str = Field(default="text2music", description="Task type: text2music, cover, repaint, extract, lego, complete")
+    task_type: str = Field(default="text2music", description="Task type: text2music, cover, cover-nofsq, repaint, extract, lego, complete")
 
     # Audio editing parameters
     repainting_start: float = Field(default=0.0, description="Repainting region start (seconds)")

--- a/acestep/ui/gradio/events/generation/ui_helpers.py
+++ b/acestep/ui/gradio/events/generation/ui_helpers.py
@@ -101,8 +101,8 @@ def uncheck_auto_for_populated_fields(bpm, key_scale, time_signature, vocal_lang
 def update_audio_cover_strength_visibility(task_type_value, init_llm_checked, reference_audio=None):
     """Update audio_cover_strength visibility and label."""
     has_reference = _has_reference_audio(reference_audio)
-    is_visible = (task_type_value == "cover") or init_llm_checked or has_reference
-    if task_type_value == "cover":
+    is_visible = (task_type_value in ("cover", "cover-nofsq")) or init_llm_checked or has_reference
+    if task_type_value in ("cover", "cover-nofsq"):
         label = t("generation.cover_strength_label")
         help_text = t("generation.cover_strength_info")
     elif init_llm_checked:

--- a/acestep/ui/streamlit/components/editor.py
+++ b/acestep/ui/streamlit/components/editor.py
@@ -51,7 +51,7 @@ def show_editor() -> None:
 
     if task == "repaint":
         repaint_ui(audio_path, duration_sec)
-    elif task == "cover":
+    elif task in ("cover", "cover-nofsq"):
         cover_ui(audio_path, duration_sec)
     elif task == "complete":
         complete_ui(audio_path, duration_sec)


### PR DESCRIPTION
cover-nofsq uses the same DiT instruction as cover but skips the FSQ roundtrip (25Hz->5Hz->25Hz), feeding raw VAE latents directly. Produces remixes that stay closer to the source structure and timbre.

Replaces fragile instruction text matching in conditioning_masks.py with direct task_type check. Passes task_type through the chain: generate_music -> generate_music_execute -> service_generate -> conditioning_batch -> conditioning_masks.

Exposed as "Remix (Raw)" in the Gradio mode selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Remix (Raw)" generation mode, a new variant of cover generation that bypasses FSQ-based audio processing.

* **Improvements**
  * Enhanced UI to properly display audio cover strength controls for the new Remix mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->