### PR TITLE
fix: prevent OOM and NaN/Inf on pre-Ampere (Pascal) GPUs

### DIFF
--- a/acestep/core/generation/handler/conditioning_target.py
+++ b/acestep/core/generation/handler/conditioning_target.py
@@ -45,8 +45,7 @@ class ConditioningTargetMixin:
             target_latents_list = []
             latent_lengths = []
             target_wavs_list = [target_wavs[i].clone() for i in range(batch_size)]
-            if target_wavs.device != self.device:
-                target_wavs = target_wavs.to(self.device)
+            # NOTE: target_wavs is rebuilt from target_wavs_list at line 98 — no need to move it to device here
 
             with self._load_model_context("vae"):
                 _cached_wav_ref: Optional[torch.Tensor] = None

--- a/acestep/core/generation/handler/generate_music_decode.py
+++ b/acestep/core/generation/handler/generate_music_decode.py
@@ -67,18 +67,30 @@ class GenerateMusicDecodeMixin:
         if torch.isnan(pred_latents).any() or torch.isinf(pred_latents).any():
             nan_count = torch.isnan(pred_latents).sum().item()
             inf_count = torch.isinf(pred_latents).sum().item()
-            hints = [
-                f"Generation produced NaN or Inf latents "
-                f"(shape={list(pred_latents.shape)}, dtype={pred_latents.dtype}, "
-                f"device={pred_latents.device}, nan={nan_count}, inf={inf_count}).",
-                "Common causes and fixes:",
-                "  1. LoRA/adapter trained on an older model version — retrain or update the adapter.",
-                "  2. Checkpoint/config mismatch — verify model checkpoints match this release.",
-                "  3. Unsupported quantization/backend — try running with --backend pt.",
-                "  4. CPU offload left parameters on wrong device — restart and regenerate.",
-                "  5. Float16 overflow on pre-Ampere GPU — set ACESTEP_DTYPE=float32.",
-            ]
-            raise RuntimeError("\n".join(hints))
+            total = pred_latents.numel()
+            bad_ratio = (nan_count + inf_count) / max(total, 1)
+            if bad_ratio > 0.5:
+                # >50% corrupt — raise as before, result would be unusable
+                hints = [
+                    f"Generation produced NaN or Inf latents "
+                    f"(shape={list(pred_latents.shape)}, dtype={pred_latents.dtype}, "
+                    f"device={pred_latents.device}, nan={nan_count}, inf={inf_count}).",
+                    "Common causes and fixes:",
+                    "  1. LoRA/adapter trained on an older model version — retrain or update the adapter.",
+                    "  2. Checkpoint/config mismatch — verify model checkpoints match this release.",
+                    "  3. Unsupported quantization/backend — try running with --backend pt.",
+                    "  4. CPU offload left parameters on wrong device — restart and regenerate.",
+                    "  5. Float16 overflow on pre-Ampere GPU — set ACESTEP_DTYPE=float32.",
+                ]
+                raise RuntimeError("\n".join(hints))
+            else:
+                # Partial NaN: pre-Ampere float16 overflow recovery — clamp to finite values
+                logger.warning(
+                    f"[generate_music] Detected {nan_count} NaN and {inf_count} Inf values "
+                    f"({bad_ratio:.1%} of {total} elements). "
+                    "Clamping to finite range (pre-Ampere float16 overflow recovery)."
+                )
+                pred_latents = torch.nan_to_num(pred_latents, nan=0.0, posinf=1.0, neginf=-1.0)
         if pred_latents.numel() > 0 and pred_latents.abs().sum() == 0:
             raise RuntimeError(
                 "Generation produced zero latents. "

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -92,10 +92,17 @@ class InitServiceOrchestratorMixin:
                 if gpu_config.cuda_supports_bfloat16():
                     self.dtype = torch.bfloat16
                 else:
-                    self.dtype = torch.float16
+                    # Pre-Ampere (Pascal): bfloat16 has same exponent range as float32,
+                    # avoids float16 overflow/NaN during DiT diffusion. Slower but stable.
+                    # ACESTEP_DTYPE=float32 for max stability (2x VRAM, may not fit 6GB).
+                    dtype_override = os.environ.get("ACESTEP_DTYPE", "").strip().lower()
+                    if dtype_override == "float32":
+                        self.dtype = torch.float32
+                    else:
+                        self.dtype = torch.bfloat16
                     logger.info(
-                        "[initialize_service] Pre-Ampere CUDA detected: "
-                        "using float16 instead of bfloat16."
+                        f"[initialize_service] Pre-Ampere CUDA detected: "
+                        f"using {self.dtype} to prevent float16 overflow."
                     )
             else:
                 self.dtype = torch.bfloat16 if resolved_device == "xpu" else torch.float32


### PR DESCRIPTION
## Summary

Three related bugs affecting GTX 1060 and other 6 GB pre-Ampere (Pascal) CUDA GPUs.

### 1. OOM in conditioning_target.py

The full target_wavs tensor (~82 MB for a 220s stereo track) was unconditionally moved to GPU even though it is immediately overwritten from target_wavs_list. Removing this dead .to(device) call frees ~82 MB of VRAM per generation.

### 2. NaN/Inf latents on pre-Ampere CUDA (init_service_orchestrator.py)

Pascal GPUs lack native bfloat16 kernels and were assigned torch.float16. float16 overflow (+-65504) causes NaN in the DiT diffusion forward pass. Fix: switch pre-Ampere to torch.bfloat16 (same 8-bit exponent as float32, avoids overflow). Adds ACESTEP_DTYPE=float32 env-var escape hatch.

### 3. Hard crash on partial NaN output (generate_music_decode.py)

When <50% of latent values are NaN/Inf, recover via torch.nan_to_num instead of crashing. RuntimeError preserved for >=50% corruption.

## Test plan

- [ ] Verify generation completes on a 6 GB Pascal GPU for durations >= 180s
- [ ] No regression on Ampere/Ada GPUs (bfloat16 path unchanged)
- [ ] ACESTEP_DTYPE=float32 override respected on pre-Ampere

:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness for handling corrupted latent values—now recovers from partial corruption instead of always failing.

* **New Features**
  * Added environment variable support for dtype selection on Pre-Ampere CUDA devices.

* **Improvements**
  * Enhanced device memory optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->