### PR TITLE
fix(retake): cover base model variant + thread resolved retake_seed into UUID

### DIFF
--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -718,6 +718,19 @@ def generate_music(
         if save_dir is not None:
             os.makedirs(save_dir, exist_ok=True)
 
+        # Resolve per-sample retake seeds (handler returns a comma-joined string
+        # of the actually-used seeds when retake_variance > 0).  We thread these
+        # back into per-audio params so the UUID hash includes the seed that
+        # actually produced the output, not the (possibly None) caller input.
+        # Without this, repeated runs with retake_seed=None and a fixed main
+        # seed would collide on UUID even though the audio differs.
+        retake_seed_value_str = (dit_extra_outputs or {}).get("retake_seed_value", "") or ""
+        retake_seeds_resolved = (
+            [s.strip() for s in retake_seed_value_str.split(",") if s.strip()]
+            if retake_seed_value_str
+            else []
+        )
+
         # Build audios list for GenerationResult with params and save files
         # Audio saving and UUID generation handled here, outside of handler
         audios = []
@@ -727,6 +740,12 @@ def generate_music(
 
             # Update audio-specific values
             audio_params["seed"] = seed_list[idx] if idx < len(seed_list) else None
+            if retake_seeds_resolved:
+                audio_params["retake_seed"] = (
+                    retake_seeds_resolved[idx]
+                    if idx < len(retake_seeds_resolved)
+                    else retake_seeds_resolved[0]
+                )
 
             # Add LM-generated audio codes (only if non-empty, to preserve
             # user-provided codes when LM was used only for CoT metas)

--- a/acestep/models/base/modeling_acestep_v15_base.py
+++ b/acestep/models/base/modeling_acestep_v15_base.py
@@ -1847,6 +1847,8 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
         silence_latent: Optional[torch.FloatTensor] = None,
         attention_mask: torch.Tensor = None,
         seed: int = None,
+        retake_seed: Optional[Union[int, List[int]]] = None,
+        retake_variance: float = 0.0,
         infer_method: str = "ode",
         use_cache: bool = True,
         infer_steps: int = 30,
@@ -1954,6 +1956,12 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             iterator = zip(t[:-1], t[1:])
 
         noise = self.prepare_noise(context_latents, seed)
+        # Retake mixing: variance-preserving blend with an independent noise draw.
+        # v=0 -> noise unchanged; v=1 -> equivalent to using retake_seed as the main seed.
+        if retake_variance > 0.0:
+            retake_noise = self.prepare_noise(context_latents, retake_seed)
+            v_rad = retake_variance * (math.pi / 2.0)
+            noise = math.cos(v_rad) * noise + math.sin(v_rad) * retake_noise
         bsz, device, dtype = context_latents.shape[0], context_latents.device, context_latents.dtype
         past_key_values = EncoderDecoderCache(DynamicCache(), DynamicCache())
         momentum_buffer = MomentumBuffer()


### PR DESCRIPTION
## Summary

Follow-up to #1157, addressing two findings from codex review of the merged PR.

### 1. Base model variant was missed (effective P1)

\`acestep/models/base/modeling_acestep_v15_base.py\` is the 6th DiT variant — #1157 only patched 5 (turbo / xl_turbo / xl_base / xl_sft / sft). The base variant's \`generate_audio()\` accepts \`**kwargs\`, so the new \`retake_seed\` / \`retake_variance\` arguments were silently absorbed. No TypeError, but no mixing applied either: users loading the \`acestep-v15-base\` checkpoint get \`retake_variance=0.5\` behaving identically to \`0.0\`.

Fix: add the same sin/cos mixing + signature params to the base variant, matching the other five.

### 2. UUID collision on random retake (P2)

When \`retake_variance > 0\` and the caller leaves \`retake_seed=None\`, the handler resolves a fresh random seed, persists it in \`extra_outputs.retake_seed_value\`, and uses it for the noise mix. \`inference.generate_music\` was still hashing \`params.retake_seed\` (= \`None\`) into the per-audio UUID, so two consecutive random retakes with the same main seed would collide on UUID — different audio, same file path, same saved-params blob.

Fix: parse \`extra_outputs.retake_seed_value\` (comma-joined per-sample) and write it into \`audio_params[\"retake_seed\"]\` before \`generate_uuid_from_params()\`.

## Test plan

- [x] \`retake_test\` (9 tests) still pass — math invariants and runtime gate unchanged
- [x] Syntax check on both touched files
- [ ] Manual: load \`acestep-v15-base\` checkpoint, run with \`retake_variance=0.5\` and verify output differs from baseline (was a no-op before this fix)
- [ ] Manual: run two back-to-back generations with \`retake_variance=0.5, retake_seed=None\` at the same main seed; verify the saved files have distinct UUIDs

## Risk

Low. The base-variant change mirrors the proven 5-variant patch from #1157 line-for-line. The UUID change only mutates \`audio_params[\"retake_seed\"]\` when the handler returned a resolved value (i.e., variance > 0); when retake is unused, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — surfaced by codex review of #1157.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `retake_seed` and `retake_variance` generation parameters, enabling independent noise sample drawing and variance-preserving blending for enhanced generation control.
* Improved seed tracking to ensure output metadata accurately reflects the actual seeds used during generation, enhancing traceability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->