### PR TITLE
fix(lora): drop stale peft_config entries to prevent ghost adapters

### DIFF
--- a/acestep/core/generation/handler/lora/lifecycle.py
+++ b/acestep/core/generation/handler/lora/lifecycle.py
@@ -288,6 +288,18 @@ def add_lora(self, lora_path: str, adapter_name: str | None = None) -> str:
         self.lora_loaded = True
         self.use_lora = True
         self._active_loras[effective_name] = 1.0
+        # FIX: Drop stale entries from peft_config that may have been left over
+        # by previous unload_lora() calls. These ghosts get resurrected by
+        # _rebuild_lora_registry() if not removed first.
+        if PeftModel is not None and isinstance(self.model.decoder, PeftModel):
+            decoder_pc = getattr(self.model.decoder, "peft_config", {}) or {}
+            for ghost_name in list(decoder_pc.keys()):
+                if ghost_name not in self._active_loras:
+                    try:
+                        self.model.decoder.delete_adapter(ghost_name)
+                        logger.info(f"Removed stale adapter from peft_config: {ghost_name}")
+                    except Exception as e:
+                        logger.warning(f"Could not remove stale adapter {ghost_name}: {e}")        
         self._ensure_lora_registry()
         self._lora_active_adapter = None
         target_count, adapters = self._rebuild_lora_registry(lora_path=lora_path)


### PR DESCRIPTION
## Summary

Fixes a state desynchronization bug in `add_lora()` where adapters from previous sessions are resurrected in the PEFT config even though they were unloaded.

Possibly related to #705.

## Context

I built a custom multi-LoRA web UI on top of the REST API exposed in `acestep/api/http/lora_routes.py` (using Claude as a coding assistant). The engine code already supports multi-adapter mode beautifully — `_active_loras` is a dict, `set_lora_scale(name, scale)` accepts an adapter name, `get_lora_status()` returns `adapters` and `scales` per adapter. So I built an interface with one slider per loaded LoRA and an "Add" button, talking to the existing REST endpoints with `adapter_name` parameters.

Everything worked great with up to 3 LoRAs blending together — until I tried to unload everything and start fresh.

## Bug reproduction

```bash
# Start with no LoRA loaded
curl http://localhost:8001/v1/lora/status
# → adapters: [], scales: {}

# Load LoRA A
curl -X POST http://localhost:8001/v1/lora/load \
  -d '{"lora_path": "/path/A", "adapter_name": "A"}'

# Load LoRA B
curl -X POST http://localhost:8001/v1/lora/load \
  -d '{"lora_path": "/path/B", "adapter_name": "B"}'

curl http://localhost:8001/v1/lora/status
# → adapters: ["A", "B"], scales: {A: 1.0, B: 1.0}  ✓

# Unload everything
curl -X POST http://localhost:8001/v1/lora/unload -d '{}'

curl http://localhost:8001/v1/lora/status
# → adapters: [], scales: {}  ← looks clean

# Wait 30s+ (no race condition involved)
# Load a fresh LoRA C
curl -X POST http://localhost:8001/v1/lora/load \
  -d '{"lora_path": "/path/C", "adapter_name": "C"}'

curl http://localhost:8001/v1/lora/status
# → adapters: ["C", "A", "B"]   ← BUG: A and B are back
#   scales: {C: 1.0}             ← but only C has a scale entry
```

## Root cause

After `unload_lora()`:
- `_active_loras.clear()` ✓
- `_lora_service.registry = {}` ✓
- `self.model.decoder = self.model.decoder.get_base_model()` — but `peft_config` keeps the previous adapter entries

`get_base_model()` extracts the base model from the PEFT wrapper without deleting the adapter configurations. They remain attached to the decoder.

When `add_lora()` is called next, it eventually calls `_rebuild_lora_registry()` (line 293), which introspects `peft_config` to discover loaded adapters. It rediscovers the stale ghost entries and re-registers them.

Result: `_lora_service.registry` and `_active_loras` get out of sync, with `registry` containing more adapters than `_active_loras` has scales for.

## Fix

In `add_lora()`, after marking the new adapter in `_active_loras` but before `_ensure_lora_registry()`, explicitly delete any `peft_config` entry that is not in `_active_loras`. This ensures `peft_config` only contains adapters legitimately tracked by the handler before the registry rebuild runs.

The fix is surgical (one block, ~10 lines) and only affects cleanup behavior — no impact on the happy path of legitimate multi-LoRA usage.

## Verification

Tested with the following scenarios:
- ✅ Load A → unload all → load B → status: only B
- ✅ Load A → load B → status: both with correct scales
- ✅ Load A scale 0.7, load B scale 0.4 → both preserved correctly
- ✅ Multi-LoRA generation (Compose mode) works as expected
- ✅ Repeated unload/load cycles do not accumulate ghosts

## Known limitations

This is a defensive fix at the symptom level. It does not prevent stale
peft_config entries from existing between an unload and the next add_lora.
Code paths that introspect decoder.peft_config in that window (notably
generation right after `POST /v1/lora/unload`) will still see the ghosts.

A proper root-cause cleanup in `unload_lora()` / `remove_lora()` would
need to coordinate with PEFT's `get_base_model()` which dereferences 
`self.peft_config[self.active_adapter]`. I attempted that path and 
broke multi-LoRA blending in the process — that interaction needs 
deeper PEFT expertise than I have.

What this PR fixes:
- ✅ load A → unload all → load C → status returns ["C"] only
- ✅ Multi-LoRA blending works correctly across loads
- ✅ Repeated unload/load cycles do not accumulate visible ghosts

What still needs work (out of scope here):
- ❌ Generation immediately after unload still uses stale adapters
- ❌ Any direct read of decoder.peft_config between unload and next add

## Side note

While building this UI, I noticed the REST API already accepts `adapter_name` in `/v1/lora/load` and `/v1/lora/scale` — it's just not exploited by the existing Gradio interface. The whole multi-LoRA infrastructure was already in place at the engine level. Beautiful work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA adapter loading to automatically remove stale adapters that aren't actively tracked, preventing potential configuration conflicts.
  * Enhanced logging for adapter cleanup operations to improve visibility during the loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->