### PR TITLE
Fix: bypass torchcodec crash in _save_mp3 on PyTorch 2.10+

### DIFF
--- a/acestep/audio_utils.py
+++ b/acestep/audio_utils.py
@@ -19,6 +19,7 @@ from typing import Union, Optional, List, Tuple
 import torch
 import numpy as np
 import torchaudio
+import soundfile as sf
 from loguru import logger
 
 
@@ -159,12 +160,15 @@ class AudioSaver:
             temp_wav_path = Path(temp_wav.name)
 
         try:
-            torchaudio.save(
-                str(temp_wav_path),
-                tensor_to_save,
-                int(target_sample_rate),
-                channels_first=True,
-                backend='soundfile',
+            # Write WAV directly via soundfile to avoid torchaudio's torchcodec
+            # dispatch, which fails on environments with incompatible FFmpeg
+            # shared libraries (e.g. Colab with PyTorch 2.10+cu128).
+            audio_np = tensor_to_save.numpy()
+            if audio_np.ndim == 2:
+                audio_np = audio_np.T  # (C, N) -> (N, C) for soundfile
+            sf.write(
+                str(temp_wav_path), audio_np, int(target_sample_rate),
+                subtype="PCM_16",
             )
             cmd = [
                 'ffmpeg', '-y', '-hide_banner', '-loglevel', 'error',

--- a/acestep/audio_utils_test.py
+++ b/acestep/audio_utils_test.py
@@ -131,14 +131,14 @@ class AudioSaverFormatTests(unittest.TestCase):
         output_path = Path(self.temp_dir) / "test.mp3"
 
         with (
-            patch('acestep.audio_utils.torchaudio.save') as mock_torchaudio_save,
+            patch('acestep.audio_utils.sf.write') as mock_sf_write,
             patch('acestep.audio_utils.subprocess.run') as mock_subprocess_run,
         ):
             saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
 
-            mock_torchaudio_save.assert_called_once()
-            save_args = mock_torchaudio_save.call_args[0]
-            self.assertEqual(save_args[2], 48000)
+            mock_sf_write.assert_called_once()
+            sf_args = mock_sf_write.call_args
+            self.assertEqual(sf_args[0][2], 48000)  # sample_rate arg
 
             cmd = mock_subprocess_run.call_args[0][0]
             self.assertIn('libmp3lame', cmd)
@@ -153,7 +153,7 @@ class AudioSaverFormatTests(unittest.TestCase):
 
         with (
             patch('acestep.audio_utils.torchaudio.functional.resample', return_value=self.sample_audio) as mock_resample,
-            patch('acestep.audio_utils.torchaudio.save') as mock_torchaudio_save,
+            patch('acestep.audio_utils.sf.write') as mock_sf_write,
             patch('acestep.audio_utils.subprocess.run') as mock_subprocess_run,
         ):
             saver._save_mp3(
@@ -165,13 +165,31 @@ class AudioSaverFormatTests(unittest.TestCase):
             )
 
             mock_resample.assert_called_once_with(self.sample_audio, 48000, 44100)
-            mock_torchaudio_save.assert_called_once()
-            save_args = mock_torchaudio_save.call_args[0]
-            self.assertEqual(save_args[2], 44100)
+            mock_sf_write.assert_called_once()
+            sf_args = mock_sf_write.call_args
+            self.assertEqual(sf_args[0][2], 44100)  # sample_rate arg
 
             cmd = mock_subprocess_run.call_args[0][0]
             self.assertIn('320k', cmd)
             self.assertIn('44100', cmd)
+
+    def test__save_mp3_does_not_call_torchaudio_save(self):
+        """Regression: _save_mp3 must not call torchaudio.save (torchcodec bypass).
+
+        On PyTorch 2.10+, torchaudio.save() unconditionally routes through
+        torchcodec even with backend='soundfile', crashing on environments
+        with incompatible FFmpeg shared libraries (e.g. Colab).
+        """
+        saver = AudioSaver()
+        output_path = Path(self.temp_dir) / "test_no_torchcodec.mp3"
+
+        with (
+            patch('acestep.audio_utils.sf.write'),
+            patch('acestep.audio_utils.subprocess.run'),
+            patch('acestep.audio_utils.torchaudio.save') as mock_ta_save,
+        ):
+            saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
+            mock_ta_save.assert_not_called()
 
     def test_save_audio_opus_uses_ffmpeg_backend(self):
         """Opus format should use ffmpeg backend like MP3."""


### PR DESCRIPTION
## Summary

`AudioSaver._save_mp3()` crashes on environments where `torchcodec`'s shared libraries
(`libtorchcodec_core*.so`) cannot load — notably **Google Colab with PyTorch 2.10.0+cu128**.

The fix replaces `torchaudio.save()` with direct `soundfile.write()` for the intermediate
WAV file in `_save_mp3`. This is a minimal, surgical change: the ffmpeg-based MP3 encoding
pipeline is untouched.

## Root Cause

In `torchaudio >= 2.10`, `torchaudio.save()` unconditionally routes through
`save_with_torchcodec()` for all formats, even when `backend='soundfile'` is specified
explicitly. If `torchcodec` cannot load its native FFmpeg shared libraries (common on Colab
due to mismatched `libavutil.so` versions or the `torch_dtype_float4_e2m1fn_x2` symbol), 
the call fails with a hard `RuntimeError`.

The error chain is:
_save_mp3 → torchaudio.save(..., backend='soundfile') → save_with_torchcodec() ← dispatched unconditionally → load_torchcodec_shared_libraries() → RuntimeError: Could not load libtorchcodec


Since `save_audio()` has a soundfile fallback for non-MP3 formats (lines 317–338), those 
survive. But MP3 has no fallback — it re-raises immediately, so the entire generation 
crashes after the audio is already computed.

## The Fix

Replace the `torchaudio.save()` call in `_save_mp3` (used only to write a temporary WAV)
with a direct `soundfile.write()` call. The `soundfile` library is already a declared 
dependency (`soundfile>=0.13.1` in `pyproject.toml`) and writes WAV files without touching 
`torchcodec`.

## Risk Assessment

| Area | Risk | Notes |
|------|------|-------|
| MP3 export quality | None | WAV→MP3 conversion via ffmpeg is unchanged |
| Other formats | None | Untouched by this change |
| Non-Colab environments | None | soundfile produces identical WAV output |
| Platforms (CUDA/MPS/XPU/CPU) | None | soundfile is platform-agnostic |

## Tested On

- Google Colab (Ubuntu 22.04, A100, PyTorch 2.10.0+cu128, torchaudio 2.10.0+cu128)
- Generation completes and MP3 files are saved successfully after patch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced MP3 export stability and reliability through an improved audio processing pipeline.

* **Refactor**
  * Modernized the internal audio file serialization mechanism in the MP3 export workflow to use a more robust audio library approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->