### PR TITLE
fix(gradio): allow Extract/Lego src_audio uploads from Gradio temp dir (#1118)

### DIFF
--- a/acestep/ui/gradio/events/generation/mode_ui.py
+++ b/acestep/ui/gradio/events/generation/mode_ui.py
@@ -207,10 +207,9 @@ def handle_extract_src_audio_change(src_audio_path, mode: str):
         return gr.update()
     try:
         import soundfile as sf
-        info = sf.info(src_audio_path)
-        duration = int(info.duration)
-        if duration and duration > 0:
-            return gr.update(value=float(duration))
+        duration = float(sf.info(src_audio_path).duration)
+        if duration > 0:
+            return gr.update(value=duration)
     except Exception as e:
         logger.warning(f"Failed to get audio duration for {mode} mode: {e}")
     return gr.update()

--- a/acestep/ui/gradio/events/generation/mode_ui.py
+++ b/acestep/ui/gradio/events/generation/mode_ui.py
@@ -197,13 +197,18 @@ def handle_extract_track_name_change(track_name_value: str, mode: str):
 
 
 def handle_extract_src_audio_change(src_audio_path, mode: str):
-    """Auto-fill audio duration from source audio in Extract/Lego mode."""
+    """Auto-fill audio duration from source audio in Extract/Lego mode.
+
+    Reads duration directly via soundfile to avoid the training-module
+    safe_path guard, which rejects Gradio-uploaded files stored under the
+    system temp directory (e.g. AppData\\Local\\Temp\\gradio\\... on Windows).
+    """
     if mode not in ("Extract", "Lego") or not src_audio_path:
         return gr.update()
     try:
-        # Late import avoids loading training audio helpers unless this path is used.
-        from acestep.training.dataset_builder_modules.audio_io import get_audio_duration
-        duration = get_audio_duration(src_audio_path)
+        import soundfile as sf
+        info = sf.info(src_audio_path)
+        duration = int(info.duration)
         if duration and duration > 0:
             return gr.update(value=float(duration))
     except Exception as e:

--- a/acestep/ui/gradio/events/generation/mode_ui_test.py
+++ b/acestep/ui/gradio/events/generation/mode_ui_test.py
@@ -242,12 +242,12 @@ class ExtractSrcAudioDurationTests(unittest.TestCase):
     def test_returns_noop_for_non_extract_lego_mode(self):
         """Non-Extract/Lego modes should return an empty update without inspecting the file."""
         result = handle_extract_src_audio_change("/anywhere/file.wav", "Custom")
-        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+        self.assertNotIn("value", result)
 
     def test_returns_noop_for_empty_src_audio(self):
         """Empty src_audio should short-circuit without raising."""
         result = handle_extract_src_audio_change("", "Extract")
-        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+        self.assertNotIn("value", result)
 
     def test_reads_duration_from_gradio_temp_path_without_safe_path(self):
         """A Gradio temp path outside the project safe root must NOT raise."""
@@ -257,15 +257,15 @@ class ExtractSrcAudioDurationTests(unittest.TestCase):
         with patch("soundfile.info", return_value=fake_info) as mock_info:
             result = handle_extract_src_audio_change(gradio_temp_path, "Extract")
             mock_info.assert_called_once_with(gradio_temp_path)
-        # Result should carry a positive numeric value without exception.
-        self.assertEqual(getattr(result, "_props", {}).get("value"), 42.0)
+        # gr.update(value=...) returns a plain dict; assert directly.
+        self.assertEqual(result.get("value"), 42.7)
 
     def test_swallows_invalid_audio_errors(self):
         """A bad/unreadable file should be logged-and-skipped, not raised."""
         from unittest.mock import patch
         with patch("soundfile.info", side_effect=RuntimeError("bad file")):
             result = handle_extract_src_audio_change("/tmp/bogus.wav", "Lego")
-        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+        self.assertNotIn("value", result)
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/generation/mode_ui_test.py
+++ b/acestep/ui/gradio/events/generation/mode_ui_test.py
@@ -221,5 +221,52 @@ class ModeUiStateClearingTests(unittest.TestCase):
             self.assertFalse(result[idx].get("interactive"))
 
 
+try:
+    from acestep.ui.gradio.events.generation.mode_ui import handle_extract_src_audio_change
+    _EXTRACT_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - environment dependency guard
+    handle_extract_src_audio_change = None
+    _EXTRACT_IMPORT_ERROR = exc
+
+
+@unittest.skipIf(handle_extract_src_audio_change is None,
+                 f"handle_extract_src_audio_change import unavailable: {_EXTRACT_IMPORT_ERROR}")
+class ExtractSrcAudioDurationTests(unittest.TestCase):
+    """Regression tests for issue #1118 — Gradio temp-path 'safe root' rejection.
+
+    Gradio uploads land under the system temp dir (e.g. AppData\\Local\\Temp\\gradio
+    on Windows), which is outside the project safe-root. The handler must read
+    duration without invoking the training-module path-safety guard.
+    """
+
+    def test_returns_noop_for_non_extract_lego_mode(self):
+        """Non-Extract/Lego modes should return an empty update without inspecting the file."""
+        result = handle_extract_src_audio_change("/anywhere/file.wav", "Custom")
+        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+
+    def test_returns_noop_for_empty_src_audio(self):
+        """Empty src_audio should short-circuit without raising."""
+        result = handle_extract_src_audio_change("", "Extract")
+        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+
+    def test_reads_duration_from_gradio_temp_path_without_safe_path(self):
+        """A Gradio temp path outside the project safe root must NOT raise."""
+        from unittest.mock import patch, MagicMock
+        fake_info = MagicMock(duration=42.7)
+        gradio_temp_path = r"C:\Users\test\AppData\Local\Temp\gradio\abc\song.wav"
+        with patch("soundfile.info", return_value=fake_info) as mock_info:
+            result = handle_extract_src_audio_change(gradio_temp_path, "Extract")
+            mock_info.assert_called_once_with(gradio_temp_path)
+        # Result should carry a positive numeric value without exception.
+        self.assertEqual(getattr(result, "_props", {}).get("value"), 42.0)
+
+    def test_swallows_invalid_audio_errors(self):
+        """A bad/unreadable file should be logged-and-skipped, not raised."""
+        from unittest.mock import patch
+        with patch("soundfile.info", side_effect=RuntimeError("bad file")):
+            result = handle_extract_src_audio_change("/tmp/bogus.wav", "Lego")
+        self.assertNotIn("value", getattr(result, "_props", {}) or {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1118.

On Windows, Gradio uploads land in AppData\Local\Temp\gradio\..., which is outside the project safe_root. handle_extract_src_audio_change called get_audio_duration from the training module, which runs safe_path and raises ValueError on those paths. Result: Extract/Lego duration never auto-filled and the job fell back to text2music with the track name as a caption.

The safe_path guard exists to protect the training pipeline from malicious manifest paths, not to validate Gradio-managed temp files. Fix reads duration directly via soundfile.info, which is already a top-level project dependency.

**Scope**
- acestep/ui/gradio/events/generation/mode_ui.py — single function changed
- acestep/ui/gradio/events/generation/mode_ui_test.py — 4 regression tests added

**Risk**
- No GPU code touched (CUDA/ROCm/XPU/MPS/MLX/CPU paths all unchanged)
- No new dependencies
- Training pipeline untouched; safe_path still guards every training entry point
- Public API of the handler unchanged

**Regression checks**
- test_reads_duration_from_gradio_temp_path_without_safe_path — exact bug repro path no longer raises
- test_returns_noop_for_non_extract_lego_mode — other modes still short-circuit
- test_returns_noop_for_empty_src_audio — empty paths handled
- test_swallows_invalid_audio_errors — bad files log and return no-op

**Reviewer notes**
Alternatives rejected: adding base=tempfile.gettempdir() to get_audio_duration (leaks UI concerns into training), whitelisting temp dir in safe_path (weakens a CodeQL sanitiser for all callers), copying the file into the project tree first (wasteful and architecturally wrong).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-audio duration extraction so files uploaded via the app (including temp-directory uploads) are correctly detected and durations reported.

* **Tests**
  * Added tests covering audio duration extraction, regression for temp-file handling, mode-specific handler behavior, and safe handling of audio-read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->