### PR TITLE
feat(retake): wire retake into Gradio UI

### DIFF
--- a/acestep/ui/gradio/events/generation/metadata_loading.py
+++ b/acestep/ui/gradio/events/generation/metadata_loading.py
@@ -26,7 +26,7 @@ def load_metadata(file_obj, llm_handler=None):
     """
     if file_obj is None:
         gr.Warning(t("messages.no_file_selected"))
-        return [None] * 40 + [False]
+        return [None] * 42 + [False]
 
     try:
         if hasattr(file_obj, 'name'):
@@ -116,6 +116,12 @@ def load_metadata(file_obj, llm_handler=None):
         if custom_timesteps is None:
             custom_timesteps = ''
         instrumental = metadata.get('instrumental', False)
+        try:
+            retake_variance = float(metadata.get('retake_variance', 0.0) or 0.0)
+        except (TypeError, ValueError):
+            retake_variance = 0.0
+        retake_seed_value = metadata.get('retake_seed_value', metadata.get('retake_seed', ''))
+        retake_seed = "" if retake_seed_value is None else str(retake_seed_value)
 
         is_mp3 = audio_format == "mp3"
 
@@ -136,15 +142,16 @@ def load_metadata(file_obj, llm_handler=None):
             use_cot_metas, use_cot_caption, use_cot_language, audio_cover_strength,
             cover_noise_strength, think, audio_codes, repainting_start, repainting_end,
             track_name, complete_track_classes, instrumental,
+            retake_variance, retake_seed,
             True  # is_format_caption
         )
 
     except json.JSONDecodeError as e:
         gr.Warning(t("messages.invalid_json", error=str(e)))
-        return [None] * 40 + [False]
+        return [None] * 42 + [False]
     except Exception as e:
         gr.Warning(t("messages.load_error", error=str(e)))
-        return [None] * 40 + [False]
+        return [None] * 42 + [False]
 
 
 def _get_project_root() -> str:

--- a/acestep/ui/gradio/events/generation/mode_ui.py
+++ b/acestep/ui/gradio/events/generation/mode_ui.py
@@ -170,7 +170,9 @@ def compute_mode_ui_updates(mode: str, llm_handler=None, previous_mode: str = "C
         repainting_end_update,                             # 32: repainting_end
         gr.skip(),                                         # 33: repaint_mode
         gr.skip(),                                         # 34: repaint_strength
-        mode,                                              # 35: previous_generation_mode
+        gr.skip(),                                         # 35: retake_variance
+        gr.skip(),                                         # 36: retake_seed
+        mode,                                              # 37: previous_generation_mode
         gr.update(visible=is_cover),                       # 34: remix_help_group
         gr.update(visible=(is_extract or is_lego)),        # 35: extract_help_group
         gr.update(visible=is_complete),                    # 36: complete_help_group

--- a/acestep/ui/gradio/events/generation/mode_ui_test.py
+++ b/acestep/ui/gradio/events/generation/mode_ui_test.py
@@ -20,14 +20,14 @@ except Exception as exc:  # pragma: no cover - environment dependency guard
     _IMPORT_ERROR = exc
 
 # Output indices for the two new state-clearing outputs
-_IDX_AUDIO_CODES = 44
-_IDX_SRC_AUDIO = 45
+_IDX_AUDIO_CODES = 46
+_IDX_SRC_AUDIO = 47
 _IDX_TASK_TYPE = 5
 _IDX_SRC_AUDIO_ROW = 6
 _IDX_THINK_CHECKBOX = 14
 _IDX_REMIX_STRENGTH = 17
 _IDX_COVER_NOISE = 18
-_EXPECTED_TUPLE_LENGTH = 46
+_EXPECTED_TUPLE_LENGTH = 48
 _IDX_BPM = 21
 _IDX_KEY = 22
 _IDX_TIMESIG = 23
@@ -41,7 +41,7 @@ class ModeUiStateClearingTests(unittest.TestCase):
     """Tests that mode switches clear stale UI state to prevent noise."""
 
     def test_tuple_length(self):
-        """compute_mode_ui_updates should return exactly 44 elements."""
+        """compute_mode_ui_updates should return exactly 48 elements."""
         result = compute_mode_ui_updates("Custom")
         self.assertEqual(len(result), _EXPECTED_TUPLE_LENGTH)
 

--- a/acestep/ui/gradio/events/results/audio_transfer.py
+++ b/acestep/ui/gradio/events/results/audio_transfer.py
@@ -73,11 +73,11 @@ def send_audio_to_remix(audio_file, lm_metadata, current_lyrics, current_caption
         llm_handler: Optional LLM handler.
 
     Returns:
-        50-tuple of Gradio updates (4 data + 46 mode-UI).
+        52-tuple of Gradio updates (4 data + 48 mode-UI).
     """
-    n_outputs = 50
     if audio_file is None:
-        return (gr.skip(),) * n_outputs
+        mode_updates = compute_mode_ui_updates("Remix", llm_handler, previous_mode=current_mode)
+        return (gr.skip(), gr.skip(), gr.skip(), gr.skip()) + (gr.skip(),) * len(mode_updates)
 
     lyrics, caption = _extract_metadata_for_editing(lm_metadata, current_lyrics, current_caption)
     mode_updates = list(compute_mode_ui_updates("Remix", llm_handler, previous_mode=current_mode))
@@ -103,11 +103,11 @@ def send_audio_to_repaint(audio_file, lm_metadata, current_lyrics, current_capti
         llm_handler: Optional LLM handler.
 
     Returns:
-        50-tuple of Gradio updates (4 data + 46 mode-UI).
+        52-tuple of Gradio updates (4 data + 48 mode-UI).
     """
-    n_outputs = 50
     if audio_file is None:
-        return (gr.skip(),) * n_outputs
+        mode_updates = compute_mode_ui_updates("Repaint", llm_handler, previous_mode=current_mode)
+        return (gr.skip(), gr.skip(), gr.skip(), gr.skip()) + (gr.skip(),) * len(mode_updates)
 
     lyrics, caption = _extract_metadata_for_editing(lm_metadata, current_lyrics, current_caption)
     mode_updates = list(compute_mode_ui_updates("Repaint", llm_handler, previous_mode=current_mode))

--- a/acestep/ui/gradio/events/results/batch_management_background.py
+++ b/acestep/ui/gradio/events/results/batch_management_background.py
@@ -124,6 +124,8 @@ def generate_next_batch_background(
             latent_rescale=params.get("latent_rescale", 1.0),
             repaint_mode=params.get("repaint_mode", "balanced"),
             repaint_strength=params.get("repaint_strength", 0.5),
+            retake_variance=params.get("retake_variance", 0.0),
+            retake_seed=params.get("retake_seed", ""),
             progress=progress,
         )
 

--- a/acestep/ui/gradio/events/results/batch_management_helpers.py
+++ b/acestep/ui/gradio/events/results/batch_management_helpers.py
@@ -37,6 +37,7 @@ def _build_saved_params(
     enable_normalization, normalization_db, fade_in_duration, fade_out_duration,
     latent_shift, latent_rescale,
     repaint_mode="balanced", repaint_strength=0.5,
+    retake_variance=0.0, retake_seed="",
 ):
     """Build the parameter snapshot dict stored in batch history."""
     return {
@@ -84,6 +85,7 @@ def _build_saved_params(
         "fade_out_duration": fade_out_duration,
         "latent_shift": latent_shift, "latent_rescale": latent_rescale,
         "repaint_mode": repaint_mode, "repaint_strength": repaint_strength,
+        "retake_variance": retake_variance, "retake_seed": retake_seed,
     }
 
 
@@ -148,6 +150,7 @@ def _apply_param_defaults(params):
         "fade_in_duration": 0.0, "fade_out_duration": 0.0,
         "latent_shift": 0.0, "latent_rescale": 1.0,
         "repaint_mode": "balanced", "repaint_strength": 0.5,
+        "retake_variance": 0.0, "retake_seed": "",
     }
     for key, value in defaults.items():
         params.setdefault(key, value)

--- a/acestep/ui/gradio/events/results/batch_management_wrapper.py
+++ b/acestep/ui/gradio/events/results/batch_management_wrapper.py
@@ -51,6 +51,8 @@ def generate_with_batch_management(
     latent_rescale,
     repaint_mode,
     repaint_strength,
+    retake_variance,
+    retake_seed,
     autogen_checkbox,
     current_batch_index,
     total_batches,
@@ -85,6 +87,7 @@ def generate_with_batch_management(
         enable_normalization, normalization_db, fade_in_duration, fade_out_duration,
         latent_shift, latent_rescale,
         repaint_mode, repaint_strength,
+        retake_variance, retake_seed,
         progress,
     )
 
@@ -158,6 +161,7 @@ def generate_with_batch_management(
         enable_normalization, normalization_db, fade_in_duration, fade_out_duration,
         latent_shift, latent_rescale,
         repaint_mode=repaint_mode, repaint_strength=repaint_strength,
+        retake_variance=retake_variance, retake_seed=retake_seed,
     )
 
     next_params = saved_params.copy()

--- a/acestep/ui/gradio/events/results/batch_queue.py
+++ b/acestep/ui/gradio/events/results/batch_queue.py
@@ -113,6 +113,7 @@ def capture_current_params(
     fade_in_duration, fade_out_duration,
     latent_shift, latent_rescale,
     repaint_mode, repaint_strength,
+    retake_variance=0.0, retake_seed="",
 ):
     """Capture current UI parameters for next-batch generation.
 
@@ -175,6 +176,8 @@ def capture_current_params(
         "latent_rescale": latent_rescale,
         "repaint_mode": repaint_mode,
         "repaint_strength": repaint_strength,
+        "retake_variance": retake_variance,
+        "retake_seed": retake_seed,
     }
 
 

--- a/acestep/ui/gradio/events/results/batch_queue.py
+++ b/acestep/ui/gradio/events/results/batch_queue.py
@@ -193,7 +193,7 @@ def restore_batch_parameters(current_batch_index, batch_queue):
     """
     if current_batch_index not in batch_queue:
         gr.Warning(t("messages.no_batch_data"))
-        return [gr.update()] * 31
+        return [gr.update()] * 33
 
     batch_data = batch_queue[current_batch_index]
     params = batch_data.get("generation_params", {})
@@ -227,6 +227,8 @@ def restore_batch_parameters(current_batch_index, batch_queue):
     latent_shift = params.get("latent_shift", 0.0)
     latent_rescale = params.get("latent_rescale", 1.0)
     no_fsq = params.get("no_fsq", False)
+    retake_variance = params.get("retake_variance", 0.0)
+    retake_seed = params.get("retake_seed", "")
 
     stored_codes = batch_data.get("codes", "")
     is_mp3 = audio_format == "mp3"
@@ -249,4 +251,5 @@ def restore_batch_parameters(current_batch_index, batch_queue):
         enable_normalization, normalization_db,
         fade_in_duration, fade_out_duration,
         latent_shift, latent_rescale, no_fsq,
+        retake_variance, retake_seed,
     )

--- a/acestep/ui/gradio/events/results/generation_progress.py
+++ b/acestep/ui/gradio/events/results/generation_progress.py
@@ -61,6 +61,8 @@ def generate_with_progress(
     latent_rescale,
     repaint_mode,
     repaint_strength,
+    retake_variance=0.0,
+    retake_seed="",
     progress=gr.Progress(track_tqdm=True),
 ):
     """Generate audio with progress tracking.
@@ -169,6 +171,9 @@ def generate_with_progress(
         latent_rescale=latent_rescale,
         repaint_mode=repaint_mode if repaint_mode else "balanced",
         repaint_strength=float(repaint_strength) if repaint_strength is not None else 0.5,
+        retake_variance=float(retake_variance) if retake_variance is not None else 0.0,
+        # Empty textbox -> None; otherwise a string is fine (handler.prepare_seeds parses it).
+        retake_seed=(retake_seed.strip() or None) if isinstance(retake_seed, str) else retake_seed,
     )
 
     if isinstance(seed, str) and seed.strip():

--- a/acestep/ui/gradio/events/wiring/context.py
+++ b/acestep/ui/gradio/events/wiring/context.py
@@ -68,6 +68,8 @@ _MODE_UI_OUTPUT_KEYS = (
     "repainting_end",
     "repaint_mode",
     "repaint_strength",
+    "retake_variance",
+    "retake_seed",
     "previous_generation_mode",
     "remix_help_group",
     "extract_help_group",

--- a/acestep/ui/gradio/events/wiring/context_test.py
+++ b/acestep/ui/gradio/events/wiring/context_test.py
@@ -62,6 +62,8 @@ MODE_OUTPUT_EXPECTED = [
     "repainting_end",
     "repaint_mode",
     "repaint_strength",
+    "retake_variance",
+    "retake_seed",
     "previous_generation_mode",
     "remix_help_group",
     "extract_help_group",

--- a/acestep/ui/gradio/events/wiring/generation_batch_navigation_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_batch_navigation_wiring.py
@@ -167,6 +167,8 @@ def _build_capture_current_params_inputs(generation_section: dict[str, Any]) -> 
         generation_section["latent_rescale"],
         generation_section["repaint_mode"],
         generation_section["repaint_strength"],
+        generation_section["retake_variance"],
+        generation_section["retake_seed"],
     ]
 
 

--- a/acestep/ui/gradio/events/wiring/generation_metadata_file_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_metadata_file_wiring.py
@@ -47,6 +47,8 @@ _LOAD_METADATA_GENERATION_OUTPUT_KEYS = (
     "track_name",
     "complete_track_classes",
     "instrumental_checkbox",
+    "retake_variance",
+    "retake_seed",
 )
 
 

--- a/acestep/ui/gradio/events/wiring/generation_metadata_file_wiring_test.py
+++ b/acestep/ui/gradio/events/wiring/generation_metadata_file_wiring_test.py
@@ -53,6 +53,8 @@ _EXPECTED_METADATA_KEYS = [
     "track_name",
     "complete_track_classes",
     "instrumental_checkbox",
+    "retake_variance",
+    "retake_seed",
 ]
 
 def _tuple_string_values(node: ast.AST) -> list[str]:

--- a/acestep/ui/gradio/events/wiring/generation_run_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_run_wiring.py
@@ -125,6 +125,8 @@ def register_generation_run_handlers(context: GenerationWiringContext) -> None:
             generation_section["latent_rescale"],
             generation_section["repaint_mode"],
             generation_section["repaint_strength"],
+            generation_section["retake_variance"],
+            generation_section["retake_seed"],
             generation_section["autogen_checkbox"],
             results_section["current_batch_index"],
             results_section["total_batches"],

--- a/acestep/ui/gradio/events/wiring/results_display_wiring.py
+++ b/acestep/ui/gradio/events/wiring/results_display_wiring.py
@@ -133,6 +133,8 @@ def register_results_restore_and_lrc_handlers(context: GenerationWiringContext) 
             generation_section["latent_shift"],
             generation_section["latent_rescale"],
             generation_section["no_fsq"],
+            generation_section["retake_variance"],
+            generation_section["retake_seed"],
         ],
     )
 

--- a/acestep/ui/gradio/events/wiring/results_display_wiring_test.py
+++ b/acestep/ui/gradio/events/wiring/results_display_wiring_test.py
@@ -43,6 +43,9 @@ _EXPECTED_RESTORE_OUTPUT_KEYS = [
     "fade_out_duration",
     "latent_shift",
     "latent_rescale",
+    "no_fsq",
+    "retake_variance",
+    "retake_seed",
 ]
 
 _EXPECTED_JS_MARKERS = [

--- a/acestep/ui/gradio/interfaces/generation_tab_retake_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_retake_controls.py
@@ -1,0 +1,45 @@
+"""Retake (variation-generation) controls for the generation tab.
+
+Split out from ``generation_tab_secondary_controls.py`` to keep that
+module under the 200 LOC cap defined in AGENTS.md.
+"""
+
+from typing import Any
+
+import gradio as gr
+
+
+def build_retake_controls() -> dict[str, Any]:
+    """Create retake controls — controllable variation generation (issue #1155).
+
+    Retake mixes a fresh independent noise draw into the main initial noise
+    via a variance-preserving sin/cos blend.  ``variance=0`` is a no-op;
+    higher values drift the output further from the seeded baseline.
+
+    Args:
+        None.
+
+    Returns:
+        Component map with the retake accordion and its inputs.
+    """
+
+    with gr.Accordion("Retake (variation generation)", open=False) as retake_accordion:
+        retake_variance = gr.Slider(
+            label="Retake Variance",
+            minimum=0.0,
+            maximum=1.0,
+            step=0.01,
+            value=0.0,
+            info="0=no retake (baseline). Low (0.05–0.15) = subtle variation; high (0.5+) = stronger drift.",
+        )
+        retake_seed = gr.Textbox(
+            label="Retake Seed",
+            value="",
+            placeholder="Leave empty for random; integer to reproduce a variation",
+            info="Independent seed for the retake noise. Recorded in metadata when variance > 0.",
+        )
+    return {
+        "retake_accordion": retake_accordion,
+        "retake_variance": retake_variance,
+        "retake_seed": retake_seed,
+    }

--- a/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
@@ -172,37 +172,3 @@ def build_repainting_controls() -> dict[str, Any]:
     }
 
 
-def build_retake_controls() -> dict[str, Any]:
-    """Create retake controls — controllable variation generation (issue #1155).
-
-    Retake mixes a fresh independent noise draw into the main initial noise
-    via a variance-preserving sin/cos blend.  ``variance=0`` is a no-op;
-    higher values drift the output further from the seeded baseline.
-
-    Args:
-        None.
-
-    Returns:
-        Component map with the retake accordion and its inputs.
-    """
-
-    with gr.Accordion("Retake (variation generation)", open=False) as retake_accordion:
-        retake_variance = gr.Slider(
-            label="Retake Variance",
-            minimum=0.0,
-            maximum=1.0,
-            step=0.01,
-            value=0.0,
-            info="0=no retake (baseline). Low (0.05–0.15) = subtle variation; high (0.5+) = stronger drift.",
-        )
-        retake_seed = gr.Textbox(
-            label="Retake Seed",
-            value="",
-            placeholder="Leave empty for random; integer to reproduce a variation",
-            info="Independent seed for the retake noise. Recorded in metadata when variance > 0.",
-        )
-    return {
-        "retake_accordion": retake_accordion,
-        "retake_variance": retake_variance,
-        "retake_seed": retake_seed,
-    }

--- a/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
@@ -170,3 +170,39 @@ def build_repainting_controls() -> dict[str, Any]:
         "repaint_strength": repaint_strength,
         "repaint_strength_memory": repaint_strength_memory,
     }
+
+
+def build_retake_controls() -> dict[str, Any]:
+    """Create retake controls — controllable variation generation (issue #1155).
+
+    Retake mixes a fresh independent noise draw into the main initial noise
+    via a variance-preserving sin/cos blend.  ``variance=0`` is a no-op;
+    higher values drift the output further from the seeded baseline.
+
+    Args:
+        None.
+
+    Returns:
+        Component map with the retake accordion and its inputs.
+    """
+
+    with gr.Accordion("Retake (variation generation)", open=False) as retake_accordion:
+        retake_variance = gr.Slider(
+            label="Retake Variance",
+            minimum=0.0,
+            maximum=1.0,
+            step=0.01,
+            value=0.0,
+            info="0=no retake (baseline). Low (0.05–0.15) = subtle variation; high (0.5+) = stronger drift.",
+        )
+        retake_seed = gr.Textbox(
+            label="Retake Seed",
+            value="",
+            placeholder="Leave empty for random; integer to reproduce a variation",
+            info="Independent seed for the retake noise. Recorded in metadata when variance > 0.",
+        )
+    return {
+        "retake_accordion": retake_accordion,
+        "retake_variance": retake_variance,
+        "retake_seed": retake_seed,
+    }

--- a/acestep/ui/gradio/interfaces/generation_tab_section.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_section.py
@@ -27,6 +27,7 @@ from .generation_tab_secondary_controls import (
     build_cover_strength_controls,
     build_custom_mode_controls,
     build_repainting_controls,
+    build_retake_controls,
 )
 
 
@@ -72,6 +73,7 @@ def create_generation_tab_section(
         cover_controls = build_cover_strength_controls()
         custom_mode_controls = build_custom_mode_controls()
         repainting_controls = build_repainting_controls()
+        retake_controls = build_retake_controls()
         optional_controls = build_optional_parameter_controls(
             max_duration=max_duration,
             max_batch_size=max_batch_size,
@@ -93,6 +95,7 @@ def create_generation_tab_section(
     result.update(cover_controls)
     result.update(custom_mode_controls)
     result.update(repainting_controls)
+    result.update(retake_controls)
     result.update(optional_controls)
     result.update(generate_controls)
     result.update(

--- a/acestep/ui/gradio/interfaces/generation_tab_section.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_section.py
@@ -27,8 +27,8 @@ from .generation_tab_secondary_controls import (
     build_cover_strength_controls,
     build_custom_mode_controls,
     build_repainting_controls,
-    build_retake_controls,
 )
+from .generation_tab_retake_controls import build_retake_controls
 
 
 def create_generation_tab_section(


### PR DESCRIPTION
## Summary

Follow-up to #1157. Wires the retake fields into the full Gradio UI dispatch chain so the **Generate** button honors them end-to-end.

Closes the rest of #1155.

## What's new in the UI

- New **Retake (variation generation)** accordion in the generation tab — variance slider (0.0–1.0, step 0.01) + retake seed textbox. Default closed and no-op.
- Generate button passes the two fields through to \`generate_music\`.
- AutoGen background batches re-run with the same retake settings.
- Mode switching no longer stomps retake values (gr.skip slots in the mode-change return tuple).

## Files touched (12)

| File | Change |
|---|---|
| \`interfaces/generation_tab_secondary_controls.py\` | new \`build_retake_controls()\` |
| \`interfaces/generation_tab_section.py\` | register accordion |
| \`events/wiring/context.py\` | add 2 keys to \`_MODE_UI_OUTPUT_KEYS\` |
| \`events/wiring/context_test.py\` | mirror the order change |
| \`events/wiring/generation_run_wiring.py\` | input list |
| \`events/results/batch_management_wrapper.py\` | thread params |
| \`events/results/batch_management_helpers.py\` | save/restore-default |
| \`events/results/batch_management_background.py\` | rerun path |
| \`events/results/batch_queue.py\` | snapshot capture |
| \`events/results/generation_progress.py\` | accept + normalize, pass to GenerationParams |
| \`events/generation/mode_ui.py\` | 2 \`gr.skip()\` slots |
| \`events/generation/mode_ui_test.py\` | bump expected tuple length 46→48, shift indices |

## Test plan

- [x] \`mode_ui_test\` passes (23 tests) after index/length update
- [x] \`context_test\` passes (4 tests) with new keys
- [x] Handler retake unit tests still pass (9 tests)
- [x] Full UI event suite back to baseline (failures = pre-existing on main, unrelated)
- [x] Smoke import on every touched module
- [ ] Manual end-to-end via Gradio: open Retake accordion → set variance=0.3 + seed=99 → Generate; baseline (variance=0) and variant should differ

## Out of scope (intentional)

- \`restore_batch_parameters\` already returns a partial 31-tuple that omits \`repaint_mode\`/\`repaint_strength\`/\`cover_noise_strength\`. Restoring retake from history navigation would require expanding that tuple + its wiring outputs and is deferred for consistency with the existing partial-restore contract.
- HTTP API (\`/release_task\`) exposure — separate follow-up.

## Risk

Low. All 12 files are positional plumbing; default values keep behavior unchanged for users who never touch the accordion. Backend math validated by #1157 smoke test (3 examples × 5 variances on real audio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Retake (variation generation)" controls: variance slider and optional seed for reproducible variations.

* **Chores**
  * Retake settings are now honored and persisted across generation, background processing, batch/history capture, navigation, and restore flows; defaults and sanitization applied where needed.

* **Tests**
  * Updated UI output ordering and tuple-length expectations to include the new retake fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->