### PR TITLE
feat(flow-edit): shared sampling loop + 4 base-variant delegates (#1156 backend)

### DIFF
--- a/acestep/models/base/modeling_acestep_v15_base.py
+++ b/acestep/models/base/modeling_acestep_v15_base.py
@@ -2199,6 +2199,19 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156): morph src toward a target prompt/lyrics.
+
+        Thin delegate to ``models.common.flow_edit_pipeline`` so all four
+        base variants share the same implementation.  See that module's
+        docstring for the algorithm and v1 sampler-trick exclusions.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility

--- a/acestep/models/common/_flow_edit_test_support.py
+++ b/acestep/models/common/_flow_edit_test_support.py
@@ -1,0 +1,75 @@
+"""Shared stub model + input fixtures for flow-edit unit tests (#1156).
+
+The real DiT decoder needs full model weights and a GPU, so tests
+substitute a deterministic linear stand-in.  Underscored module name
+keeps it out of unittest discovery.
+"""
+
+from typing import Tuple
+
+import torch
+
+
+class _StubDecoderOutput(tuple):
+    """Mimics HuggingFace's ``ModelOutput``-like 2-tuple ``(vt, kv)``."""
+
+
+class StubDecoder(torch.nn.Module):
+    """Deterministic linear-ish stand-in for a DiT decoder.
+
+    Approximates ``decoder(hidden_states, ..., context_latents)`` with a
+    fixed linear projection plus a context-dependent perturbation so
+    that:
+
+    * ``V_src`` and ``V_tar`` differ when their context_latents differ.
+    * Output is reproducible given fixed inputs.
+    * No gradients, no real network — runs in milliseconds on CPU.
+    """
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.channels = channels
+        torch.manual_seed(13)
+        self.W = torch.randn(channels, channels) * 0.1
+
+    def forward(
+        self,
+        hidden_states,
+        timestep,
+        timestep_r,
+        attention_mask,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        context_latents,
+        use_cache=False,
+        past_key_values=None,
+    ):
+        ctx_signal = context_latents[..., : self.channels].mean(dim=-2, keepdim=True)
+        proj = hidden_states @ self.W.to(hidden_states.dtype)
+        vt = proj + 0.05 * ctx_signal + 0.01 * timestep.view(-1, 1, 1)
+        return _StubDecoderOutput((vt, past_key_values))
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class StubModel:
+    """Minimal model facade exposing the surface ``flow_edit`` uses."""
+
+    def __init__(self, channels: int = 16):
+        self.channels = channels
+        self.decoder = StubDecoder(channels)
+        self.null_condition_emb = torch.randn(1, 1, channels)
+
+
+def make_inputs(bsz: int = 1, seq: int = 8, channels: int = 16) -> Tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+]:
+    """Return ``(src_latents, enc_hs, enc_am, ctx, attn)`` with fixed seeds."""
+    torch.manual_seed(42)
+    src_latents = torch.randn(bsz, seq, channels)
+    enc_hs = torch.randn(bsz, 4, channels)
+    enc_am = torch.ones(bsz, 4)
+    ctx = torch.randn(bsz, seq, channels * 2)
+    attn = torch.ones(bsz, seq)
+    return src_latents, enc_hs, enc_am, ctx, attn

--- a/acestep/models/common/flow_edit.py
+++ b/acestep/models/common/flow_edit.py
@@ -147,7 +147,12 @@ def flowedit_sampling_loop(
 
         if step_idx < n_max_step:
             # Edit window: integrate V_delta = V_tar - V_src over n_avg draws.
-            V_delta_avg = torch.zeros_like(zt_edit)
+            # ``prev_vt_*`` must stay frozen at the *previous step*'s value
+            # for the entire inner loop — otherwise later draws would EMA
+            # against earlier draws of the same step, biasing the Monte
+            # Carlo average and making the result depend on draw order.
+            V_src_sum = torch.zeros_like(zt_edit)
+            V_tar_sum = torch.zeros_like(zt_edit)
             for _ in range(n_avg):
                 fwd_noise = draw_fwd_noise(src_latents.shape, retake_generators, device, dtype)
                 zt_src = (1.0 - t_curr_f) * src_latents + t_curr_f * fwd_noise
@@ -162,9 +167,13 @@ def flowedit_sampling_loop(
                                             velocity_norm_threshold, velocity_ema_factor)
                 V_tar = apply_velocity_post(V_tar, zt_tar, prev_vt_tar,
                                             velocity_norm_threshold, velocity_ema_factor)
-                prev_vt_src, prev_vt_tar = V_src, V_tar
-                V_delta_avg = V_delta_avg + (V_tar - V_src) / n_avg
-            zt_edit = zt_edit + dt_b * V_delta_avg
+                V_src_sum = V_src_sum + V_src
+                V_tar_sum = V_tar_sum + V_tar
+            V_src_avg = V_src_sum / n_avg
+            V_tar_avg = V_tar_sum / n_avg
+            # Update EMA carry-over once the step's effective velocity is known.
+            prev_vt_src, prev_vt_tar = V_src_avg, V_tar_avg
+            zt_edit = zt_edit + dt_b * (V_tar_avg - V_src_avg)
         else:
             # Past the edit window: regular Euler with target cond on the
             # affine-shifted running variable.  Initialised once at the

--- a/acestep/models/common/flow_edit.py
+++ b/acestep/models/common/flow_edit.py
@@ -13,13 +13,16 @@ Edit window step::
     V_delta_avg += (1/n_avg) · (V_tar - V_src)
     zt_edit   += (t_prev - t_curr) · V_delta_avg
 
-After ``i ≥ n_max`` we Euler-step ``zt_edit`` with the *target* condition
-only, denoising the edited content to a clean latent.
+After ``i ≥ n_max`` we Euler-step a target-only running variable
+``xt_tar = zt_edit + xt_src - x_src``, denoising the edited content.
 
-v1 supports: euler + plain CFG + APG + CFG interval + velocity clamp /
-EMA, all with **independent state per trajectory** (one MomentumBuffer /
-prev_vt for src, another for tar).  DCW, heun, ADG are deferred to
-follow-up PRs (each needs paired-forward derivation).
+v1 supports euler + plain CFG + APG + CFG interval + velocity clamp/EMA,
+all with **independent state per trajectory** (separate APG momentum,
+prev_vt, KV cache for src and tar).  Inside the n_avg inner loop APG
+momentum is snapshot-and-restored so each MC draw uses the same
+pre-step state — without that the buffer would advance n_avg times,
+making guidance depend on draw order.  EMA is applied once per step
+on the averaged velocity.  DCW, heun, ADG are deferred to follow-ups.
 
 Helpers live in :mod:`.flow_edit_helpers` per the 200 LOC module cap.
 """
@@ -37,10 +40,13 @@ from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 from .apg_guidance import MomentumBuffer
 from .flow_edit_helpers import (
     apply_cfg_branch,
-    apply_velocity_post,
+    apply_velocity_clamp,
+    apply_velocity_ema,
     build_timestep_schedule,
     draw_fwd_noise,
     pack_for_cfg,
+    restore_and_advance_momentum,
+    snapshot_momentum,
 )
 
 
@@ -84,8 +90,6 @@ def flowedit_sampling_loop(
     t = build_timestep_schedule(infer_steps, shift, timesteps, device, dtype)
     infer_steps = int(t.shape[0] - 1)
     n_min_step, n_max_step = int(infer_steps * n_min), int(infer_steps * n_max)
-
-    # Flow-edit accumulator starts at the source and gets pushed toward the target.
     zt_edit = src_latents.clone()
     do_cfg = diffusion_guidance_scale > 1.0
 
@@ -98,19 +102,12 @@ def flowedit_sampling_loop(
         tar_context_latents, attention_mask, null_condition_emb, do_cfg,
     )
 
-    # Independent KV cache, APG momentum, and EMA prev_vt per trajectory.
     src_kv = EncoderDecoderCache(DynamicCache(), DynamicCache())
     tar_kv = EncoderDecoderCache(DynamicCache(), DynamicCache())
     src_momentum, tar_momentum = MomentumBuffer(), MomentumBuffer()
     prev_vt_src: Optional[torch.Tensor] = None
     prev_vt_tar: Optional[torch.Tensor] = None
-    # ``xt_tar`` is the post-window running variable.  It's initialised at
-    # ``step_idx == n_max_step`` from the affine shift ``zt_edit + xt_src
-    # - x_src`` and then Euler-evolved with the target velocity (matches
-    # 1.0's flowedit_diffusion_process tail).  When ``n_max == 1.0`` it
-    # stays None and the function returns ``zt_edit``.
-    xt_tar: Optional[torch.Tensor] = None
-
+    xt_tar: Optional[torch.Tensor] = None  # post-window running variable
     iterator = zip(t[:-1], t[1:])
     if use_progress_bar:
         iterator = tqdm(iterator, total=infer_steps, desc="flow-edit")
@@ -124,7 +121,6 @@ def flowedit_sampling_loop(
     total_start = time.time()
 
     def _fwd(zt, pack, t_curr, kv):
-        """Decoder forward; returns ``(vt, new_kv)``.  Doubles ``zt`` for CFG."""
         enc_hs, enc_am, ctx, attn = pack
         x = torch.cat([zt, zt], dim=0) if do_cfg else zt
         t_tensor = t_curr * torch.ones((x.shape[0],), device=device, dtype=dtype)
@@ -146,39 +142,42 @@ def flowedit_sampling_loop(
         )
 
         if step_idx < n_max_step:
-            # Edit window: integrate V_delta = V_tar - V_src over n_avg draws.
-            # ``prev_vt_*`` must stay frozen at the *previous step*'s value
-            # for the entire inner loop — otherwise later draws would EMA
-            # against earlier draws of the same step, biasing the Monte
-            # Carlo average and making the result depend on draw order.
+            # Snapshot APG so each MC draw starts from the same pre-step
+            # momentum; we apply one update with the averaged diff after.
+            src_pre, tar_pre = snapshot_momentum(src_momentum, tar_momentum)
             V_src_sum = torch.zeros_like(zt_edit)
             V_tar_sum = torch.zeros_like(zt_edit)
+            diff_src_sum: Optional[torch.Tensor] = None
+            diff_tar_sum: Optional[torch.Tensor] = None
             for _ in range(n_avg):
+                src_momentum.running_average = src_pre
+                tar_momentum.running_average = tar_pre
                 fwd_noise = draw_fwd_noise(src_latents.shape, retake_generators, device, dtype)
                 zt_src = (1.0 - t_curr_f) * src_latents + t_curr_f * fwd_noise
                 zt_tar = zt_edit + zt_src - src_latents
                 pred_src, src_kv = _fwd(zt_src, src_pack, t_curr, src_kv)
                 pred_tar, tar_kv = _fwd(zt_tar, tar_pack, t_curr, tar_kv)
+                if do_cfg and apply_cfg_now:
+                    cs, us = pred_src.chunk(2)
+                    ct, ut = pred_tar.chunk(2)
+                    diff_src_sum = (cs - us) if diff_src_sum is None else diff_src_sum + (cs - us)
+                    diff_tar_sum = (ct - ut) if diff_tar_sum is None else diff_tar_sum + (ct - ut)
                 V_src = apply_cfg_branch(pred_src, do_cfg, apply_cfg_now,
                                          diffusion_guidance_scale, src_momentum)
                 V_tar = apply_cfg_branch(pred_tar, do_cfg, apply_cfg_now,
                                          diffusion_guidance_scale, tar_momentum)
-                V_src = apply_velocity_post(V_src, zt_src, prev_vt_src,
-                                            velocity_norm_threshold, velocity_ema_factor)
-                V_tar = apply_velocity_post(V_tar, zt_tar, prev_vt_tar,
-                                            velocity_norm_threshold, velocity_ema_factor)
-                V_src_sum = V_src_sum + V_src
-                V_tar_sum = V_tar_sum + V_tar
-            V_src_avg = V_src_sum / n_avg
-            V_tar_avg = V_tar_sum / n_avg
-            # Update EMA carry-over once the step's effective velocity is known.
+                V_src_sum = V_src_sum + apply_velocity_clamp(V_src, zt_src, velocity_norm_threshold)
+                V_tar_sum = V_tar_sum + apply_velocity_clamp(V_tar, zt_tar, velocity_norm_threshold)
+            restore_and_advance_momentum(
+                src_momentum, tar_momentum, src_pre, tar_pre,
+                None if diff_src_sum is None else diff_src_sum / n_avg,
+                None if diff_tar_sum is None else diff_tar_sum / n_avg,
+            )
+            V_src_avg = apply_velocity_ema(V_src_sum / n_avg, prev_vt_src, velocity_ema_factor)
+            V_tar_avg = apply_velocity_ema(V_tar_sum / n_avg, prev_vt_tar, velocity_ema_factor)
             prev_vt_src, prev_vt_tar = V_src_avg, V_tar_avg
             zt_edit = zt_edit + dt_b * (V_tar_avg - V_src_avg)
         else:
-            # Past the edit window: regular Euler with target cond on the
-            # affine-shifted running variable.  Initialised once at the
-            # transition (``step_idx == n_max_step``) from the same
-            # forward-diffused source the edit step uses.
             if xt_tar is None:
                 fwd_noise = draw_fwd_noise(src_latents.shape, retake_generators, device, dtype)
                 xt_src = (1.0 - t_curr_f) * src_latents + t_curr_f * fwd_noise
@@ -186,8 +185,8 @@ def flowedit_sampling_loop(
             pred_tar, tar_kv = _fwd(xt_tar, tar_pack, t_curr, tar_kv)
             V_tar = apply_cfg_branch(pred_tar, do_cfg, apply_cfg_now,
                                      diffusion_guidance_scale, tar_momentum)
-            V_tar = apply_velocity_post(V_tar, xt_tar, prev_vt_tar,
-                                        velocity_norm_threshold, velocity_ema_factor)
+            V_tar = apply_velocity_clamp(V_tar, xt_tar, velocity_norm_threshold)
+            V_tar = apply_velocity_ema(V_tar, prev_vt_tar, velocity_ema_factor)
             prev_vt_tar = V_tar
             xt_tar = xt_tar + dt_b * V_tar
 
@@ -196,7 +195,5 @@ def flowedit_sampling_loop(
     time_costs["diffusion_time_cost"] = elapsed
     time_costs["diffusion_per_step_time_cost"] = elapsed / active_steps
     time_costs["total_time_cost"] = elapsed
-    # Match 1.0's tail: if the post-window initialised a running variable
-    # we return that; otherwise ``zt_edit`` is the final state.
     target_latents = zt_edit if xt_tar is None else xt_tar
     return {"target_latents": target_latents, "time_costs": time_costs}

--- a/acestep/models/common/flow_edit.py
+++ b/acestep/models/common/flow_edit.py
@@ -1,0 +1,193 @@
+"""Flow-edit sampling loop, shared across DiT base variants (issue #1156).
+
+Ports ACE-Step 1.0's ``flowedit_diffusion_process``: edit an existing clip
+toward a new caption/lyrics by integrating ``V_delta = V_tar - V_src`` over
+a sub-window ``[n_min, n_max]`` of the diffusion schedule.
+
+Edit window step::
+
+    fwd_noise = randn(x_src.shape)                       # fresh per inner avg
+    zt_src    = (1 - t) · x_src + t · fwd_noise
+    zt_tar    = zt_edit + zt_src - x_src
+    V_src, V_tar = paired_decoder_forward(...)            # may use CFG/APG
+    V_delta_avg += (1/n_avg) · (V_tar - V_src)
+    zt_edit   += (t_prev - t_curr) · V_delta_avg
+
+After ``i ≥ n_max`` we Euler-step ``zt_edit`` with the *target* condition
+only, denoising the edited content to a clean latent.
+
+v1 supports: euler + plain CFG + APG + CFG interval + velocity clamp /
+EMA, all with **independent state per trajectory** (one MomentumBuffer /
+prev_vt for src, another for tar).  DCW, heun, ADG are deferred to
+follow-up PRs (each needs paired-forward derivation).
+
+Helpers live in :mod:`.flow_edit_helpers` per the 200 LOC module cap.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+import torch
+from loguru import logger
+from tqdm import tqdm
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
+
+from .apg_guidance import MomentumBuffer
+from .flow_edit_helpers import (
+    apply_cfg_branch,
+    apply_velocity_post,
+    build_timestep_schedule,
+    draw_fwd_noise,
+    pack_for_cfg,
+)
+
+
+@torch.no_grad()
+def flowedit_sampling_loop(
+    model,
+    *,
+    src_encoder_hidden_states: torch.Tensor,
+    src_encoder_attention_mask: torch.Tensor,
+    src_context_latents: torch.Tensor,
+    tar_encoder_hidden_states: torch.Tensor,
+    tar_encoder_attention_mask: torch.Tensor,
+    tar_context_latents: torch.Tensor,
+    src_latents: torch.Tensor,
+    attention_mask: torch.Tensor,
+    null_condition_emb: torch.Tensor,
+    retake_generators: Optional[Any] = None,
+    infer_steps: int = 60,
+    timesteps: Optional[torch.Tensor] = None,
+    shift: float = 1.0,
+    diffusion_guidance_scale: float = 15.0,
+    cfg_interval_start: float = 0.0,
+    cfg_interval_end: float = 1.0,
+    velocity_norm_threshold: float = 0.0,
+    velocity_ema_factor: float = 0.0,
+    n_min: float = 0.0,
+    n_max: float = 1.0,
+    n_avg: int = 1,
+    use_progress_bar: bool = True,
+) -> Dict[str, Any]:
+    """Run the shared flow-edit sampling loop. See module docstring for the
+    algorithm.  ``model`` is the DiT variant (must expose ``.decoder(...)``).
+    Returns ``{"target_latents": zt_edit, "time_costs": {...}}``.
+    """
+    if n_avg < 1:
+        raise ValueError(f"n_avg must be >= 1, got {n_avg}")
+    if not 0.0 <= n_min <= n_max <= 1.0:
+        raise ValueError(f"Expected 0<=n_min<=n_max<=1; got {n_min=}, {n_max=}")
+
+    device, dtype, bsz = src_latents.device, src_latents.dtype, src_latents.shape[0]
+    t = build_timestep_schedule(infer_steps, shift, timesteps, device, dtype)
+    infer_steps = int(t.shape[0] - 1)
+    n_min_step, n_max_step = int(infer_steps * n_min), int(infer_steps * n_max)
+
+    # Flow-edit accumulator starts at the source and gets pushed toward the target.
+    zt_edit = src_latents.clone()
+    do_cfg = diffusion_guidance_scale > 1.0
+
+    src_pack = pack_for_cfg(
+        src_encoder_hidden_states, src_encoder_attention_mask,
+        src_context_latents, attention_mask, null_condition_emb, do_cfg,
+    )
+    tar_pack = pack_for_cfg(
+        tar_encoder_hidden_states, tar_encoder_attention_mask,
+        tar_context_latents, attention_mask, null_condition_emb, do_cfg,
+    )
+
+    # Independent KV cache, APG momentum, and EMA prev_vt per trajectory.
+    src_kv = EncoderDecoderCache(DynamicCache(), DynamicCache())
+    tar_kv = EncoderDecoderCache(DynamicCache(), DynamicCache())
+    src_momentum, tar_momentum = MomentumBuffer(), MomentumBuffer()
+    prev_vt_src: Optional[torch.Tensor] = None
+    prev_vt_tar: Optional[torch.Tensor] = None
+    # ``xt_tar`` is the post-window running variable.  It's initialised at
+    # ``step_idx == n_max_step`` from the affine shift ``zt_edit + xt_src
+    # - x_src`` and then Euler-evolved with the target velocity (matches
+    # 1.0's flowedit_diffusion_process tail).  When ``n_max == 1.0`` it
+    # stays None and the function returns ``zt_edit``.
+    xt_tar: Optional[torch.Tensor] = None
+
+    iterator = zip(t[:-1], t[1:])
+    if use_progress_bar:
+        iterator = tqdm(iterator, total=infer_steps, desc="flow-edit")
+    logger.info(
+        "[flow_edit] start — infer_steps={}, n_min_step={}, n_max_step={}, n_avg={}, "
+        "guidance_scale={:.2f}, cfg_interval=[{:.2f}, {:.2f}]",
+        infer_steps, n_min_step, n_max_step, n_avg,
+        diffusion_guidance_scale, cfg_interval_start, cfg_interval_end,
+    )
+    time_costs: Dict[str, float] = {}
+    total_start = time.time()
+
+    def _fwd(zt, pack, t_curr, kv):
+        """Decoder forward; returns ``(vt, new_kv)``.  Doubles ``zt`` for CFG."""
+        enc_hs, enc_am, ctx, attn = pack
+        x = torch.cat([zt, zt], dim=0) if do_cfg else zt
+        t_tensor = t_curr * torch.ones((x.shape[0],), device=device, dtype=dtype)
+        out = model.decoder(
+            hidden_states=x, timestep=t_tensor, timestep_r=t_tensor,
+            attention_mask=attn, encoder_hidden_states=enc_hs,
+            encoder_attention_mask=enc_am, context_latents=ctx,
+            use_cache=True, past_key_values=kv,
+        )
+        return out[0], out[1]
+
+    for step_idx, (t_curr, t_prev) in enumerate(iterator):
+        if step_idx < n_min_step:
+            continue
+        t_curr_f = float(t_curr)
+        apply_cfg_now = cfg_interval_start <= t_curr_f <= cfg_interval_end
+        dt_b = (t_prev - t_curr).to(device=device, dtype=dtype) * torch.ones(
+            (bsz, 1, 1), device=device, dtype=dtype,
+        )
+
+        if step_idx < n_max_step:
+            # Edit window: integrate V_delta = V_tar - V_src over n_avg draws.
+            V_delta_avg = torch.zeros_like(zt_edit)
+            for _ in range(n_avg):
+                fwd_noise = draw_fwd_noise(src_latents.shape, retake_generators, device, dtype)
+                zt_src = (1.0 - t_curr_f) * src_latents + t_curr_f * fwd_noise
+                zt_tar = zt_edit + zt_src - src_latents
+                pred_src, src_kv = _fwd(zt_src, src_pack, t_curr, src_kv)
+                pred_tar, tar_kv = _fwd(zt_tar, tar_pack, t_curr, tar_kv)
+                V_src = apply_cfg_branch(pred_src, do_cfg, apply_cfg_now,
+                                         diffusion_guidance_scale, src_momentum)
+                V_tar = apply_cfg_branch(pred_tar, do_cfg, apply_cfg_now,
+                                         diffusion_guidance_scale, tar_momentum)
+                V_src = apply_velocity_post(V_src, zt_src, prev_vt_src,
+                                            velocity_norm_threshold, velocity_ema_factor)
+                V_tar = apply_velocity_post(V_tar, zt_tar, prev_vt_tar,
+                                            velocity_norm_threshold, velocity_ema_factor)
+                prev_vt_src, prev_vt_tar = V_src, V_tar
+                V_delta_avg = V_delta_avg + (V_tar - V_src) / n_avg
+            zt_edit = zt_edit + dt_b * V_delta_avg
+        else:
+            # Past the edit window: regular Euler with target cond on the
+            # affine-shifted running variable.  Initialised once at the
+            # transition (``step_idx == n_max_step``) from the same
+            # forward-diffused source the edit step uses.
+            if xt_tar is None:
+                fwd_noise = draw_fwd_noise(src_latents.shape, retake_generators, device, dtype)
+                xt_src = (1.0 - t_curr_f) * src_latents + t_curr_f * fwd_noise
+                xt_tar = zt_edit + xt_src - src_latents
+            pred_tar, tar_kv = _fwd(xt_tar, tar_pack, t_curr, tar_kv)
+            V_tar = apply_cfg_branch(pred_tar, do_cfg, apply_cfg_now,
+                                     diffusion_guidance_scale, tar_momentum)
+            V_tar = apply_velocity_post(V_tar, xt_tar, prev_vt_tar,
+                                        velocity_norm_threshold, velocity_ema_factor)
+            prev_vt_tar = V_tar
+            xt_tar = xt_tar + dt_b * V_tar
+
+    elapsed = time.time() - total_start
+    active_steps = max(1, infer_steps - n_min_step)
+    time_costs["diffusion_time_cost"] = elapsed
+    time_costs["diffusion_per_step_time_cost"] = elapsed / active_steps
+    time_costs["total_time_cost"] = elapsed
+    # Match 1.0's tail: if the post-window initialised a running variable
+    # we return that; otherwise ``zt_edit`` is the final state.
+    target_latents = zt_edit if xt_tar is None else xt_tar
+    return {"target_latents": target_latents, "time_costs": time_costs}

--- a/acestep/models/common/flow_edit_helpers.py
+++ b/acestep/models/common/flow_edit_helpers.py
@@ -69,26 +69,70 @@ def apply_cfg_branch(
     )
 
 
-def apply_velocity_post(
+def apply_velocity_clamp(
     vt: torch.Tensor,
     xt: torch.Tensor,
-    prev_vt: Optional[torch.Tensor],
     norm_threshold: float,
+) -> torch.Tensor:
+    """Per-trajectory velocity-norm clamp.  No-op when ``norm_threshold <= 0``."""
+    if norm_threshold <= 0.0:
+        return vt
+    vt_norm = torch.norm(vt, dim=(1, 2), keepdim=True)
+    xt_norm = torch.norm(xt, dim=(1, 2), keepdim=True) + 1e-10
+    scale = torch.clamp(norm_threshold * xt_norm / (vt_norm + 1e-10), max=1.0)
+    return vt * scale
+
+
+def apply_velocity_ema(
+    vt: torch.Tensor,
+    prev_vt: Optional[torch.Tensor],
     ema_factor: float,
 ) -> torch.Tensor:
-    """Per-trajectory velocity-norm clamp and EMA smoothing.
+    """EMA smoothing across *timesteps* (not across n_avg draws).
 
-    Mirrors the inline post-processing in ``generate_audio`` so flow-edit
-    behaves identically to regular generation when retake/CFG are off.
+    Caller is responsible for invoking this once per scheduler step on
+    the averaged velocity.  Applying it inside the n_avg loop with a
+    mutating ``prev_vt`` would leak earlier draws into later ones.
     """
-    if norm_threshold > 0.0:
-        vt_norm = torch.norm(vt, dim=(1, 2), keepdim=True)
-        xt_norm = torch.norm(xt, dim=(1, 2), keepdim=True) + 1e-10
-        scale = torch.clamp(norm_threshold * xt_norm / (vt_norm + 1e-10), max=1.0)
-        vt = vt * scale
-    if ema_factor > 0.0 and prev_vt is not None:
-        vt = (1.0 - ema_factor) * vt + ema_factor * prev_vt
-    return vt
+    if ema_factor <= 0.0 or prev_vt is None:
+        return vt
+    return (1.0 - ema_factor) * vt + ema_factor * prev_vt
+
+
+def snapshot_momentum(
+    src_momentum: MomentumBuffer,
+    tar_momentum: MomentumBuffer,
+):
+    """Capture the running averages so the inner n_avg loop can reset them.
+
+    APG's running average is meant to advance *once per scheduler step*;
+    if we let ``apply_cfg_branch`` mutate the buffer on every n_avg
+    draw, guidance becomes draw-order- and ``n_avg``-dependent.  Pair
+    this with :func:`restore_and_advance_momentum` after the loop.
+    """
+    return src_momentum.running_average, tar_momentum.running_average
+
+
+def restore_and_advance_momentum(
+    src_momentum: MomentumBuffer,
+    tar_momentum: MomentumBuffer,
+    src_pre,
+    tar_pre,
+    avg_diff_src: Optional[torch.Tensor],
+    avg_diff_tar: Optional[torch.Tensor],
+) -> None:
+    """Reset to pre-step state and advance once with the averaged diff.
+
+    ``avg_diff_*`` is ``None`` when CFG was inactive this step (no
+    averaged diff exists); in that case the buffer simply rolls back
+    to its pre-step state.
+    """
+    src_momentum.running_average = src_pre
+    tar_momentum.running_average = tar_pre
+    if avg_diff_src is not None:
+        src_momentum.update(avg_diff_src)
+    if avg_diff_tar is not None:
+        tar_momentum.update(avg_diff_tar)
 
 
 def draw_fwd_noise(

--- a/acestep/models/common/flow_edit_helpers.py
+++ b/acestep/models/common/flow_edit_helpers.py
@@ -1,0 +1,144 @@
+"""Helper primitives for ``flow_edit.flowedit_sampling_loop`` (#1156).
+
+Split out per the project's 200 LOC module cap.  Each helper is a small,
+side-effect-free function that the main loop composes per step.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import torch
+
+from .apg_guidance import MomentumBuffer, apg_forward
+
+
+def build_timestep_schedule(
+    infer_steps: int,
+    shift: float,
+    timesteps: Optional[torch.Tensor],
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return the closed timestep tensor of length ``infer_steps + 1``.
+
+    Mirrors the base-variant logic: ``linspace(1, 0, n+1)`` optionally
+    transformed by ``shift * t / (1 + (shift - 1) * t)``.  If the caller
+    supplied a tensor we use it verbatim; if its tail is non-zero we
+    pad a single zero so the schedule is closed.
+    """
+    if timesteps is not None:
+        t = timesteps.to(device=device, dtype=dtype)
+        if t.numel() == 0:
+            raise ValueError("timesteps must contain at least one element")
+        if t[-1].item() != 0.0:
+            t = torch.cat([t, torch.zeros(1, device=device, dtype=dtype)])
+        return t
+    t = torch.linspace(1.0, 0.0, infer_steps + 1, device=device, dtype=dtype)
+    if shift != 1.0:
+        t = shift * t / (1 + (shift - 1) * t)
+    return t
+
+
+def apply_cfg_branch(
+    pred: torch.Tensor,
+    do_cfg: bool,
+    apply_cfg_now: bool,
+    guidance_scale: float,
+    momentum_buffer: MomentumBuffer,
+) -> torch.Tensor:
+    """Reduce a ``(cond, null)``-packed prediction to a guided velocity.
+
+    ``do_cfg`` is the global gate (``guidance_scale > 1``).
+    ``apply_cfg_now`` is the per-step gate (timestep within
+    ``[cfg_interval_start, cfg_interval_end]``).  The momentum buffer is
+    *per trajectory* — flow-edit maintains separate buffers for src and
+    tar so APG's running average doesn't leak between branches.
+    """
+    if not do_cfg:
+        return pred
+    pred_cond, pred_null = pred.chunk(2)
+    if not apply_cfg_now:
+        return pred_cond
+    return apg_forward(
+        pred_cond=pred_cond,
+        pred_uncond=pred_null,
+        guidance_scale=guidance_scale,
+        momentum_buffer=momentum_buffer,
+        dims=[1],
+    )
+
+
+def apply_velocity_post(
+    vt: torch.Tensor,
+    xt: torch.Tensor,
+    prev_vt: Optional[torch.Tensor],
+    norm_threshold: float,
+    ema_factor: float,
+) -> torch.Tensor:
+    """Per-trajectory velocity-norm clamp and EMA smoothing.
+
+    Mirrors the inline post-processing in ``generate_audio`` so flow-edit
+    behaves identically to regular generation when retake/CFG are off.
+    """
+    if norm_threshold > 0.0:
+        vt_norm = torch.norm(vt, dim=(1, 2), keepdim=True)
+        xt_norm = torch.norm(xt, dim=(1, 2), keepdim=True) + 1e-10
+        scale = torch.clamp(norm_threshold * xt_norm / (vt_norm + 1e-10), max=1.0)
+        vt = vt * scale
+    if ema_factor > 0.0 and prev_vt is not None:
+        vt = (1.0 - ema_factor) * vt + ema_factor * prev_vt
+    return vt
+
+
+def draw_fwd_noise(
+    shape,
+    generator: Any,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Generator-aware ``randn`` for per-step forward-diffusion noise.
+
+    ``generator`` may be ``None`` (fully random), a single
+    ``torch.Generator``, or a list of per-sample generators (matches the
+    semantics of the model's ``prepare_noise`` so ``retake_seeds`` flow
+    through unchanged).
+    """
+    if generator is None:
+        return torch.randn(shape, device=device, dtype=dtype)
+    if isinstance(generator, list):
+        parts: List[torch.Tensor] = []
+        for g in generator:
+            if g is None:
+                parts.append(torch.randn((1, *shape[1:]), device=device, dtype=dtype))
+            else:
+                parts.append(
+                    torch.randn((1, *shape[1:]), generator=g, device=device, dtype=dtype)
+                )
+        return torch.cat(parts, dim=0)
+    return torch.randn(shape, generator=generator, device=device, dtype=dtype)
+
+
+def pack_for_cfg(
+    enc_hs: torch.Tensor,
+    enc_am: torch.Tensor,
+    ctx: torch.Tensor,
+    attn: torch.Tensor,
+    null_condition_emb: torch.Tensor,
+    do_cfg: bool,
+):
+    """Double encoder/context/attention tensors for CFG, or pass through.
+
+    Returns a 4-tuple ``(enc_hs, enc_am, ctx, attn)`` ready for one
+    ``decoder()`` call.  Source and target each call this independently
+    so their CFG packs stay separate.
+    """
+    if not do_cfg:
+        return enc_hs, enc_am, ctx, attn
+    null = null_condition_emb.expand_as(enc_hs)
+    return (
+        torch.cat([enc_hs, null], dim=0),
+        torch.cat([enc_am, enc_am], dim=0),
+        torch.cat([ctx, ctx], dim=0),
+        torch.cat([attn, attn], dim=0),
+    )

--- a/acestep/models/common/flow_edit_helpers_test.py
+++ b/acestep/models/common/flow_edit_helpers_test.py
@@ -7,10 +7,13 @@ import torch
 from acestep.models.common.apg_guidance import MomentumBuffer
 from acestep.models.common.flow_edit_helpers import (
     apply_cfg_branch,
-    apply_velocity_post,
+    apply_velocity_clamp,
+    apply_velocity_ema,
     build_timestep_schedule,
     draw_fwd_noise,
     pack_for_cfg,
+    restore_and_advance_momentum,
+    snapshot_momentum,
 )
 
 
@@ -73,38 +76,77 @@ class ApplyCfgBranchTests(unittest.TestCase):
         self.assertFalse(torch.equal(out, self.pred_cond))
 
 
-class ApplyVelocityPostTests(unittest.TestCase):
-    """Velocity-norm clamp + EMA must be no-op when both gates are zero."""
+class ApplyVelocityClampTests(unittest.TestCase):
+    """Velocity-norm clamp must be a no-op when threshold is 0."""
 
-    def test_no_clamp_no_ema_is_noop(self):
+    def test_threshold_zero_is_noop(self):
         torch.manual_seed(0)
         vt = torch.randn(2, 4, 8)
         xt = torch.randn(2, 4, 8)
-        out = apply_velocity_post(vt, xt, None, norm_threshold=0.0, ema_factor=0.0)
-        self.assertTrue(torch.equal(out, vt))
+        self.assertTrue(torch.equal(apply_velocity_clamp(vt, xt, 0.0), vt))
 
     def test_clamp_reduces_outlier_norms(self):
         vt = torch.full((1, 4, 8), 100.0)
         xt = torch.full((1, 4, 8), 1.0)
-        out = apply_velocity_post(vt, xt, None, norm_threshold=2.0, ema_factor=0.0)
-        # Output norm should be near 2*||xt|| (the clamp target).
+        out = apply_velocity_clamp(vt, xt, 2.0)
         out_norm = torch.norm(out, dim=(1, 2)).item()
         xt_norm = torch.norm(xt, dim=(1, 2)).item()
         self.assertAlmostEqual(out_norm, 2.0 * xt_norm, places=2)
 
+
+class ApplyVelocityEmaTests(unittest.TestCase):
+    """EMA smoothing: per-timestep blend, not per-MC-draw (regression for codex P2)."""
+
     def test_ema_no_prev_returns_vt(self):
-        torch.manual_seed(1)
         vt = torch.randn(1, 4, 8)
-        out = apply_velocity_post(vt, vt, None, norm_threshold=0.0, ema_factor=0.5)
-        self.assertTrue(torch.equal(out, vt))
+        self.assertTrue(torch.equal(apply_velocity_ema(vt, None, 0.5), vt))
+
+    def test_ema_zero_factor_returns_vt(self):
+        vt = torch.randn(1, 4, 8)
+        prev = torch.randn(1, 4, 8)
+        self.assertTrue(torch.equal(apply_velocity_ema(vt, prev, 0.0), vt))
 
     def test_ema_with_prev_blends(self):
-        torch.manual_seed(2)
         vt = torch.ones(1, 4, 8)
         prev = torch.zeros(1, 4, 8)
-        out = apply_velocity_post(vt, vt, prev, norm_threshold=0.0, ema_factor=0.3)
+        out = apply_velocity_ema(vt, prev, 0.3)
         # 0.7*1 + 0.3*0 = 0.7
         self.assertTrue(torch.allclose(out, torch.full_like(vt, 0.7)))
+
+
+class MomentumSnapshotTests(unittest.TestCase):
+    """Snapshot/restore must isolate APG momentum across MC draws."""
+
+    def test_snapshot_then_advance_matches_single_update(self):
+        """One pre-step snapshot + one final update == one direct update."""
+        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
+        buf_a.update(torch.tensor([1.0, 2.0]))
+        # Snapshot AFTER the prev-step state.
+        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
+        # Simulate inner loop "polluting" buf_a with a diff that should NOT
+        # carry forward — we restore-and-advance with avg_diff outside.
+        buf_a.update(torch.tensor([99.0, 99.0]))
+        # Reference: apply only the avg_diff once from the snapshot.
+        ref = MomentumBuffer()
+        ref.update(torch.tensor([1.0, 2.0]))
+        ref.update(torch.tensor([3.0, 4.0]))
+        # Restore and advance once with the avg.
+        restore_and_advance_momentum(
+            buf_a, buf_b, snap_a, snap_b,
+            avg_diff_src=torch.tensor([3.0, 4.0]),
+            avg_diff_tar=torch.tensor([5.0, 6.0]),
+        )
+        self.assertTrue(torch.equal(buf_a.running_average, ref.running_average))
+
+    def test_no_cfg_diff_just_rolls_back(self):
+        """When CFG is inactive (avg_diff is None) the buffer rolls back."""
+        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
+        buf_a.update(torch.tensor([1.0]))
+        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
+        # Simulate pollution.
+        buf_a.update(torch.tensor([42.0]))
+        restore_and_advance_momentum(buf_a, buf_b, snap_a, snap_b, None, None)
+        self.assertTrue(torch.equal(buf_a.running_average, snap_a))
 
 
 class DrawFwdNoiseTests(unittest.TestCase):

--- a/acestep/models/common/flow_edit_helpers_test.py
+++ b/acestep/models/common/flow_edit_helpers_test.py
@@ -1,4 +1,9 @@
-"""Unit tests for ``flow_edit_helpers`` primitives (#1156)."""
+"""Schedule, CFG, packing, and noise unit tests for ``flow_edit_helpers``.
+
+Velocity / momentum helpers live in
+``flow_edit_helpers_velocity_test.py`` (split per the AGENTS.md
+200 LOC module cap).
+"""
 
 import unittest
 
@@ -7,13 +12,9 @@ import torch
 from acestep.models.common.apg_guidance import MomentumBuffer
 from acestep.models.common.flow_edit_helpers import (
     apply_cfg_branch,
-    apply_velocity_clamp,
-    apply_velocity_ema,
     build_timestep_schedule,
     draw_fwd_noise,
     pack_for_cfg,
-    restore_and_advance_momentum,
-    snapshot_momentum,
 )
 
 
@@ -25,7 +26,6 @@ class BuildTimestepScheduleTests(unittest.TestCase):
         self.assertEqual(t.shape, (9,))
         self.assertAlmostEqual(t[0].item(), 1.0)
         self.assertAlmostEqual(t[-1].item(), 0.0)
-        # Even spacing for shift=1
         diffs = (t[:-1] - t[1:]).tolist()
         self.assertTrue(all(abs(d - diffs[0]) < 1e-6 for d in diffs))
 
@@ -59,94 +59,21 @@ class ApplyCfgBranchTests(unittest.TestCase):
 
     def test_no_cfg_passes_through_unchanged(self):
         out = apply_cfg_branch(self.pred_cond, do_cfg=False, apply_cfg_now=True,
-                                guidance_scale=7.0, momentum_buffer=MomentumBuffer())
+                               guidance_scale=7.0, momentum_buffer=MomentumBuffer())
         self.assertTrue(torch.equal(out, self.pred_cond))
 
     def test_cfg_outside_interval_returns_cond_chunk(self):
         out = apply_cfg_branch(self.pred_packed, do_cfg=True, apply_cfg_now=False,
-                                guidance_scale=7.0, momentum_buffer=MomentumBuffer())
+                               guidance_scale=7.0, momentum_buffer=MomentumBuffer())
         self.assertTrue(torch.equal(out, self.pred_cond))
 
     def test_cfg_inside_interval_uses_apg(self):
         buf = MomentumBuffer()
         out = apply_cfg_branch(self.pred_packed, do_cfg=True, apply_cfg_now=True,
-                                guidance_scale=7.0, momentum_buffer=buf)
+                               guidance_scale=7.0, momentum_buffer=buf)
         # APG amplifies the orthogonal component, so the result must differ
         # from a no-op pass-through of the cond chunk.
         self.assertFalse(torch.equal(out, self.pred_cond))
-
-
-class ApplyVelocityClampTests(unittest.TestCase):
-    """Velocity-norm clamp must be a no-op when threshold is 0."""
-
-    def test_threshold_zero_is_noop(self):
-        torch.manual_seed(0)
-        vt = torch.randn(2, 4, 8)
-        xt = torch.randn(2, 4, 8)
-        self.assertTrue(torch.equal(apply_velocity_clamp(vt, xt, 0.0), vt))
-
-    def test_clamp_reduces_outlier_norms(self):
-        vt = torch.full((1, 4, 8), 100.0)
-        xt = torch.full((1, 4, 8), 1.0)
-        out = apply_velocity_clamp(vt, xt, 2.0)
-        out_norm = torch.norm(out, dim=(1, 2)).item()
-        xt_norm = torch.norm(xt, dim=(1, 2)).item()
-        self.assertAlmostEqual(out_norm, 2.0 * xt_norm, places=2)
-
-
-class ApplyVelocityEmaTests(unittest.TestCase):
-    """EMA smoothing: per-timestep blend, not per-MC-draw (regression for codex P2)."""
-
-    def test_ema_no_prev_returns_vt(self):
-        vt = torch.randn(1, 4, 8)
-        self.assertTrue(torch.equal(apply_velocity_ema(vt, None, 0.5), vt))
-
-    def test_ema_zero_factor_returns_vt(self):
-        vt = torch.randn(1, 4, 8)
-        prev = torch.randn(1, 4, 8)
-        self.assertTrue(torch.equal(apply_velocity_ema(vt, prev, 0.0), vt))
-
-    def test_ema_with_prev_blends(self):
-        vt = torch.ones(1, 4, 8)
-        prev = torch.zeros(1, 4, 8)
-        out = apply_velocity_ema(vt, prev, 0.3)
-        # 0.7*1 + 0.3*0 = 0.7
-        self.assertTrue(torch.allclose(out, torch.full_like(vt, 0.7)))
-
-
-class MomentumSnapshotTests(unittest.TestCase):
-    """Snapshot/restore must isolate APG momentum across MC draws."""
-
-    def test_snapshot_then_advance_matches_single_update(self):
-        """One pre-step snapshot + one final update == one direct update."""
-        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
-        buf_a.update(torch.tensor([1.0, 2.0]))
-        # Snapshot AFTER the prev-step state.
-        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
-        # Simulate inner loop "polluting" buf_a with a diff that should NOT
-        # carry forward — we restore-and-advance with avg_diff outside.
-        buf_a.update(torch.tensor([99.0, 99.0]))
-        # Reference: apply only the avg_diff once from the snapshot.
-        ref = MomentumBuffer()
-        ref.update(torch.tensor([1.0, 2.0]))
-        ref.update(torch.tensor([3.0, 4.0]))
-        # Restore and advance once with the avg.
-        restore_and_advance_momentum(
-            buf_a, buf_b, snap_a, snap_b,
-            avg_diff_src=torch.tensor([3.0, 4.0]),
-            avg_diff_tar=torch.tensor([5.0, 6.0]),
-        )
-        self.assertTrue(torch.equal(buf_a.running_average, ref.running_average))
-
-    def test_no_cfg_diff_just_rolls_back(self):
-        """When CFG is inactive (avg_diff is None) the buffer rolls back."""
-        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
-        buf_a.update(torch.tensor([1.0]))
-        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
-        # Simulate pollution.
-        buf_a.update(torch.tensor([42.0]))
-        restore_and_advance_momentum(buf_a, buf_b, snap_a, snap_b, None, None)
-        self.assertTrue(torch.equal(buf_a.running_average, snap_a))
 
 
 class DrawFwdNoiseTests(unittest.TestCase):
@@ -158,7 +85,7 @@ class DrawFwdNoiseTests(unittest.TestCase):
         a = draw_fwd_noise(self.SHAPE, None, torch.device("cpu"), torch.float32)
         b = draw_fwd_noise(self.SHAPE, None, torch.device("cpu"), torch.float32)
         self.assertEqual(a.shape, self.SHAPE)
-        self.assertFalse(torch.equal(a, b))  # different draws
+        self.assertFalse(torch.equal(a, b))
 
     def test_single_generator_reproducible(self):
         g1 = torch.Generator().manual_seed(42)
@@ -171,7 +98,6 @@ class DrawFwdNoiseTests(unittest.TestCase):
         gens = [torch.Generator().manual_seed(i) for i in (1, 2, 3)]
         out = draw_fwd_noise(self.SHAPE, gens, torch.device("cpu"), torch.float32)
         self.assertEqual(out.shape, self.SHAPE)
-        # Each sample should differ (different seeds).
         self.assertFalse(torch.equal(out[0], out[1]))
         self.assertFalse(torch.equal(out[1], out[2]))
 
@@ -196,12 +122,10 @@ class PackForCfgTests(unittest.TestCase):
 
     def test_cfg_doubles_batch_and_uses_null(self):
         out = pack_for_cfg(self.enc_hs, self.enc_am, self.ctx, self.attn, self.null, do_cfg=True)
-        # Batch dim doubled
         self.assertEqual(out[0].shape[0], 4)
         self.assertEqual(out[1].shape[0], 4)
         self.assertEqual(out[2].shape[0], 4)
         self.assertEqual(out[3].shape[0], 4)
-        # First half = original, second half = null-broadcast
         self.assertTrue(torch.equal(out[0][:2], self.enc_hs))
         self.assertTrue(torch.equal(out[0][2:], self.null.expand_as(self.enc_hs)))
 

--- a/acestep/models/common/flow_edit_helpers_test.py
+++ b/acestep/models/common/flow_edit_helpers_test.py
@@ -1,0 +1,168 @@
+"""Unit tests for ``flow_edit_helpers`` primitives (#1156)."""
+
+import unittest
+
+import torch
+
+from acestep.models.common.apg_guidance import MomentumBuffer
+from acestep.models.common.flow_edit_helpers import (
+    apply_cfg_branch,
+    apply_velocity_post,
+    build_timestep_schedule,
+    draw_fwd_noise,
+    pack_for_cfg,
+)
+
+
+class BuildTimestepScheduleTests(unittest.TestCase):
+    """Pin schedule construction — must match the base-variant inline logic."""
+
+    def test_linspace_default_no_shift(self):
+        t = build_timestep_schedule(8, 1.0, None, torch.device("cpu"), torch.float32)
+        self.assertEqual(t.shape, (9,))
+        self.assertAlmostEqual(t[0].item(), 1.0)
+        self.assertAlmostEqual(t[-1].item(), 0.0)
+        # Even spacing for shift=1
+        diffs = (t[:-1] - t[1:]).tolist()
+        self.assertTrue(all(abs(d - diffs[0]) < 1e-6 for d in diffs))
+
+    def test_shift_transform_monotonic_decreasing(self):
+        t = build_timestep_schedule(8, 3.0, None, torch.device("cpu"), torch.float32)
+        for i in range(len(t) - 1):
+            self.assertGreater(t[i].item(), t[i + 1].item() - 1e-6)
+        self.assertAlmostEqual(t[0].item(), 1.0)
+        self.assertAlmostEqual(t[-1].item(), 0.0)
+
+    def test_user_timesteps_passed_through(self):
+        custom = torch.tensor([1.0, 0.7, 0.3, 0.0])
+        t = build_timestep_schedule(0, 1.0, custom, torch.device("cpu"), torch.float32)
+        self.assertTrue(torch.allclose(t, custom))
+
+    def test_user_timesteps_padded_to_zero(self):
+        custom = torch.tensor([0.97, 0.5, 0.1])
+        t = build_timestep_schedule(0, 1.0, custom, torch.device("cpu"), torch.float32)
+        self.assertEqual(t.shape, (4,))
+        self.assertAlmostEqual(t[-1].item(), 0.0)
+
+
+class ApplyCfgBranchTests(unittest.TestCase):
+    """Verify CFG dispatch matches the inline base-variant logic."""
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.pred_cond = torch.randn(2, 4, 8)
+        self.pred_null = torch.randn(2, 4, 8)
+        self.pred_packed = torch.cat([self.pred_cond, self.pred_null], dim=0)
+
+    def test_no_cfg_passes_through_unchanged(self):
+        out = apply_cfg_branch(self.pred_cond, do_cfg=False, apply_cfg_now=True,
+                                guidance_scale=7.0, momentum_buffer=MomentumBuffer())
+        self.assertTrue(torch.equal(out, self.pred_cond))
+
+    def test_cfg_outside_interval_returns_cond_chunk(self):
+        out = apply_cfg_branch(self.pred_packed, do_cfg=True, apply_cfg_now=False,
+                                guidance_scale=7.0, momentum_buffer=MomentumBuffer())
+        self.assertTrue(torch.equal(out, self.pred_cond))
+
+    def test_cfg_inside_interval_uses_apg(self):
+        buf = MomentumBuffer()
+        out = apply_cfg_branch(self.pred_packed, do_cfg=True, apply_cfg_now=True,
+                                guidance_scale=7.0, momentum_buffer=buf)
+        # APG amplifies the orthogonal component, so the result must differ
+        # from a no-op pass-through of the cond chunk.
+        self.assertFalse(torch.equal(out, self.pred_cond))
+
+
+class ApplyVelocityPostTests(unittest.TestCase):
+    """Velocity-norm clamp + EMA must be no-op when both gates are zero."""
+
+    def test_no_clamp_no_ema_is_noop(self):
+        torch.manual_seed(0)
+        vt = torch.randn(2, 4, 8)
+        xt = torch.randn(2, 4, 8)
+        out = apply_velocity_post(vt, xt, None, norm_threshold=0.0, ema_factor=0.0)
+        self.assertTrue(torch.equal(out, vt))
+
+    def test_clamp_reduces_outlier_norms(self):
+        vt = torch.full((1, 4, 8), 100.0)
+        xt = torch.full((1, 4, 8), 1.0)
+        out = apply_velocity_post(vt, xt, None, norm_threshold=2.0, ema_factor=0.0)
+        # Output norm should be near 2*||xt|| (the clamp target).
+        out_norm = torch.norm(out, dim=(1, 2)).item()
+        xt_norm = torch.norm(xt, dim=(1, 2)).item()
+        self.assertAlmostEqual(out_norm, 2.0 * xt_norm, places=2)
+
+    def test_ema_no_prev_returns_vt(self):
+        torch.manual_seed(1)
+        vt = torch.randn(1, 4, 8)
+        out = apply_velocity_post(vt, vt, None, norm_threshold=0.0, ema_factor=0.5)
+        self.assertTrue(torch.equal(out, vt))
+
+    def test_ema_with_prev_blends(self):
+        torch.manual_seed(2)
+        vt = torch.ones(1, 4, 8)
+        prev = torch.zeros(1, 4, 8)
+        out = apply_velocity_post(vt, vt, prev, norm_threshold=0.0, ema_factor=0.3)
+        # 0.7*1 + 0.3*0 = 0.7
+        self.assertTrue(torch.allclose(out, torch.full_like(vt, 0.7)))
+
+
+class DrawFwdNoiseTests(unittest.TestCase):
+    """Generator-aware noise draw must respect both single and per-sample seeds."""
+
+    SHAPE = (3, 4, 8)
+
+    def test_no_generator_returns_random(self):
+        a = draw_fwd_noise(self.SHAPE, None, torch.device("cpu"), torch.float32)
+        b = draw_fwd_noise(self.SHAPE, None, torch.device("cpu"), torch.float32)
+        self.assertEqual(a.shape, self.SHAPE)
+        self.assertFalse(torch.equal(a, b))  # different draws
+
+    def test_single_generator_reproducible(self):
+        g1 = torch.Generator().manual_seed(42)
+        g2 = torch.Generator().manual_seed(42)
+        a = draw_fwd_noise(self.SHAPE, g1, torch.device("cpu"), torch.float32)
+        b = draw_fwd_noise(self.SHAPE, g2, torch.device("cpu"), torch.float32)
+        self.assertTrue(torch.equal(a, b))
+
+    def test_per_sample_generator_list(self):
+        gens = [torch.Generator().manual_seed(i) for i in (1, 2, 3)]
+        out = draw_fwd_noise(self.SHAPE, gens, torch.device("cpu"), torch.float32)
+        self.assertEqual(out.shape, self.SHAPE)
+        # Each sample should differ (different seeds).
+        self.assertFalse(torch.equal(out[0], out[1]))
+        self.assertFalse(torch.equal(out[1], out[2]))
+
+
+class PackForCfgTests(unittest.TestCase):
+    """CFG packing must double tensors and inject the null embedding."""
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.enc_hs = torch.randn(2, 16, 32)
+        self.enc_am = torch.ones(2, 16)
+        self.ctx = torch.randn(2, 24, 64)
+        self.attn = torch.ones(2, 24)
+        self.null = torch.randn(1, 1, 32)
+
+    def test_no_cfg_passes_through(self):
+        out = pack_for_cfg(self.enc_hs, self.enc_am, self.ctx, self.attn, self.null, do_cfg=False)
+        self.assertTrue(torch.equal(out[0], self.enc_hs))
+        self.assertTrue(torch.equal(out[1], self.enc_am))
+        self.assertTrue(torch.equal(out[2], self.ctx))
+        self.assertTrue(torch.equal(out[3], self.attn))
+
+    def test_cfg_doubles_batch_and_uses_null(self):
+        out = pack_for_cfg(self.enc_hs, self.enc_am, self.ctx, self.attn, self.null, do_cfg=True)
+        # Batch dim doubled
+        self.assertEqual(out[0].shape[0], 4)
+        self.assertEqual(out[1].shape[0], 4)
+        self.assertEqual(out[2].shape[0], 4)
+        self.assertEqual(out[3].shape[0], 4)
+        # First half = original, second half = null-broadcast
+        self.assertTrue(torch.equal(out[0][:2], self.enc_hs))
+        self.assertTrue(torch.equal(out[0][2:], self.null.expand_as(self.enc_hs)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/models/common/flow_edit_helpers_velocity_test.py
+++ b/acestep/models/common/flow_edit_helpers_velocity_test.py
@@ -1,0 +1,90 @@
+"""Velocity-clamp / EMA / APG-momentum unit tests for ``flow_edit_helpers``.
+
+Schedule / CFG / packing / noise tests live in
+``flow_edit_helpers_test.py`` (split per the AGENTS.md 200 LOC cap).
+"""
+
+import unittest
+
+import torch
+
+from acestep.models.common.apg_guidance import MomentumBuffer
+from acestep.models.common.flow_edit_helpers import (
+    apply_velocity_clamp,
+    apply_velocity_ema,
+    restore_and_advance_momentum,
+    snapshot_momentum,
+)
+
+
+class ApplyVelocityClampTests(unittest.TestCase):
+    """Velocity-norm clamp must be a no-op when threshold is 0."""
+
+    def test_threshold_zero_is_noop(self):
+        torch.manual_seed(0)
+        vt = torch.randn(2, 4, 8)
+        xt = torch.randn(2, 4, 8)
+        self.assertTrue(torch.equal(apply_velocity_clamp(vt, xt, 0.0), vt))
+
+    def test_clamp_reduces_outlier_norms(self):
+        vt = torch.full((1, 4, 8), 100.0)
+        xt = torch.full((1, 4, 8), 1.0)
+        out = apply_velocity_clamp(vt, xt, 2.0)
+        out_norm = torch.norm(out, dim=(1, 2)).item()
+        xt_norm = torch.norm(xt, dim=(1, 2)).item()
+        self.assertAlmostEqual(out_norm, 2.0 * xt_norm, places=2)
+
+
+class ApplyVelocityEmaTests(unittest.TestCase):
+    """EMA smoothing: per-timestep blend, not per-MC-draw (regression for codex P2)."""
+
+    def test_ema_no_prev_returns_vt(self):
+        vt = torch.randn(1, 4, 8)
+        self.assertTrue(torch.equal(apply_velocity_ema(vt, None, 0.5), vt))
+
+    def test_ema_zero_factor_returns_vt(self):
+        vt = torch.randn(1, 4, 8)
+        prev = torch.randn(1, 4, 8)
+        self.assertTrue(torch.equal(apply_velocity_ema(vt, prev, 0.0), vt))
+
+    def test_ema_with_prev_blends(self):
+        vt = torch.ones(1, 4, 8)
+        prev = torch.zeros(1, 4, 8)
+        out = apply_velocity_ema(vt, prev, 0.3)
+        # 0.7*1 + 0.3*0 = 0.7
+        self.assertTrue(torch.allclose(out, torch.full_like(vt, 0.7)))
+
+
+class MomentumSnapshotTests(unittest.TestCase):
+    """Snapshot/restore must isolate APG momentum across MC draws."""
+
+    def test_snapshot_then_advance_matches_single_update(self):
+        """One pre-step snapshot + one final update == one direct update."""
+        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
+        buf_a.update(torch.tensor([1.0, 2.0]))
+        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
+        # Simulate inner loop "polluting" buf_a with a diff that should NOT
+        # carry forward — we restore-and-advance with avg_diff outside.
+        buf_a.update(torch.tensor([99.0, 99.0]))
+        ref = MomentumBuffer()
+        ref.update(torch.tensor([1.0, 2.0]))
+        ref.update(torch.tensor([3.0, 4.0]))
+        restore_and_advance_momentum(
+            buf_a, buf_b, snap_a, snap_b,
+            avg_diff_src=torch.tensor([3.0, 4.0]),
+            avg_diff_tar=torch.tensor([5.0, 6.0]),
+        )
+        self.assertTrue(torch.equal(buf_a.running_average, ref.running_average))
+
+    def test_no_cfg_diff_just_rolls_back(self):
+        """When CFG is inactive (avg_diff is None) the buffer rolls back."""
+        buf_a, buf_b = MomentumBuffer(), MomentumBuffer()
+        buf_a.update(torch.tensor([1.0]))
+        snap_a, snap_b = snapshot_momentum(buf_a, buf_b)
+        buf_a.update(torch.tensor([42.0]))
+        restore_and_advance_momentum(buf_a, buf_b, snap_a, snap_b, None, None)
+        self.assertTrue(torch.equal(buf_a.running_average, snap_a))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/models/common/flow_edit_pipeline.py
+++ b/acestep/models/common/flow_edit_pipeline.py
@@ -109,6 +109,10 @@ def flowedit_generate_audio(
     edit_n_min: float = 0.0,
     edit_n_max: float = 1.0,
     edit_n_avg: int = 1,
+    # Conditioning hints (forwarded to both prepare_condition calls — they
+    # describe the *source audio*, which is shared across src and tar).
+    precomputed_lm_hints_25Hz: Optional[torch.Tensor] = None,
+    audio_codes: Optional[torch.Tensor] = None,
     # Accepted-but-disabled v1 sampler tricks (logged + bypassed)
     sampler_mode: str = "euler",
     use_adg: bool = False,
@@ -142,6 +146,8 @@ def flowedit_generate_audio(
         src_latents=src_latents,
         chunk_masks=chunk_masks,
         is_covers=is_covers,
+        precomputed_lm_hints_25Hz=precomputed_lm_hints_25Hz,
+        audio_codes=audio_codes,
     )
     tar_enc_hs, tar_enc_am, tar_ctx = model.prepare_condition(
         text_hidden_states=target_text_hidden_states,
@@ -156,6 +162,8 @@ def flowedit_generate_audio(
         src_latents=src_latents,
         chunk_masks=chunk_masks,
         is_covers=is_covers,
+        precomputed_lm_hints_25Hz=precomputed_lm_hints_25Hz,
+        audio_codes=audio_codes,
     )
 
     # Forward-noise generators: prefer retake_seed (independent draws), else

--- a/acestep/models/common/flow_edit_pipeline.py
+++ b/acestep/models/common/flow_edit_pipeline.py
@@ -1,0 +1,192 @@
+"""High-level flow-edit entrypoint shared by 4 base DiT variants (#1156).
+
+Each variant exposes a thin ``flowedit_generate_audio`` method that
+delegates here.  This module wraps :func:`flow_edit.flowedit_sampling_loop`
+with model-side glue: it builds source and target conditions via
+``model.prepare_condition`` and threads through the v1 sampler-trick
+exclusions (DCW / heun / ADG → forced off with one log line).
+
+Kept separate from ``flow_edit.py`` to honour the 200 LOC module cap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from loguru import logger
+
+from .flow_edit import flowedit_sampling_loop
+
+
+def _seed_to_generators(
+    seed: Optional[Union[int, List[Optional[int]]]],
+    batch_size: int,
+    device: torch.device,
+) -> Optional[Union[torch.Generator, List[Optional[torch.Generator]]]]:
+    """Convert seed input to ``torch.Generator``(s) for ``draw_fwd_noise``.
+
+    Mirrors ``prepare_noise`` semantics: ``None`` → unseeded; ``int`` →
+    one generator; ``list[int|None]`` → per-sample generators (with
+    ``None``/negative entries left unseeded).
+    """
+    if seed is None:
+        return None
+    if isinstance(seed, list):
+        gens: List[Optional[torch.Generator]] = []
+        for s in seed:
+            if s is None or (isinstance(s, int) and s < 0):
+                gens.append(None)
+            else:
+                gens.append(torch.Generator(device=device).manual_seed(int(s)))
+        # Pad / truncate to batch_size.
+        if len(gens) < batch_size:
+            gens = gens + [None] * (batch_size - len(gens))
+        return gens[:batch_size]
+    return torch.Generator(device=device).manual_seed(int(seed))
+
+
+def _warn_about_disabled_v1_tricks(
+    sampler_mode: str,
+    use_adg: bool,
+    dcw_enabled: bool,
+) -> None:
+    """One info log if user-supplied sampler tricks are silently bypassed.
+
+    DCW / heun / ADG are deferred to follow-up PRs (each needs paired-
+    forward derivation).  v1 forces them off; this surface lets the user
+    see why their UI knobs didn't take effect.
+    """
+    disabled = []
+    if sampler_mode == "heun":
+        disabled.append("sampler_mode=heun")
+    if use_adg:
+        disabled.append("use_adg=True")
+    if dcw_enabled:
+        disabled.append("dcw_enabled=True")
+    if disabled:
+        logger.info(
+            "[flowedit] task_type='edit' v1 ignores {}; forcing euler + plain "
+            "CFG/APG.  See issue #1156 for the per-feature follow-up plan.",
+            ", ".join(disabled),
+        )
+
+
+@torch.no_grad()
+def flowedit_generate_audio(
+    model,
+    *,
+    # Source condition raw inputs
+    text_hidden_states: torch.Tensor,
+    text_attention_mask: torch.Tensor,
+    lyric_hidden_states: torch.Tensor,
+    lyric_attention_mask: torch.Tensor,
+    refer_audio_acoustic_hidden_states_packed: torch.Tensor,
+    refer_audio_order_mask: torch.Tensor,
+    src_latents: torch.Tensor,
+    chunk_masks: torch.Tensor,
+    is_covers: torch.Tensor,
+    silence_latent: torch.Tensor,
+    # Target condition raw inputs (separate prompt/lyrics)
+    target_text_hidden_states: torch.Tensor,
+    target_text_attention_mask: torch.Tensor,
+    target_lyric_hidden_states: torch.Tensor,
+    target_lyric_attention_mask: torch.Tensor,
+    # Sampling
+    attention_mask: Optional[torch.Tensor] = None,
+    seed: Optional[Union[int, List[int]]] = None,
+    retake_seed: Optional[Union[int, List[int]]] = None,
+    infer_steps: int = 60,
+    timesteps: Optional[torch.Tensor] = None,
+    diffusion_guidance_scale: float = 15.0,
+    cfg_interval_start: float = 0.0,
+    cfg_interval_end: float = 1.0,
+    shift: float = 1.0,
+    velocity_norm_threshold: float = 0.0,
+    velocity_ema_factor: float = 0.0,
+    use_progress_bar: bool = True,
+    # Flow-edit window
+    edit_n_min: float = 0.0,
+    edit_n_max: float = 1.0,
+    edit_n_avg: int = 1,
+    # Accepted-but-disabled v1 sampler tricks (logged + bypassed)
+    sampler_mode: str = "euler",
+    use_adg: bool = False,
+    dcw_enabled: bool = False,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Flow-edit entrypoint: prepare paired conditions and run the loop.
+
+    Returns ``{"target_latents": zt_edit, "time_costs": {...}}``.
+    """
+    _ = kwargs  # tolerate forwarded but unused kwargs (e.g. dcw_*)
+    _warn_about_disabled_v1_tricks(sampler_mode, use_adg, dcw_enabled)
+
+    if attention_mask is None:
+        latent_length = src_latents.shape[1]
+        attention_mask = torch.ones(
+            src_latents.shape[0], latent_length,
+            device=src_latents.device, dtype=src_latents.dtype,
+        )
+
+    src_enc_hs, src_enc_am, src_ctx = model.prepare_condition(
+        text_hidden_states=text_hidden_states,
+        text_attention_mask=text_attention_mask,
+        lyric_hidden_states=lyric_hidden_states,
+        lyric_attention_mask=lyric_attention_mask,
+        refer_audio_acoustic_hidden_states_packed=refer_audio_acoustic_hidden_states_packed,
+        refer_audio_order_mask=refer_audio_order_mask,
+        hidden_states=src_latents,
+        attention_mask=attention_mask,
+        silence_latent=silence_latent,
+        src_latents=src_latents,
+        chunk_masks=chunk_masks,
+        is_covers=is_covers,
+    )
+    tar_enc_hs, tar_enc_am, tar_ctx = model.prepare_condition(
+        text_hidden_states=target_text_hidden_states,
+        text_attention_mask=target_text_attention_mask,
+        lyric_hidden_states=target_lyric_hidden_states,
+        lyric_attention_mask=target_lyric_attention_mask,
+        refer_audio_acoustic_hidden_states_packed=refer_audio_acoustic_hidden_states_packed,
+        refer_audio_order_mask=refer_audio_order_mask,
+        hidden_states=src_latents,
+        attention_mask=attention_mask,
+        silence_latent=silence_latent,
+        src_latents=src_latents,
+        chunk_masks=chunk_masks,
+        is_covers=is_covers,
+    )
+
+    # Forward-noise generators: prefer retake_seed (independent draws), else
+    # fall back to the main seed so a fixed (seed, n_min, n_max, n_avg) tuple
+    # is reproducible end-to-end.
+    bsz = src_latents.shape[0]
+    fwd_seed = retake_seed if retake_seed is not None else seed
+    retake_generators = _seed_to_generators(fwd_seed, bsz, src_latents.device)
+
+    return flowedit_sampling_loop(
+        model,
+        src_encoder_hidden_states=src_enc_hs,
+        src_encoder_attention_mask=src_enc_am,
+        src_context_latents=src_ctx,
+        tar_encoder_hidden_states=tar_enc_hs,
+        tar_encoder_attention_mask=tar_enc_am,
+        tar_context_latents=tar_ctx,
+        src_latents=src_latents,
+        attention_mask=attention_mask,
+        null_condition_emb=model.null_condition_emb,
+        retake_generators=retake_generators,
+        infer_steps=infer_steps,
+        timesteps=timesteps,
+        shift=shift,
+        diffusion_guidance_scale=diffusion_guidance_scale,
+        cfg_interval_start=cfg_interval_start,
+        cfg_interval_end=cfg_interval_end,
+        velocity_norm_threshold=velocity_norm_threshold,
+        velocity_ema_factor=velocity_ema_factor,
+        n_min=edit_n_min,
+        n_max=edit_n_max,
+        n_avg=edit_n_avg,
+        use_progress_bar=use_progress_bar,
+    )

--- a/acestep/models/common/flow_edit_pipeline_test.py
+++ b/acestep/models/common/flow_edit_pipeline_test.py
@@ -1,0 +1,87 @@
+"""Pipeline-level tests for ``flow_edit_pipeline.flowedit_generate_audio``.
+
+Covers the model-side glue: ``prepare_condition`` is invoked twice (once
+for src, once for tar) and conditioning hints
+(``precomputed_lm_hints_25Hz`` / ``audio_codes``) are forwarded to both.
+"""
+
+import unittest
+
+import torch
+
+from acestep.models.common.flow_edit_pipeline import flowedit_generate_audio
+from acestep.models.common._flow_edit_test_support import StubModel
+
+
+class _CapturingModel(StubModel):
+    """Stub model whose ``prepare_condition`` records the kwargs it saw."""
+
+    def __init__(self, channels: int = 16):
+        super().__init__(channels=channels)
+        self.captured_calls = []
+
+    def prepare_condition(self, **kwargs):
+        self.captured_calls.append(kwargs)
+        bsz = kwargs["src_latents"].shape[0]
+        seq = kwargs["src_latents"].shape[1]
+        return (
+            torch.randn(bsz, 4, self.channels),
+            torch.ones(bsz, 4),
+            torch.randn(bsz, seq, self.channels * 2),
+        )
+
+
+class FlowEditPipelineConditionForwardingTests(unittest.TestCase):
+
+    def test_lm_hints_and_audio_codes_forwarded_to_both_calls(self):
+        """Regression for codex P2 round-1 finding: hints must reach prepare_condition.
+
+        Pre-fix the pipeline ate ``precomputed_lm_hints_25Hz`` and
+        ``audio_codes`` via ``**kwargs``, so both calls fell back to
+        tokenising ``src_latents``.  This breaks cover/edit flows that
+        rely on those hints.
+        """
+        model = _CapturingModel()
+        bsz, seq, ch = 1, 8, model.channels
+        src = torch.randn(bsz, seq, ch)
+        text_hs = torch.randn(bsz, 4, ch)
+        text_am = torch.ones(bsz, 4)
+        lyric_hs = torch.randn(bsz, 4, ch)
+        lyric_am = torch.ones(bsz, 4)
+        refer = torch.zeros(0, 4, ch)
+        refer_om = torch.zeros(0, dtype=torch.long)
+        chunk_masks = torch.ones(bsz, seq, ch)
+        is_covers = torch.zeros(bsz, dtype=torch.long)
+        silence = torch.zeros(bsz, seq, ch)
+
+        sentinel_hints = torch.full((bsz, seq, ch), 0.42)
+        sentinel_codes = torch.tensor([[1, 2, 3]])
+
+        flowedit_generate_audio(
+            model,
+            text_hidden_states=text_hs, text_attention_mask=text_am,
+            lyric_hidden_states=lyric_hs, lyric_attention_mask=lyric_am,
+            refer_audio_acoustic_hidden_states_packed=refer,
+            refer_audio_order_mask=refer_om,
+            src_latents=src, chunk_masks=chunk_masks,
+            is_covers=is_covers, silence_latent=silence,
+            target_text_hidden_states=text_hs,
+            target_text_attention_mask=text_am,
+            target_lyric_hidden_states=lyric_hs,
+            target_lyric_attention_mask=lyric_am,
+            infer_steps=2,
+            diffusion_guidance_scale=1.0,
+            edit_n_min=0.0, edit_n_max=1.0, edit_n_avg=1,
+            use_progress_bar=False,
+            precomputed_lm_hints_25Hz=sentinel_hints,
+            audio_codes=sentinel_codes,
+        )
+
+        self.assertEqual(len(model.captured_calls), 2)
+        for call in model.captured_calls:
+            self.assertIs(call["precomputed_lm_hints_25Hz"], sentinel_hints)
+            self.assertIs(call["audio_codes"], sentinel_codes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/models/common/flow_edit_test.py
+++ b/acestep/models/common/flow_edit_test.py
@@ -190,6 +190,108 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
                 diffusion_guidance_scale=1.0,
             )
 
+    def test_ema_does_not_leak_inside_inner_loop(self):
+        """Regression for codex P2 round-1 finding.
+
+        Pre-fix the loop updated ``prev_vt_*`` after every n_avg draw, so
+        later draws got EMA-smoothed against earlier draws of the same
+        step.  Post-fix the EMA carry-over is updated *once* per step
+        from the averaged velocity, so n_avg results stay independent of
+        draw order.  This test exercises the path with non-zero EMA and
+        n_avg=4 and pins reproducibility.
+        """
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+
+        def _run():
+            return flowedit_sampling_loop(
+                model,
+                src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+                src_context_latents=ctx_a,
+                tar_encoder_hidden_states=enc_hs_b, tar_encoder_attention_mask=enc_am_b,
+                tar_context_latents=ctx_b,
+                src_latents=src, attention_mask=attn,
+                null_condition_emb=model.null_condition_emb,
+                retake_generators=torch.Generator().manual_seed(99),
+                infer_steps=4,
+                diffusion_guidance_scale=1.0,
+                velocity_ema_factor=0.3,
+                n_min=0.0, n_max=1.0, n_avg=4,
+                use_progress_bar=False,
+            )["target_latents"]
+
+        # Two runs with identical seeds must match bit-for-bit; this would
+        # have been flaky if prev_vt mutated mid-loop.
+        self.assertTrue(torch.equal(_run(), _run()))
+
+
+class _CapturingModel(_StubModel):
+    """Stub model whose ``prepare_condition`` records the kwargs it saw."""
+
+    def __init__(self, channels=16):
+        super().__init__(channels=channels)
+        self.captured_calls = []
+
+    def prepare_condition(self, **kwargs):
+        self.captured_calls.append(kwargs)
+        bsz = kwargs["src_latents"].shape[0]
+        seq = kwargs["src_latents"].shape[1]
+        # Match the real method's return signature (enc_hs, enc_am, ctx).
+        return (
+            torch.randn(bsz, 4, self.channels),
+            torch.ones(bsz, 4),
+            torch.randn(bsz, seq, self.channels * 2),
+        )
+
+
+class FlowEditPipelineConditionForwardingTests(unittest.TestCase):
+
+    def test_lm_hints_and_audio_codes_forwarded_to_both_calls(self):
+        """Regression for codex P2 round-1 finding: hints must reach prepare_condition."""
+        from acestep.models.common.flow_edit_pipeline import flowedit_generate_audio
+
+        model = _CapturingModel()
+        bsz, seq, ch = 1, 8, model.channels
+        src = torch.randn(bsz, seq, ch)
+        text_hs = torch.randn(bsz, 4, ch)
+        text_am = torch.ones(bsz, 4)
+        lyric_hs = torch.randn(bsz, 4, ch)
+        lyric_am = torch.ones(bsz, 4)
+        refer = torch.zeros(0, 4, ch)
+        refer_om = torch.zeros(0, dtype=torch.long)
+        chunk_masks = torch.ones(bsz, seq, ch)
+        is_covers = torch.zeros(bsz, dtype=torch.long)
+        silence = torch.zeros(bsz, seq, ch)
+
+        sentinel_hints = torch.full((bsz, seq, ch), 0.42)
+        sentinel_codes = torch.tensor([[1, 2, 3]])
+
+        flowedit_generate_audio(
+            model,
+            text_hidden_states=text_hs, text_attention_mask=text_am,
+            lyric_hidden_states=lyric_hs, lyric_attention_mask=lyric_am,
+            refer_audio_acoustic_hidden_states_packed=refer,
+            refer_audio_order_mask=refer_om,
+            src_latents=src, chunk_masks=chunk_masks,
+            is_covers=is_covers, silence_latent=silence,
+            target_text_hidden_states=text_hs,
+            target_text_attention_mask=text_am,
+            target_lyric_hidden_states=lyric_hs,
+            target_lyric_attention_mask=lyric_am,
+            infer_steps=2,
+            diffusion_guidance_scale=1.0,
+            edit_n_min=0.0, edit_n_max=1.0, edit_n_avg=1,
+            use_progress_bar=False,
+            precomputed_lm_hints_25Hz=sentinel_hints,
+            audio_codes=sentinel_codes,
+        )
+
+        self.assertEqual(len(model.captured_calls), 2)  # one for src, one for tar
+        for call in model.captured_calls:
+            self.assertIs(call["precomputed_lm_hints_25Hz"], sentinel_hints)
+            self.assertIs(call["audio_codes"], sentinel_codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/acestep/models/common/flow_edit_test.py
+++ b/acestep/models/common/flow_edit_test.py
@@ -190,6 +190,55 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
                 diffusion_guidance_scale=1.0,
             )
 
+    def test_apg_momentum_does_not_advance_per_draw(self):
+        """Regression for codex P2 round-2 finding.
+
+        Pre-fix the inner ``n_avg`` loop called ``apg_forward`` n_avg
+        times per step, advancing APG's running average n_avg times per
+        scheduler step.  Post-fix the buffer is snapshot-and-restored
+        around each draw, then advanced *once* with the averaged diff
+        outside the loop.  This test pins that behaviour by asserting
+        the loop with ``n_avg=1`` and ``n_avg=4`` give the same APG
+        state after one step (since both should advance momentum once
+        per step, just averaged).
+
+        We exercise CFG (``guidance_scale > 1``) so APG actually runs.
+        """
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+
+        def _run(n_avg):
+            return flowedit_sampling_loop(
+                model,
+                src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+                src_context_latents=ctx_a,
+                tar_encoder_hidden_states=enc_hs_b, tar_encoder_attention_mask=enc_am_b,
+                tar_context_latents=ctx_b,
+                src_latents=src, attention_mask=attn,
+                null_condition_emb=model.null_condition_emb,
+                retake_generators=torch.Generator().manual_seed(7),
+                infer_steps=2,                 # one edit step (idx 0)
+                diffusion_guidance_scale=2.0,  # force APG path
+                n_min=0.0, n_max=0.5, n_avg=n_avg,
+                use_progress_bar=False,
+            )["target_latents"]
+
+        # n_avg=1: one draw, one APG update.
+        # n_avg=4: four draws averaged, *one* APG update from avg diff.
+        # Both should produce *finite* outputs; if APG advanced per draw,
+        # n_avg=4 would diverge much faster (running avg compounds 4×).
+        a1, a4 = _run(1), _run(4)
+        self.assertFalse(torch.isnan(a1).any())
+        self.assertFalse(torch.isnan(a4).any())
+        # Magnitude check: with the fix, both draws should be in the
+        # same ballpark.  With the bug, n_avg=4's norm would be far
+        # larger than n_avg=1's.
+        ratio = a4.abs().max().item() / max(a1.abs().max().item(), 1e-6)
+        self.assertLess(ratio, 5.0,
+            f"n_avg=4 output is {ratio:.2f}× n_avg=1 — APG momentum likely "
+            "advancing per draw instead of per step.")
+
     def test_ema_does_not_leak_inside_inner_loop(self):
         """Regression for codex P2 round-1 finding.
 

--- a/acestep/models/common/flow_edit_test.py
+++ b/acestep/models/common/flow_edit_test.py
@@ -1,0 +1,195 @@
+"""Integration tests for ``flowedit_sampling_loop`` with a mock decoder (#1156).
+
+The real DiT decoder needs full model weights and a GPU, so these tests
+substitute a deterministic linear stub.  They pin the *contract*:
+
+* Window/branch routing — what ``zt_edit`` vs ``xt_tar`` should look like
+  depending on ``n_min`` / ``n_max``.
+* Determinism — fixed seeds → bit-equal outputs.
+* ``n_avg`` averaging — increasing it must reduce the variance of the
+  V_delta estimator (within tolerance).
+* CFG packing — ``guidance_scale > 1`` doubles the decoder input batch.
+
+A real-audio smoke test on jieyue is run separately (see
+``scripts/flow_edit_smoke_test.py`` after this lands).
+"""
+
+import unittest
+
+import torch
+
+from acestep.models.common.flow_edit import flowedit_sampling_loop
+
+
+class _StubDecoderOutput(tuple):
+    """Mimics HuggingFace's ``ModelOutput``-like 2-tuple ``(vt, kv)``."""
+
+
+class _StubDecoder(torch.nn.Module):
+    """Deterministic linear-ish stand-in for a DiT decoder.
+
+    The real decoder maps ``(hidden_states, timestep, ..., context_latents)``
+    to a velocity tensor.  We approximate it with a fixed linear projection
+    plus a context-dependent perturbation so that:
+
+    * ``V_src`` and ``V_tar`` differ when their context_latents differ.
+    * Output is reproducible given fixed inputs.
+    * No gradients, no real network — runs in milliseconds on CPU.
+    """
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.channels = channels
+        torch.manual_seed(13)
+        self.W = torch.randn(channels, channels) * 0.1
+
+    def forward(
+        self,
+        hidden_states,
+        timestep,
+        timestep_r,
+        attention_mask,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        context_latents,
+        use_cache=False,
+        past_key_values=None,
+    ):
+        # vt shape == hidden_states shape (model returns velocity)
+        # Project and add a context-dependent term so src_cond ≠ tar_cond.
+        ctx_signal = context_latents[..., : self.channels].mean(dim=-2, keepdim=True)
+        proj = hidden_states @ self.W.to(hidden_states.dtype)
+        vt = proj + 0.05 * ctx_signal + 0.01 * timestep.view(-1, 1, 1)
+        return _StubDecoderOutput((vt, past_key_values))
+
+    # The real decoder is called as ``model.decoder(...)``; allow that.
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class _StubModel:
+    """Minimal model facade exposing the surface ``flow_edit`` uses."""
+
+    def __init__(self, channels: int = 16):
+        self.channels = channels
+        self.decoder = _StubDecoder(channels)
+        self.null_condition_emb = torch.randn(1, 1, channels)
+
+
+def _make_inputs(bsz: int = 1, seq: int = 8, channels: int = 16):
+    torch.manual_seed(42)
+    src_latents = torch.randn(bsz, seq, channels)
+    enc_hs = torch.randn(bsz, 4, channels)
+    enc_am = torch.ones(bsz, 4)
+    ctx = torch.randn(bsz, seq, channels * 2)
+    attn = torch.ones(bsz, seq)
+    return src_latents, enc_hs, enc_am, ctx, attn
+
+
+class FlowEditSamplingLoopContractTests(unittest.TestCase):
+
+    def test_n_max_zero_only_post_window(self):
+        """``n_max=0`` skips the edit branch and Euler-steps from xt_src."""
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        out = flowedit_sampling_loop(
+            model,
+            src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+            src_context_latents=ctx_a,
+            tar_encoder_hidden_states=enc_hs_b, tar_encoder_attention_mask=enc_am_b,
+            tar_context_latents=ctx_b,
+            src_latents=src, attention_mask=attn,
+            null_condition_emb=model.null_condition_emb,
+            retake_generators=torch.Generator().manual_seed(7),
+            infer_steps=4,
+            diffusion_guidance_scale=1.0,
+            n_min=0.0, n_max=0.0, n_avg=1,
+            use_progress_bar=False,
+        )
+        # Output came from the post-window branch (xt_tar), so must differ
+        # from src — the stub has a non-zero projection.
+        self.assertFalse(torch.equal(out["target_latents"], src))
+
+    def test_n_min_equals_n_max_equals_one_returns_src(self):
+        """``n_min=n_max=1`` skips both branches → output equals source."""
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        out = flowedit_sampling_loop(
+            model,
+            src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+            src_context_latents=ctx_a,
+            tar_encoder_hidden_states=enc_hs_b, tar_encoder_attention_mask=enc_am_b,
+            tar_context_latents=ctx_b,
+            src_latents=src, attention_mask=attn,
+            null_condition_emb=model.null_condition_emb,
+            retake_generators=torch.Generator().manual_seed(7),
+            infer_steps=4,
+            diffusion_guidance_scale=1.0,
+            n_min=1.0, n_max=1.0, n_avg=1,
+            use_progress_bar=False,
+        )
+        self.assertTrue(torch.equal(out["target_latents"], src))
+
+    def test_determinism_same_seed_same_output(self):
+        """Bit-equal outputs given identical seeds."""
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+
+        def _run():
+            return flowedit_sampling_loop(
+                model,
+                src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+                src_context_latents=ctx_a,
+                tar_encoder_hidden_states=enc_hs_b, tar_encoder_attention_mask=enc_am_b,
+                tar_context_latents=ctx_b,
+                src_latents=src, attention_mask=attn,
+                null_condition_emb=model.null_condition_emb,
+                retake_generators=torch.Generator().manual_seed(13),
+                infer_steps=4,
+                diffusion_guidance_scale=1.0,
+                n_min=0.2, n_max=0.8, n_avg=2,
+                use_progress_bar=False,
+            )["target_latents"]
+
+        a = _run()
+        b = _run()
+        self.assertTrue(torch.equal(a, b))
+
+    def test_invalid_n_avg_raises(self):
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        with self.assertRaises(ValueError):
+            flowedit_sampling_loop(
+                model,
+                src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+                src_context_latents=ctx_a,
+                tar_encoder_hidden_states=enc_hs_a, tar_encoder_attention_mask=enc_am_a,
+                tar_context_latents=ctx_a,
+                src_latents=src, attention_mask=attn,
+                null_condition_emb=model.null_condition_emb,
+                infer_steps=4, n_avg=0, use_progress_bar=False,
+                diffusion_guidance_scale=1.0,
+            )
+
+    def test_invalid_window_raises(self):
+        model = _StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        with self.assertRaises(ValueError):
+            flowedit_sampling_loop(
+                model,
+                src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
+                src_context_latents=ctx_a,
+                tar_encoder_hidden_states=enc_hs_a, tar_encoder_attention_mask=enc_am_a,
+                tar_context_latents=ctx_a,
+                src_latents=src, attention_mask=attn,
+                null_condition_emb=model.null_condition_emb,
+                infer_steps=4, n_min=0.7, n_max=0.3, use_progress_bar=False,
+                diffusion_guidance_scale=1.0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/models/common/flow_edit_test.py
+++ b/acestep/models/common/flow_edit_test.py
@@ -1,17 +1,8 @@
-"""Integration tests for ``flowedit_sampling_loop`` with a mock decoder (#1156).
+"""Loop-contract tests for ``flowedit_sampling_loop`` (#1156).
 
-The real DiT decoder needs full model weights and a GPU, so these tests
-substitute a deterministic linear stub.  They pin the *contract*:
-
-* Window/branch routing — what ``zt_edit`` vs ``xt_tar`` should look like
-  depending on ``n_min`` / ``n_max``.
-* Determinism — fixed seeds → bit-equal outputs.
-* ``n_avg`` averaging — increasing it must reduce the variance of the
-  V_delta estimator (within tolerance).
-* CFG packing — ``guidance_scale > 1`` doubles the decoder input batch.
-
-A real-audio smoke test on jieyue is run separately (see
-``scripts/flow_edit_smoke_test.py`` after this lands).
+Uses the deterministic stub decoder in ``_flow_edit_test_support``;
+pipeline-level forwarding tests live in ``flow_edit_pipeline_test.py``.
+Real-audio smoke test runs separately on a GPU machine.
 """
 
 import unittest
@@ -20,79 +11,16 @@ import torch
 
 from acestep.models.common.flow_edit import flowedit_sampling_loop
 
-
-class _StubDecoderOutput(tuple):
-    """Mimics HuggingFace's ``ModelOutput``-like 2-tuple ``(vt, kv)``."""
-
-
-class _StubDecoder(torch.nn.Module):
-    """Deterministic linear-ish stand-in for a DiT decoder.
-
-    The real decoder maps ``(hidden_states, timestep, ..., context_latents)``
-    to a velocity tensor.  We approximate it with a fixed linear projection
-    plus a context-dependent perturbation so that:
-
-    * ``V_src`` and ``V_tar`` differ when their context_latents differ.
-    * Output is reproducible given fixed inputs.
-    * No gradients, no real network — runs in milliseconds on CPU.
-    """
-
-    def __init__(self, channels: int):
-        super().__init__()
-        self.channels = channels
-        torch.manual_seed(13)
-        self.W = torch.randn(channels, channels) * 0.1
-
-    def forward(
-        self,
-        hidden_states,
-        timestep,
-        timestep_r,
-        attention_mask,
-        encoder_hidden_states,
-        encoder_attention_mask,
-        context_latents,
-        use_cache=False,
-        past_key_values=None,
-    ):
-        # vt shape == hidden_states shape (model returns velocity)
-        # Project and add a context-dependent term so src_cond ≠ tar_cond.
-        ctx_signal = context_latents[..., : self.channels].mean(dim=-2, keepdim=True)
-        proj = hidden_states @ self.W.to(hidden_states.dtype)
-        vt = proj + 0.05 * ctx_signal + 0.01 * timestep.view(-1, 1, 1)
-        return _StubDecoderOutput((vt, past_key_values))
-
-    # The real decoder is called as ``model.decoder(...)``; allow that.
-    def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
-
-
-class _StubModel:
-    """Minimal model facade exposing the surface ``flow_edit`` uses."""
-
-    def __init__(self, channels: int = 16):
-        self.channels = channels
-        self.decoder = _StubDecoder(channels)
-        self.null_condition_emb = torch.randn(1, 1, channels)
-
-
-def _make_inputs(bsz: int = 1, seq: int = 8, channels: int = 16):
-    torch.manual_seed(42)
-    src_latents = torch.randn(bsz, seq, channels)
-    enc_hs = torch.randn(bsz, 4, channels)
-    enc_am = torch.ones(bsz, 4)
-    ctx = torch.randn(bsz, seq, channels * 2)
-    attn = torch.ones(bsz, seq)
-    return src_latents, enc_hs, enc_am, ctx, attn
+from acestep.models.common._flow_edit_test_support import StubModel, make_inputs
 
 
 class FlowEditSamplingLoopContractTests(unittest.TestCase):
 
     def test_n_max_zero_only_post_window(self):
         """``n_max=0`` skips the edit branch and Euler-steps from xt_src."""
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
-        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = make_inputs()
         out = flowedit_sampling_loop(
             model,
             src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
@@ -107,15 +35,13 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
             n_min=0.0, n_max=0.0, n_avg=1,
             use_progress_bar=False,
         )
-        # Output came from the post-window branch (xt_tar), so must differ
-        # from src — the stub has a non-zero projection.
         self.assertFalse(torch.equal(out["target_latents"], src))
 
     def test_n_min_equals_n_max_equals_one_returns_src(self):
         """``n_min=n_max=1`` skips both branches → output equals source."""
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
-        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = make_inputs()
         out = flowedit_sampling_loop(
             model,
             src_encoder_hidden_states=enc_hs_a, src_encoder_attention_mask=enc_am_a,
@@ -134,9 +60,9 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
 
     def test_determinism_same_seed_same_output(self):
         """Bit-equal outputs given identical seeds."""
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
-        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = make_inputs()
 
         def _run():
             return flowedit_sampling_loop(
@@ -159,8 +85,8 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
         self.assertTrue(torch.equal(a, b))
 
     def test_invalid_n_avg_raises(self):
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
         with self.assertRaises(ValueError):
             flowedit_sampling_loop(
                 model,
@@ -175,8 +101,8 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
             )
 
     def test_invalid_window_raises(self):
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
         with self.assertRaises(ValueError):
             flowedit_sampling_loop(
                 model,
@@ -196,17 +122,14 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
         Pre-fix the inner ``n_avg`` loop called ``apg_forward`` n_avg
         times per step, advancing APG's running average n_avg times per
         scheduler step.  Post-fix the buffer is snapshot-and-restored
-        around each draw, then advanced *once* with the averaged diff
-        outside the loop.  This test pins that behaviour by asserting
-        the loop with ``n_avg=1`` and ``n_avg=4`` give the same APG
-        state after one step (since both should advance momentum once
-        per step, just averaged).
-
-        We exercise CFG (``guidance_scale > 1``) so APG actually runs.
+        around each draw, then advanced once with the averaged diff
+        outside the loop.  We exercise CFG (``guidance_scale > 1``) so
+        APG actually runs and assert the n_avg=4 output stays in the
+        same magnitude ballpark as n_avg=1.
         """
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
-        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = make_inputs()
 
         def _run(n_avg):
             return flowedit_sampling_loop(
@@ -218,22 +141,15 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
                 src_latents=src, attention_mask=attn,
                 null_condition_emb=model.null_condition_emb,
                 retake_generators=torch.Generator().manual_seed(7),
-                infer_steps=2,                 # one edit step (idx 0)
-                diffusion_guidance_scale=2.0,  # force APG path
+                infer_steps=2,
+                diffusion_guidance_scale=2.0,
                 n_min=0.0, n_max=0.5, n_avg=n_avg,
                 use_progress_bar=False,
             )["target_latents"]
 
-        # n_avg=1: one draw, one APG update.
-        # n_avg=4: four draws averaged, *one* APG update from avg diff.
-        # Both should produce *finite* outputs; if APG advanced per draw,
-        # n_avg=4 would diverge much faster (running avg compounds 4×).
         a1, a4 = _run(1), _run(4)
         self.assertFalse(torch.isnan(a1).any())
         self.assertFalse(torch.isnan(a4).any())
-        # Magnitude check: with the fix, both draws should be in the
-        # same ballpark.  With the bug, n_avg=4's norm would be far
-        # larger than n_avg=1's.
         ratio = a4.abs().max().item() / max(a1.abs().max().item(), 1e-6)
         self.assertLess(ratio, 5.0,
             f"n_avg=4 output is {ratio:.2f}× n_avg=1 — APG momentum likely "
@@ -242,16 +158,14 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
     def test_ema_does_not_leak_inside_inner_loop(self):
         """Regression for codex P2 round-1 finding.
 
-        Pre-fix the loop updated ``prev_vt_*`` after every n_avg draw, so
-        later draws got EMA-smoothed against earlier draws of the same
-        step.  Post-fix the EMA carry-over is updated *once* per step
-        from the averaged velocity, so n_avg results stay independent of
-        draw order.  This test exercises the path with non-zero EMA and
-        n_avg=4 and pins reproducibility.
+        Bit-equal outputs across runs with identical seeds, non-zero EMA,
+        and ``n_avg=4``.  Pre-fix this would have been flaky since
+        ``prev_vt_*`` mutated mid-loop made the result depend on draw
+        order.
         """
-        model = _StubModel()
-        src, enc_hs_a, enc_am_a, ctx_a, attn = _make_inputs()
-        _, enc_hs_b, enc_am_b, ctx_b, _ = _make_inputs()
+        model = StubModel()
+        src, enc_hs_a, enc_am_a, ctx_a, attn = make_inputs()
+        _, enc_hs_b, enc_am_b, ctx_b, _ = make_inputs()
 
         def _run():
             return flowedit_sampling_loop(
@@ -270,76 +184,7 @@ class FlowEditSamplingLoopContractTests(unittest.TestCase):
                 use_progress_bar=False,
             )["target_latents"]
 
-        # Two runs with identical seeds must match bit-for-bit; this would
-        # have been flaky if prev_vt mutated mid-loop.
         self.assertTrue(torch.equal(_run(), _run()))
-
-
-class _CapturingModel(_StubModel):
-    """Stub model whose ``prepare_condition`` records the kwargs it saw."""
-
-    def __init__(self, channels=16):
-        super().__init__(channels=channels)
-        self.captured_calls = []
-
-    def prepare_condition(self, **kwargs):
-        self.captured_calls.append(kwargs)
-        bsz = kwargs["src_latents"].shape[0]
-        seq = kwargs["src_latents"].shape[1]
-        # Match the real method's return signature (enc_hs, enc_am, ctx).
-        return (
-            torch.randn(bsz, 4, self.channels),
-            torch.ones(bsz, 4),
-            torch.randn(bsz, seq, self.channels * 2),
-        )
-
-
-class FlowEditPipelineConditionForwardingTests(unittest.TestCase):
-
-    def test_lm_hints_and_audio_codes_forwarded_to_both_calls(self):
-        """Regression for codex P2 round-1 finding: hints must reach prepare_condition."""
-        from acestep.models.common.flow_edit_pipeline import flowedit_generate_audio
-
-        model = _CapturingModel()
-        bsz, seq, ch = 1, 8, model.channels
-        src = torch.randn(bsz, seq, ch)
-        text_hs = torch.randn(bsz, 4, ch)
-        text_am = torch.ones(bsz, 4)
-        lyric_hs = torch.randn(bsz, 4, ch)
-        lyric_am = torch.ones(bsz, 4)
-        refer = torch.zeros(0, 4, ch)
-        refer_om = torch.zeros(0, dtype=torch.long)
-        chunk_masks = torch.ones(bsz, seq, ch)
-        is_covers = torch.zeros(bsz, dtype=torch.long)
-        silence = torch.zeros(bsz, seq, ch)
-
-        sentinel_hints = torch.full((bsz, seq, ch), 0.42)
-        sentinel_codes = torch.tensor([[1, 2, 3]])
-
-        flowedit_generate_audio(
-            model,
-            text_hidden_states=text_hs, text_attention_mask=text_am,
-            lyric_hidden_states=lyric_hs, lyric_attention_mask=lyric_am,
-            refer_audio_acoustic_hidden_states_packed=refer,
-            refer_audio_order_mask=refer_om,
-            src_latents=src, chunk_masks=chunk_masks,
-            is_covers=is_covers, silence_latent=silence,
-            target_text_hidden_states=text_hs,
-            target_text_attention_mask=text_am,
-            target_lyric_hidden_states=lyric_hs,
-            target_lyric_attention_mask=lyric_am,
-            infer_steps=2,
-            diffusion_guidance_scale=1.0,
-            edit_n_min=0.0, edit_n_max=1.0, edit_n_avg=1,
-            use_progress_bar=False,
-            precomputed_lm_hints_25Hz=sentinel_hints,
-            audio_codes=sentinel_codes,
-        )
-
-        self.assertEqual(len(model.captured_calls), 2)  # one for src, one for tar
-        for call in model.captured_calls:
-            self.assertIs(call["precomputed_lm_hints_25Hz"], sentinel_hints)
-            self.assertIs(call["audio_codes"], sentinel_codes)
 
 
 if __name__ == "__main__":

--- a/acestep/models/sft/modeling_acestep_v15_base.py
+++ b/acestep/models/sft/modeling_acestep_v15_base.py
@@ -2192,6 +2192,19 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156): morph src toward a target prompt/lyrics.
+
+        Thin delegate to ``models.common.flow_edit_pipeline`` so all four
+        base variants share the same implementation.  See that module's
+        docstring for the algorithm and v1 sampler-trick exclusions.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility

--- a/acestep/models/xl_base/modeling_acestep_v15_xl_base.py
+++ b/acestep/models/xl_base/modeling_acestep_v15_xl_base.py
@@ -2209,6 +2209,19 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156): morph src toward a target prompt/lyrics.
+
+        Thin delegate to ``models.common.flow_edit_pipeline`` so all four
+        base variants share the same implementation.  See that module's
+        docstring for the algorithm and v1 sampler-trick exclusions.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility

--- a/acestep/models/xl_sft/modeling_acestep_v15_xl_base.py
+++ b/acestep/models/xl_sft/modeling_acestep_v15_xl_base.py
@@ -2209,6 +2209,19 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156): morph src toward a target prompt/lyrics.
+
+        Thin delegate to ``models.common.flow_edit_pipeline`` so all four
+        base variants share the same implementation.  See that module's
+        docstring for the algorithm and v1 sampler-trick exclusions.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility


### PR DESCRIPTION
## Summary

Phase A of #1156 Flow Edit. Adds a model-agnostic flow-edit sampling loop and exposes a thin delegate method on each of the 4 base DiT variants. After this lands, flow-edit is reachable from Python via \`model.flowedit_generate_audio(**kwargs)\`.

Handler/service/inference plumbing + Gradio UI follow in **PR-B** — splitting keeps each PR's diff small enough for thorough codex review (we shipped retake the same way).

## Math contract

Ports ACE-Step 1.0's \`flowedit_diffusion_process\` line-by-line. Per step inside the edit window \`[n_min, n_max]\`:

\`\`\`
fwd_noise = randn(x_src.shape)
zt_src    = (1 - t) · x_src + t · fwd_noise
zt_tar    = zt_edit + zt_src - x_src
V_src, V_tar = paired_decoder_forward(...)
V_delta_avg += (1/n_avg) · (V_tar - V_src)
zt_edit   += (t_prev - t_curr) · V_delta_avg
\`\`\`

After \`step_idx == n_max_step\`, the loop re-initialises a target-only running variable \`xt_tar = zt_edit + xt_src - x_src\` and Euler-steps it with V_tar (matches 1.0's tail).

## v1 sampler-trick coverage

Per the locked Phase 0 design on #1156, supported in v1:
- Euler sampler
- Plain CFG
- **APG** with **independent MomentumBuffer per trajectory** (matches 1.0)
- CFG interval
- Velocity clamp / EMA (independent state per trajectory)

Deferred to follow-up PRs:
- DCW (operates on latent not velocity; needs paired-forward derivation)
- \`sampler_mode=heun\` (8× decoder forwards/step is cost-prohibitive)
- ADG (no 1.0 reference; needs its own validation)

A single info log fires when a user passes any of the deferred tricks so they can see why the UI knob didn't take effect.

## Files

| File | LOC | Purpose |
|---|---|---|
| \`acestep/models/common/flow_edit.py\` | 193 | \`flowedit_sampling_loop\` — paired CFG loop with V_delta integration |
| \`acestep/models/common/flow_edit_helpers.py\` | 144 | schedule, CFG packing, velocity post-processing, generator-aware noise |
| \`acestep/models/common/flow_edit_pipeline.py\` | 192 | \`flowedit_generate_audio\` — high-level wrapper that builds source/target conditions |
| \`acestep/models/common/flow_edit_helpers_test.py\` | new | 16 unit tests on helpers (pure-functional) |
| \`acestep/models/common/flow_edit_test.py\` | new | 5 integration tests on the loop with a stub decoder |
| 4 model variants | +13 each | thin delegate method (lazy import) |

All modules under the 200 LOC AGENTS.md cap.

## Scope

- **In scope**: xl_base, xl_sft, sft, base
- **Out of scope**: turbo, xl_turbo (CFG-distilled; paired-CFG flow-edit not well-defined)

## Tests

\`\`\`
$ python -m unittest acestep.models.common.flow_edit_helpers_test acestep.models.common.flow_edit_test
Ran 21 tests in 0.007s — OK
\`\`\`

Test coverage:
- **Unit (16)**: each helper primitive — schedule construction, CFG dispatch (no-CFG / interval / APG branches), velocity clamp/EMA, generator-aware noise (None / single / per-sample), CFG packing
- **Integration (5)**: window routing (\`n_max=0\` → only post-window, \`n_min=n_max=1\` → no-op returning src), determinism across seeds, error guards on invalid \`n_avg\` / window

A real-audio smoke test on a GPU machine will run after PR-B lands the handler plumbing (handler is what loads the actual checkpoint).

## Test plan

- [x] All unit + integration tests pass (no GPU needed)
- [x] Each touched module under 200 LOC cap
- [x] Syntax check on all 4 patched variants
- [x] PR-A is callable via \`model.flowedit_generate_audio(**kwargs)\` from Python
- [ ] codex review (will be run after this PR is opened)
- [ ] PR-B: plumb through handler/service/inference + Gradio UI

## Risk

Low. Pure additions — no existing code path modified. The 4 variant changes are ~13 lines each, all delegating to a shared module with lazy import (cold-import unaffected for non-flow-edit callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flow-Edit audio generation with a user-facing flowedit_generate_audio API across model variants.
  * Configurable sampling (steps, edit window, shift), reproducible seeding (seed/retake, per-sample), classifier-free guidance interval, velocity clamping/EMA, and progress options.

* **Tests**
  * Added comprehensive tests covering sampling determinism, CFG behavior, timestep scheduling, velocity post-processing, momentum handling, and pipeline wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->