### PR TITLE
feat(flow-edit): plumb task_type=edit through handler/service/inference (PR-B)

### DIFF
--- a/acestep/constants.py
+++ b/acestep/constants.py
@@ -84,9 +84,16 @@ TASK_TYPES_TURBO = ["text2music", "repaint", "cover", "cover-nofsq"]
 # - extract: Separate individual tracks/stems from audio
 # - lego: Multi-track generation (add layers)
 # - complete: Automatic completion of partial audio
-# - edit: Flow-edit — morph the source toward a new prompt/lyrics
-#   (paired CFG, ~4× decoder forwards/step; only on base variants)
-TASK_TYPES_BASE = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete", "edit"]
+# Note: ``edit`` is a base-only task (#1156) but intentionally NOT
+# advertised here — the HTTP /release_task surface and Gradio dropdowns
+# both read TASK_TYPES_BASE.  Until PR-C wires the API/UI fields
+# (edit_target_caption / lyrics / window) through, keep edit out of
+# discovery so clients aren't told "edit is supported" while still
+# unable to pass the required target params.  Python callers using
+# ``GenerationParams(task_type="edit")`` directly are unaffected — the
+# dispatch only checks TASK_TYPES (which does include edit) for
+# validation.
+TASK_TYPES_BASE = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
 
 
 # ==============================================================================

--- a/acestep/constants.py
+++ b/acestep/constants.py
@@ -71,11 +71,11 @@ VALID_TIME_SIGNATURES = [2, 3, 4, 6]
 # ==============================================================================
 
 # All supported generation tasks across different model variants
-TASK_TYPES = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
+TASK_TYPES = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete", "edit"]
 
 # Task types available for turbo models (optimized subset for speed)
 # - text2music: Generate from text descriptions
-# - repaint: Selective audio editing/regeneration  
+# - repaint: Selective audio editing/regeneration
 # - cover: Style transfer using reference audio
 TASK_TYPES_TURBO = ["text2music", "repaint", "cover", "cover-nofsq"]
 
@@ -84,7 +84,9 @@ TASK_TYPES_TURBO = ["text2music", "repaint", "cover", "cover-nofsq"]
 # - extract: Separate individual tracks/stems from audio
 # - lego: Multi-track generation (add layers)
 # - complete: Automatic completion of partial audio
-TASK_TYPES_BASE = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
+# - edit: Flow-edit — morph the source toward a new prompt/lyrics
+#   (paired CFG, ~4× decoder forwards/step; only on base variants)
+TASK_TYPES_BASE = ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete", "edit"]
 
 
 # ==============================================================================
@@ -134,6 +136,7 @@ TASK_INSTRUCTIONS = {
     "lego_default": "Generate the track based on the audio context:",
     "complete": "Complete the input track with {TRACK_CLASSES}:",
     "complete_default": "Complete the input track:",
+    "edit": "Edit the audio toward the target conditions:",
 }
 
 

--- a/acestep/core/generation/handler/_flow_edit_dispatch_test_support.py
+++ b/acestep/core/generation/handler/_flow_edit_dispatch_test_support.py
@@ -39,6 +39,8 @@ class FakeHandler:
     def _prepare_text_conditioning_inputs(self, *, batch_size, instructions,
                                           captions, lyrics, parsed_metas,
                                           vocal_languages, audio_cover_strength):
+        # Capture parsed_metas so tests can verify _parse_metas ran first.
+        self.captured_parsed_metas = parsed_metas
         seq = 4
         return (
             ["fake-text-input"] * batch_size,
@@ -48,6 +50,18 @@ class FakeHandler:
             torch.ones(batch_size, seq),
             None, None,
         )
+
+    def _parse_metas(self, metas):
+        """Stub mirroring the real handler's contract: dict -> formatted string."""
+        out = []
+        for m in metas:
+            if isinstance(m, dict):
+                # Real handler emits "- bpm: 120\n- key: ..." style; stub uses
+                # a sentinel prefix so tests can detect parse-vs-raw-dict.
+                out.append("PARSED:" + ",".join(f"{k}={v}" for k, v in m.items()))
+            else:
+                out.append(str(m))
+        return out
 
     def infer_text_embeddings(self, ids):
         return torch.zeros(ids.shape[0], ids.shape[1], 16)

--- a/acestep/core/generation/handler/_flow_edit_dispatch_test_support.py
+++ b/acestep/core/generation/handler/_flow_edit_dispatch_test_support.py
@@ -1,0 +1,85 @@
+"""Shared test fixtures for flow-edit dispatch tests (#1156 PR-B).
+
+Underscored module name keeps it out of unittest discovery.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import torch
+
+
+class FakeHandler:
+    """Minimal handler stand-in exposing the surface ``dispatch_flow_edit`` needs."""
+
+    def __init__(self, model_has_flowedit: bool = True):
+        self.device = torch.device("cpu")
+        self.model = MagicMock()
+        if not model_has_flowedit:
+            del self.model.flowedit_generate_audio
+        else:
+            self.model.flowedit_generate_audio.return_value = {
+                "target_latents": torch.zeros(1, 8, 16),
+                "time_costs": {},
+            }
+        # Sentinel tensors so tests can verify the dispatch returns
+        # ``prepare_condition`` outputs (not the raw embeddings).
+        self.prepared_enc_hs = torch.full((1, 4, 16), 7.0)
+        self.prepared_enc_am = torch.full((1, 4), 7.0)
+        self.prepared_ctx = torch.full((1, 8, 32), 7.0)
+        self.model.prepare_condition.return_value = (
+            self.prepared_enc_hs, self.prepared_enc_am, self.prepared_ctx,
+        )
+        self.silence_latent = torch.zeros(1, 8, 16)
+
+    @contextmanager
+    def _load_model_context(self, name):
+        yield
+
+    def _prepare_text_conditioning_inputs(self, *, batch_size, instructions,
+                                          captions, lyrics, parsed_metas,
+                                          vocal_languages, audio_cover_strength):
+        seq = 4
+        return (
+            ["fake-text-input"] * batch_size,
+            torch.zeros(batch_size, seq, dtype=torch.long),
+            torch.ones(batch_size, seq),
+            torch.zeros(batch_size, seq, dtype=torch.long),
+            torch.ones(batch_size, seq),
+            None, None,
+        )
+
+    def infer_text_embeddings(self, ids):
+        return torch.zeros(ids.shape[0], ids.shape[1], 16)
+
+    def infer_lyric_embeddings(self, ids):
+        return torch.zeros(ids.shape[0], ids.shape[1], 16)
+
+
+def make_payload(bsz: int = 1, seq: int = 8, ch: int = 16):
+    return {
+        "src_latents": torch.randn(bsz, seq, ch),
+        "text_hidden_states": torch.randn(bsz, 4, ch),
+        "text_attention_mask": torch.ones(bsz, 4),
+        "lyric_hidden_states": torch.randn(bsz, 4, ch),
+        "lyric_attention_mask": torch.ones(bsz, 4),
+        "refer_audio_acoustic_hidden_states_packed": torch.zeros(0, 4, ch),
+        "refer_audio_order_mask": torch.zeros(0, dtype=torch.long),
+        "chunk_mask": torch.ones(bsz, seq, ch),
+        "is_covers": torch.zeros(bsz, dtype=torch.long),
+        "precomputed_lm_hints_25Hz": None,
+    }
+
+
+def make_edit_ctx(target_caption="my new caption", target_lyrics="new lyrics"):
+    return {
+        "task_type": "edit",
+        "edit_target_caption": target_caption,
+        "edit_target_lyrics": target_lyrics,
+        "vocal_languages": ["en"],
+        "metas": [""],
+        "instructions": ["Fill the audio semantic mask based on the given conditions:"],
+        "edit_n_min": 0.2,
+        "edit_n_max": 0.8,
+        "edit_n_avg": 1,
+    }

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -225,6 +225,11 @@ class GenerateMusicMixin:
         repaint_strength: float = 0.5,
         retake_seed: Optional[Union[str, float, int]] = None,
         retake_variance: float = 0.0,
+        edit_target_caption: str = "",
+        edit_target_lyrics: str = "",
+        edit_n_min: float = 0.0,
+        edit_n_max: float = 1.0,
+        edit_n_avg: int = 1,
         progress=None,
     ) -> Dict[str, Any]:
         """Generate audio from text/reference inputs and return response payload.
@@ -325,11 +330,26 @@ class GenerateMusicMixin:
             if audio_error is not None:
                 return audio_error
 
-            # Cover/repaint/lego/extract: lock duration to source audio.
+            # Cover/repaint/lego/extract/edit: lock duration to source audio.
             if processed_src_audio is not None and task_type in (
-                "cover", "cover-nofsq", "repaint", "lego", "extract",
+                "cover", "cover-nofsq", "repaint", "lego", "extract", "edit",
             ):
                 audio_duration = processed_src_audio.shape[-1] / self.sample_rate
+
+            # Flow-edit guards: paired CFG ≈ 4× decoder forwards/step, so
+            # warn when a user combines edit with knobs that don't apply.
+            if task_type == "edit":
+                if repainting_start or (repainting_end is not None and repainting_end >= 0):
+                    logger.info(
+                        "[generate_music] task_type='edit' is whole-song; ignoring "
+                        "repainting_start={} / repainting_end={}.",
+                        repainting_start, repainting_end,
+                    )
+                if not edit_target_caption and not edit_target_lyrics:
+                    logger.warning(
+                        "[generate_music] task_type='edit' with empty edit_target_caption "
+                        "and edit_target_lyrics — output will closely match the source.",
+                    )
 
             service_inputs = self._prepare_generate_music_service_inputs(
                 actual_batch_size=actual_batch_size,
@@ -391,6 +411,11 @@ class GenerateMusicMixin:
                 task_type=task_type,
                 actual_retake_seed_list=actual_retake_seed_list,
                 retake_variance=retake_variance,
+                edit_target_caption=edit_target_caption,
+                edit_target_lyrics=edit_target_lyrics,
+                edit_n_min=edit_n_min,
+                edit_n_max=edit_n_max,
+                edit_n_avg=edit_n_avg,
             )
             outputs = service_run["outputs"]
             infer_steps_for_progress = service_run["infer_steps_for_progress"]

--- a/acestep/core/generation/handler/generate_music_execute.py
+++ b/acestep/core/generation/handler/generate_music_execute.py
@@ -46,6 +46,11 @@ class GenerateMusicExecuteMixin:
         task_type: str = "",
         actual_retake_seed_list: Optional[List[int]] = None,
         retake_variance: float = 0.0,
+        edit_target_caption: str = "",
+        edit_target_lyrics: str = "",
+        edit_n_min: float = 0.0,
+        edit_n_max: float = 1.0,
+        edit_n_avg: int = 1,
     ) -> Dict[str, Any]:
         """Invoke ``service_generate`` while maintaining background progress estimation.
 
@@ -107,6 +112,11 @@ class GenerateMusicExecuteMixin:
                     task_type=task_type,
                     retake_seed=actual_retake_seed_list,
                     retake_variance=retake_variance,
+                    edit_target_caption=edit_target_caption,
+                    edit_target_lyrics=edit_target_lyrics,
+                    edit_n_min=edit_n_min,
+                    edit_n_max=edit_n_max,
+                    edit_n_avg=edit_n_avg,
                 )
             except Exception as exc:
                 _error["exc"] = exc

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -126,7 +126,8 @@ class GenerateMusicRequestMixin:
             refer_audios = [[torch.zeros(2, 30 * self.sample_rate)] for _ in range(actual_batch_size)]
 
         processed_src_audio = None
-        _src_audio_required_tasks = {"cover", "cover-nofsq", "repaint", "lego", "extract"}
+        # Flow-edit (#1156) needs the source audio just like cover/repaint/etc.
+        _src_audio_required_tasks = {"cover", "cover-nofsq", "repaint", "lego", "extract", "edit"}
         if task_type == "text2music":
             if src_audio is not None:
                 logger.info("[generate_music] text2music task does not use src_audio, ignoring")

--- a/acestep/core/generation/handler/service_generate.py
+++ b/acestep/core/generation/handler/service_generate.py
@@ -58,52 +58,21 @@ class ServiceGenerateMixin:
         task_type: str = "",
         retake_seed: Optional[Union[int, List[int]]] = None,
         retake_variance: float = 0.0,
+        edit_target_caption: str = "",
+        edit_target_lyrics: str = "",
+        edit_n_min: float = 0.0,
+        edit_n_max: float = 1.0,
+        edit_n_avg: int = 1,
     ) -> Dict[str, Any]:
         """Generate music latents and metadata from text/audio conditioning inputs.
 
-        Args:
-            captions: Caption string(s) describing the target generation.
-            lyrics: Lyric string(s) aligned with each requested sample.
-            keys: Optional sample identifiers.
-            target_wavs: Optional target audio tensor for repaint/cover flows.
-            refer_audios: Optional nested reference-audio tensors for style conditioning.
-            metas: Optional metadata payload(s) for each sample.
-            vocal_languages: Optional per-sample vocal language code(s).
-            infer_steps: Number of diffusion steps to run.
-            guidance_scale: CFG guidance strength.
-            seed: Optional scalar or per-sample seed list.
-            return_intermediate: Whether to include intermediate tensors in outputs.
-            repainting_start: Optional repaint start time(s) in seconds.
-            repainting_end: Optional repaint end time(s) in seconds.
-            instructions: Optional per-sample instruction string(s).
-            audio_cover_strength: Cover blend strength.
-            cover_noise_strength: Cover noise blend strength.
-            use_adg: Whether adaptive diffusion guidance is enabled.
-            cfg_interval_start: CFG schedule start ratio.
-            cfg_interval_end: CFG schedule end ratio.
-            shift: Diffusion shift parameter.
-            audio_code_hints: Optional serialized audio-code hints.
-            infer_method: Diffusion inference method selector.
-            timesteps: Optional explicit diffusion timestep sequence.
-            repaint_crossfade_frames: Crossfade width (latent frames) at repaint
-                boundaries for boundary blending.  ~0.4s at 25 Hz.
-            sampler_mode: Sampler algorithm — ``"euler"`` or ``"heun"``.
-            velocity_norm_threshold: Velocity norm clamping threshold (0 = disabled).
-            velocity_ema_factor: Velocity EMA smoothing factor (0 = disabled).
-            dcw_enabled: Enable Differential Correction in Wavelet domain
-                (CVPR 2026, arXiv:2604.16044).  Opt-in sampler-side correction
-                for SNR-t bias.  Default ``False``.
-            dcw_mode: DCW correction mode — ``"low"``, ``"high"``, ``"double"``
-                or ``"pix"``.  Default ``"low"``.
-            dcw_scaler: DCW correction strength for the low band (or the
-                single band in ``"high"``/``"pix"`` modes).  Modulated by
-                ``t_curr`` inside the sampler.
-            dcw_high_scaler: DCW correction strength for the high band in
-                ``"double"`` mode.
-            dcw_wavelet: PyWavelets basis — e.g. ``"haar"``, ``"db4"``,
-                ``"sym8"``.
-            task_type: Generation task selector used when preparing
-                conditioning masks.
+        See :class:`ServiceGenerateRequestMixin` and the per-handler call sites for
+        the contract on each input.  Notable groups:
+        ``captions``/``lyrics``/``metas``/``vocal_languages`` are per-sample
+        conditioning; ``cfg_interval_*`` / ``sampler_mode`` /
+        ``velocity_*`` / ``dcw_*`` are sampler tweaks; ``task_type`` selects
+        the generation branch (``"edit"`` activates the flow-edit dispatch
+        via ``edit_ctx`` in :func:`_execute_service_generate_diffusion`).
 
         Returns:
             Dict[str, Any]: Service output payload containing generated latents,
@@ -174,16 +143,18 @@ class ServiceGenerateMixin:
             retake_seed=retake_seed,
             retake_variance=retake_variance,
         )
+        # edit_ctx activates the flow-edit branch when task_type=="edit".
+        edit_ctx = {
+            "task_type": task_type, "edit_target_caption": edit_target_caption,
+            "edit_target_lyrics": edit_target_lyrics, "vocal_languages": normalized.get("vocal_languages"),
+            "metas": normalized.get("metas"), "instructions": normalized.get("instructions"),
+            "edit_n_min": edit_n_min, "edit_n_max": edit_n_max, "edit_n_avg": edit_n_avg,
+        }
         outputs, encoder_hidden_states, encoder_attention_mask, context_latents = (
             self._execute_service_generate_diffusion(
-                payload=payload,
-                generate_kwargs=generate_kwargs,
-                seed_param=seed_param,
-                infer_method=infer_method,
-                shift=shift,
-                audio_cover_strength=audio_cover_strength,
-                retake_seed=retake_seed,
-                retake_variance=retake_variance,
+                payload=payload, generate_kwargs=generate_kwargs, seed_param=seed_param,
+                infer_method=infer_method, shift=shift, audio_cover_strength=audio_cover_strength,
+                retake_seed=retake_seed, retake_variance=retake_variance, edit_ctx=edit_ctx,
             )
         )
         return self._attach_service_generate_outputs(

--- a/acestep/core/generation/handler/service_generate_execute.py
+++ b/acestep/core/generation/handler/service_generate_execute.py
@@ -145,8 +145,16 @@ class ServiceGenerateExecuteMixin:
         audio_cover_strength: float,
         retake_seed: Any = None,
         retake_variance: float = 0.0,
+        edit_ctx: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]:
         """Execute condition preparation and diffusion using MLX or PyTorch backend."""
+        if edit_ctx is not None and edit_ctx.get("task_type") == "edit":
+            from .service_generate_flow_edit import dispatch_flow_edit
+
+            return dispatch_flow_edit(
+                self, payload=payload, generate_kwargs=generate_kwargs,
+                seed_param=seed_param, edit_ctx=edit_ctx,
+            )
         dit_backend = (
             "MLX (native)" if (self.use_mlx_dit and self.mlx_decoder is not None) else f"PyTorch ({self.device})"
         )

--- a/acestep/core/generation/handler/service_generate_flow_edit.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit.py
@@ -7,79 +7,18 @@ so we build a fresh set of target text/lyric embeddings here using the
 handler's tokenizer + encoder, then call
 ``model.flowedit_generate_audio`` with both sets.
 
-This module exists to keep ``service_generate_execute.py`` under the
-200 LOC cap while still delegating to the handler's existing tokenizer
-and encoder helpers.
+Target tokenization + embedding helpers live in
+``service_generate_flow_edit_target.py`` (split per the 200 LOC cap).
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import torch
 from loguru import logger
 
-from acestep.constants import DEFAULT_DIT_INSTRUCTION
-
-
-def _tokenize_target(
-    handler,
-    *,
-    target_caption: str,
-    target_lyrics: str,
-    vocal_languages: Optional[List[str]],
-    metas: Optional[List[Any]],
-    instructions: Optional[List[str]],
-    batch_size: int,
-):
-    """Build padded target text/lyric token tensors via handler helpers.
-
-    Reuses ``_prepare_text_conditioning_inputs`` so the SFT prompt format,
-    lyric language formatting, and padding stay consistent with the
-    source-side preparation.
-    """
-    captions = [target_caption] * batch_size
-    lyrics = [target_lyrics] * batch_size
-    langs = list(vocal_languages) if vocal_languages else ["unknown"] * batch_size
-    if len(langs) < batch_size:
-        langs = langs + ["unknown"] * (batch_size - len(langs))
-    parsed_metas_list = list(metas) if metas else [""] * batch_size
-    if len(parsed_metas_list) < batch_size:
-        parsed_metas_list = parsed_metas_list + [""] * (batch_size - len(parsed_metas_list))
-    instr_list = list(instructions) if instructions else [DEFAULT_DIT_INSTRUCTION] * batch_size
-    if len(instr_list) < batch_size:
-        instr_list = instr_list + [DEFAULT_DIT_INSTRUCTION] * (batch_size - len(instr_list))
-
-    (
-        _text_inputs,
-        text_token_idss,
-        text_attention_masks,
-        lyric_token_idss,
-        lyric_attention_masks,
-        _nc_text_ids,
-        _nc_text_am,
-    ) = handler._prepare_text_conditioning_inputs(
-        batch_size=batch_size,
-        instructions=instr_list,
-        captions=captions,
-        lyrics=lyrics,
-        parsed_metas=parsed_metas_list,
-        vocal_languages=langs,
-        audio_cover_strength=1.0,  # disable non-cover branch — we don't need it for edit
-    )
-    return text_token_idss, text_attention_masks, lyric_token_idss, lyric_attention_masks
-
-
-def _embed_target(
-    handler,
-    text_token_idss: torch.Tensor,
-    lyric_token_idss: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Run text + lyric encoders on the target tokens, return embedding tensors."""
-    with handler._load_model_context("text_encoder"):
-        text_hs = handler.infer_text_embeddings(text_token_idss)
-        lyric_hs = handler.infer_lyric_embeddings(lyric_token_idss)
-    return text_hs, lyric_hs
+from .service_generate_flow_edit_target import embed_target, tokenize_target
 
 
 def dispatch_flow_edit(
@@ -92,10 +31,10 @@ def dispatch_flow_edit(
 ) -> Tuple[Dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]:
     """Run the flow-edit branch and return the same 4-tuple as the regular path.
 
-    Builds the target text/lyric embeddings inline (no batch_prep
-    changes), then calls ``model.flowedit_generate_audio``.  The
-    encoder-state outputs returned are the *source* ones so downstream
-    metadata persistence is unchanged from the regular path.
+    Builds target text/lyric embeddings via the handler's tokenizer +
+    encoder, runs ``prepare_condition`` on the source side so the
+    returned context has the right shape for downstream scoring/LRC,
+    then calls ``model.flowedit_generate_audio``.
     """
     if not hasattr(handler.model, "flowedit_generate_audio"):
         raise RuntimeError(
@@ -113,8 +52,8 @@ def dispatch_flow_edit(
         bsz, edit_n_min, edit_n_max, edit_n_avg,
     )
 
-    # Build target tokens and embeddings using the handler's tokenizer + encoder.
-    tar_text_ids, tar_text_am, tar_lyric_ids, tar_lyric_am = _tokenize_target(
+    # Target tokens + embeddings (handler's tokenizer / encoder).
+    tar_text_ids, tar_text_am, tar_lyric_ids, tar_lyric_am = tokenize_target(
         handler,
         target_caption=edit_ctx.get("edit_target_caption") or "",
         target_lyrics=edit_ctx.get("edit_target_lyrics") or "",
@@ -123,17 +62,37 @@ def dispatch_flow_edit(
         instructions=edit_ctx.get("instructions"),
         batch_size=bsz,
     )
-    tar_text_hs, tar_lyric_hs = _embed_target(handler, tar_text_ids, tar_lyric_ids)
+    tar_text_hs, tar_lyric_hs = embed_target(handler, tar_text_ids, tar_lyric_ids)
 
-    # Move tensors to the right device/dtype to match payload conventions.
     device, dtype = src_latents.device, src_latents.dtype
     tar_text_am = tar_text_am.to(device=device, dtype=dtype)
     tar_lyric_am = tar_lyric_am.to(device=device, dtype=dtype)
 
     with torch.inference_mode():
         with handler._load_model_context("model"):
+            # prepare_condition on the source so the 4-tuple's encoder /
+            # context outputs have the post-condition shape downstream
+            # auto-LRC / DiT alignment scoring expects.
+            attn = torch.ones(
+                src_latents.shape[0], src_latents.shape[1],
+                device=device, dtype=dtype,
+            )
+            src_enc_hs, src_enc_am, src_ctx = handler.model.prepare_condition(
+                text_hidden_states=payload["text_hidden_states"],
+                text_attention_mask=payload["text_attention_mask"],
+                lyric_hidden_states=payload["lyric_hidden_states"],
+                lyric_attention_mask=payload["lyric_attention_mask"],
+                refer_audio_acoustic_hidden_states_packed=payload["refer_audio_acoustic_hidden_states_packed"],
+                refer_audio_order_mask=payload["refer_audio_order_mask"],
+                hidden_states=src_latents,
+                attention_mask=attn,
+                silence_latent=handler.silence_latent,
+                src_latents=src_latents,
+                chunk_masks=payload["chunk_mask"],
+                is_covers=payload["is_covers"],
+                precomputed_lm_hints_25Hz=payload.get("precomputed_lm_hints_25Hz"),
+            )
             outputs = handler.model.flowedit_generate_audio(
-                # Source raw inputs — pulled from the prepared payload.
                 text_hidden_states=payload["text_hidden_states"],
                 text_attention_mask=payload["text_attention_mask"],
                 lyric_hidden_states=payload["lyric_hidden_states"],
@@ -144,12 +103,10 @@ def dispatch_flow_edit(
                 chunk_masks=payload["chunk_mask"],
                 is_covers=payload["is_covers"],
                 silence_latent=handler.silence_latent,
-                # Target inputs — freshly tokenized and encoded above.
                 target_text_hidden_states=tar_text_hs,
                 target_text_attention_mask=tar_text_am,
                 target_lyric_hidden_states=tar_lyric_hs,
                 target_lyric_attention_mask=tar_lyric_am,
-                # Sampling
                 seed=seed_param,
                 infer_steps=generate_kwargs.get("infer_steps"),
                 timesteps=generate_kwargs.get("timesteps"),
@@ -159,11 +116,9 @@ def dispatch_flow_edit(
                 shift=generate_kwargs.get("shift", 1.0),
                 velocity_norm_threshold=generate_kwargs.get("velocity_norm_threshold", 0.0),
                 velocity_ema_factor=generate_kwargs.get("velocity_ema_factor", 0.0),
-                # Flow-edit window
                 edit_n_min=edit_n_min,
                 edit_n_max=edit_n_max,
                 edit_n_avg=edit_n_avg,
-                # Conditioning hints (forwarded to both prepare_condition calls).
                 precomputed_lm_hints_25Hz=payload.get("precomputed_lm_hints_25Hz"),
                 # v1-disabled tricks — pipeline logs them and bypasses.
                 sampler_mode=generate_kwargs.get("sampler_mode", "euler"),
@@ -171,10 +126,4 @@ def dispatch_flow_edit(
                 dcw_enabled=generate_kwargs.get("dcw_enabled", False),
             )
 
-    # Match the regular path's 4-tuple.  encoder/context tensors are the
-    # *source* condition; downstream payload assembly inspects them for
-    # latent shapes and intermediate-output stashing only.
-    enc_hs = payload["text_hidden_states"]
-    enc_am = payload["text_attention_mask"]
-    ctx = src_latents
-    return outputs, enc_hs, enc_am, ctx
+    return outputs, src_enc_hs, src_enc_am, src_ctx

--- a/acestep/core/generation/handler/service_generate_flow_edit.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit.py
@@ -108,6 +108,10 @@ def dispatch_flow_edit(
                 target_lyric_hidden_states=tar_lyric_hs,
                 target_lyric_attention_mask=tar_lyric_am,
                 seed=seed_param,
+                # Retake seed (#1157) drives flowedit's per-step
+                # forward-noise generators so variation/reproducibility
+                # works the same way it does in regular generation.
+                retake_seed=generate_kwargs.get("retake_seed"),
                 infer_steps=generate_kwargs.get("infer_steps"),
                 timesteps=generate_kwargs.get("timesteps"),
                 diffusion_guidance_scale=generate_kwargs.get("diffusion_guidance_scale", 1.0),

--- a/acestep/core/generation/handler/service_generate_flow_edit.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit.py
@@ -1,0 +1,180 @@
+"""Flow-edit dispatch path for ``task_type == "edit"`` (issue #1156).
+
+The regular generation path (``_execute_service_generate_diffusion``)
+calls ``model.generate_audio`` with a single set of text + lyric
+embeddings.  Flow-edit needs *paired* conditioning (source + target),
+so we build a fresh set of target text/lyric embeddings here using the
+handler's tokenizer + encoder, then call
+``model.flowedit_generate_audio`` with both sets.
+
+This module exists to keep ``service_generate_execute.py`` under the
+200 LOC cap while still delegating to the handler's existing tokenizer
+and encoder helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from loguru import logger
+
+from acestep.constants import DEFAULT_DIT_INSTRUCTION
+
+
+def _tokenize_target(
+    handler,
+    *,
+    target_caption: str,
+    target_lyrics: str,
+    vocal_languages: Optional[List[str]],
+    metas: Optional[List[Any]],
+    instructions: Optional[List[str]],
+    batch_size: int,
+):
+    """Build padded target text/lyric token tensors via handler helpers.
+
+    Reuses ``_prepare_text_conditioning_inputs`` so the SFT prompt format,
+    lyric language formatting, and padding stay consistent with the
+    source-side preparation.
+    """
+    captions = [target_caption] * batch_size
+    lyrics = [target_lyrics] * batch_size
+    langs = list(vocal_languages) if vocal_languages else ["unknown"] * batch_size
+    if len(langs) < batch_size:
+        langs = langs + ["unknown"] * (batch_size - len(langs))
+    parsed_metas_list = list(metas) if metas else [""] * batch_size
+    if len(parsed_metas_list) < batch_size:
+        parsed_metas_list = parsed_metas_list + [""] * (batch_size - len(parsed_metas_list))
+    instr_list = list(instructions) if instructions else [DEFAULT_DIT_INSTRUCTION] * batch_size
+    if len(instr_list) < batch_size:
+        instr_list = instr_list + [DEFAULT_DIT_INSTRUCTION] * (batch_size - len(instr_list))
+
+    (
+        _text_inputs,
+        text_token_idss,
+        text_attention_masks,
+        lyric_token_idss,
+        lyric_attention_masks,
+        _nc_text_ids,
+        _nc_text_am,
+    ) = handler._prepare_text_conditioning_inputs(
+        batch_size=batch_size,
+        instructions=instr_list,
+        captions=captions,
+        lyrics=lyrics,
+        parsed_metas=parsed_metas_list,
+        vocal_languages=langs,
+        audio_cover_strength=1.0,  # disable non-cover branch — we don't need it for edit
+    )
+    return text_token_idss, text_attention_masks, lyric_token_idss, lyric_attention_masks
+
+
+def _embed_target(
+    handler,
+    text_token_idss: torch.Tensor,
+    lyric_token_idss: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Run text + lyric encoders on the target tokens, return embedding tensors."""
+    with handler._load_model_context("text_encoder"):
+        text_hs = handler.infer_text_embeddings(text_token_idss)
+        lyric_hs = handler.infer_lyric_embeddings(lyric_token_idss)
+    return text_hs, lyric_hs
+
+
+def dispatch_flow_edit(
+    handler,
+    *,
+    payload: Dict[str, Any],
+    generate_kwargs: Dict[str, Any],
+    seed_param: Any,
+    edit_ctx: Dict[str, Any],
+) -> Tuple[Dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the flow-edit branch and return the same 4-tuple as the regular path.
+
+    Builds the target text/lyric embeddings inline (no batch_prep
+    changes), then calls ``model.flowedit_generate_audio``.  The
+    encoder-state outputs returned are the *source* ones so downstream
+    metadata persistence is unchanged from the regular path.
+    """
+    if not hasattr(handler.model, "flowedit_generate_audio"):
+        raise RuntimeError(
+            "Flow-edit (task_type='edit') requires a base DiT variant — "
+            "the loaded model does not expose flowedit_generate_audio. "
+            "Supported variants: xl_base, xl_sft, sft, base."
+        )
+    src_latents = payload["src_latents"]
+    bsz = src_latents.shape[0]
+    edit_n_min = float(edit_ctx.get("edit_n_min", 0.0))
+    edit_n_max = float(edit_ctx.get("edit_n_max", 1.0))
+    edit_n_avg = int(edit_ctx.get("edit_n_avg", 1))
+    logger.info(
+        "[flow_edit] dispatch — task=edit, bsz={}, n_min={}, n_max={}, n_avg={}",
+        bsz, edit_n_min, edit_n_max, edit_n_avg,
+    )
+
+    # Build target tokens and embeddings using the handler's tokenizer + encoder.
+    tar_text_ids, tar_text_am, tar_lyric_ids, tar_lyric_am = _tokenize_target(
+        handler,
+        target_caption=edit_ctx.get("edit_target_caption") or "",
+        target_lyrics=edit_ctx.get("edit_target_lyrics") or "",
+        vocal_languages=edit_ctx.get("vocal_languages"),
+        metas=edit_ctx.get("metas"),
+        instructions=edit_ctx.get("instructions"),
+        batch_size=bsz,
+    )
+    tar_text_hs, tar_lyric_hs = _embed_target(handler, tar_text_ids, tar_lyric_ids)
+
+    # Move tensors to the right device/dtype to match payload conventions.
+    device, dtype = src_latents.device, src_latents.dtype
+    tar_text_am = tar_text_am.to(device=device, dtype=dtype)
+    tar_lyric_am = tar_lyric_am.to(device=device, dtype=dtype)
+
+    with torch.inference_mode():
+        with handler._load_model_context("model"):
+            outputs = handler.model.flowedit_generate_audio(
+                # Source raw inputs — pulled from the prepared payload.
+                text_hidden_states=payload["text_hidden_states"],
+                text_attention_mask=payload["text_attention_mask"],
+                lyric_hidden_states=payload["lyric_hidden_states"],
+                lyric_attention_mask=payload["lyric_attention_mask"],
+                refer_audio_acoustic_hidden_states_packed=payload["refer_audio_acoustic_hidden_states_packed"],
+                refer_audio_order_mask=payload["refer_audio_order_mask"],
+                src_latents=src_latents,
+                chunk_masks=payload["chunk_mask"],
+                is_covers=payload["is_covers"],
+                silence_latent=handler.silence_latent,
+                # Target inputs — freshly tokenized and encoded above.
+                target_text_hidden_states=tar_text_hs,
+                target_text_attention_mask=tar_text_am,
+                target_lyric_hidden_states=tar_lyric_hs,
+                target_lyric_attention_mask=tar_lyric_am,
+                # Sampling
+                seed=seed_param,
+                infer_steps=generate_kwargs.get("infer_steps"),
+                timesteps=generate_kwargs.get("timesteps"),
+                diffusion_guidance_scale=generate_kwargs.get("diffusion_guidance_scale", 1.0),
+                cfg_interval_start=generate_kwargs.get("cfg_interval_start", 0.0),
+                cfg_interval_end=generate_kwargs.get("cfg_interval_end", 1.0),
+                shift=generate_kwargs.get("shift", 1.0),
+                velocity_norm_threshold=generate_kwargs.get("velocity_norm_threshold", 0.0),
+                velocity_ema_factor=generate_kwargs.get("velocity_ema_factor", 0.0),
+                # Flow-edit window
+                edit_n_min=edit_n_min,
+                edit_n_max=edit_n_max,
+                edit_n_avg=edit_n_avg,
+                # Conditioning hints (forwarded to both prepare_condition calls).
+                precomputed_lm_hints_25Hz=payload.get("precomputed_lm_hints_25Hz"),
+                # v1-disabled tricks — pipeline logs them and bypasses.
+                sampler_mode=generate_kwargs.get("sampler_mode", "euler"),
+                use_adg=generate_kwargs.get("use_adg", False),
+                dcw_enabled=generate_kwargs.get("dcw_enabled", False),
+            )
+
+    # Match the regular path's 4-tuple.  encoder/context tensors are the
+    # *source* condition; downstream payload assembly inspects them for
+    # latent shapes and intermediate-output stashing only.
+    enc_hs = payload["text_hidden_states"]
+    enc_am = payload["text_attention_mask"]
+    ctx = src_latents
+    return outputs, enc_hs, enc_am, ctx

--- a/acestep/core/generation/handler/service_generate_flow_edit_target.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_target.py
@@ -46,7 +46,15 @@ def tokenize_target(
     captions = [target_caption] * batch_size
     lyrics = [target_lyrics] * batch_size
     langs = _pad_to_batch(vocal_languages, "unknown", batch_size)
-    parsed_metas_list = _pad_to_batch(metas, "", batch_size)
+    # ``metas`` arrives here in whatever shape ``service_generate``'s
+    # ``_normalize_inputs`` left it — usually a list of dicts when the
+    # request flows through ``generate_music`` ->
+    # ``prepare_batch_data``.  The source path normalises with
+    # ``_parse_metas`` before tokenizing; if we skip it the target
+    # prompt gets a raw ``{'bpm': ...}`` repr instead of the proper
+    # ``- bpm: ...`` block, so conditioning silently drifts.
+    raw_metas = _pad_to_batch(metas, "", batch_size)
+    parsed_metas_list = handler._parse_metas(raw_metas)
     instr_list = _pad_to_batch(instructions, DEFAULT_DIT_INSTRUCTION, batch_size)
 
     (

--- a/acestep/core/generation/handler/service_generate_flow_edit_target.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_target.py
@@ -1,0 +1,90 @@
+"""Build the *target* text/lyric conditioning for flow-edit (#1156 PR-B).
+
+Source-side conditioning is already in the payload built by
+``preprocess_batch``.  Flow-edit needs a paired *target* condition
+(``edit_target_caption`` / ``edit_target_lyrics``); we tokenize and
+encode it here using the handler's existing helpers so SFT prompt
+formatting, lyric language handling, and padding stay consistent with
+the source side.
+
+Split out from ``service_generate_flow_edit.py`` per the 200 LOC cap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+import torch
+
+from acestep.constants import DEFAULT_DIT_INSTRUCTION
+
+
+def _pad_to_batch(values: Optional[List[Any]], default: Any, batch_size: int) -> List[Any]:
+    """Right-pad/copy ``values`` to ``batch_size``, falling back to ``default``."""
+    out = list(values) if values else [default] * batch_size
+    if len(out) < batch_size:
+        out = out + [default] * (batch_size - len(out))
+    return out
+
+
+def tokenize_target(
+    handler,
+    *,
+    target_caption: str,
+    target_lyrics: str,
+    vocal_languages: Optional[List[str]],
+    metas: Optional[List[Any]],
+    instructions: Optional[List[str]],
+    batch_size: int,
+):
+    """Build padded target text/lyric token tensors via handler helpers.
+
+    Reuses ``_prepare_text_conditioning_inputs`` so the SFT prompt format,
+    lyric language formatting, and padding stay consistent with the
+    source-side preparation.
+    """
+    captions = [target_caption] * batch_size
+    lyrics = [target_lyrics] * batch_size
+    langs = _pad_to_batch(vocal_languages, "unknown", batch_size)
+    parsed_metas_list = _pad_to_batch(metas, "", batch_size)
+    instr_list = _pad_to_batch(instructions, DEFAULT_DIT_INSTRUCTION, batch_size)
+
+    (
+        _text_inputs,
+        text_token_idss,
+        text_attention_masks,
+        lyric_token_idss,
+        lyric_attention_masks,
+        _nc_text_ids,
+        _nc_text_am,
+    ) = handler._prepare_text_conditioning_inputs(
+        batch_size=batch_size,
+        instructions=instr_list,
+        captions=captions,
+        lyrics=lyrics,
+        parsed_metas=parsed_metas_list,
+        vocal_languages=langs,
+        audio_cover_strength=1.0,  # disable non-cover branch — not needed for edit
+    )
+    return text_token_idss, text_attention_masks, lyric_token_idss, lyric_attention_masks
+
+
+def embed_target(
+    handler,
+    text_token_idss: torch.Tensor,
+    lyric_token_idss: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Run text + lyric encoders on the target tokens, return embedding tensors.
+
+    Tokens come back from the tokenizer on CPU; the regular batch path
+    moves them to ``handler.device`` before encoding (see
+    ``preprocess_batch``), so we mirror that here.  Without the move
+    text-encoder runs on CUDA / MPS / XPU would hit a device mismatch.
+    """
+    device = handler.device
+    text_token_idss = text_token_idss.to(device=device)
+    lyric_token_idss = lyric_token_idss.to(device=device)
+    with handler._load_model_context("text_encoder"):
+        text_hs = handler.infer_text_embeddings(text_token_idss)
+        lyric_hs = handler.infer_lyric_embeddings(lyric_token_idss)
+    return text_hs, lyric_hs

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -97,6 +97,29 @@ class DispatchFlowEditTests(unittest.TestCase):
         self.assertEqual(kwargs["edit_n_max"], 1.0)
         self.assertEqual(kwargs["edit_n_avg"], 1)
 
+    def test_dict_metas_parsed_before_tokenization(self):
+        """Regression for codex P2 round-3 finding.
+
+        Pre-fix the dispatch passed raw metas (often dicts from
+        ``prepare_batch_data``) straight into
+        ``_prepare_text_conditioning_inputs``, so target prompts got a
+        ``{'bpm': 120}`` repr instead of the parsed ``- bpm: 120`` block
+        the source path produced.  Post-fix the dispatch calls
+        ``handler._parse_metas`` first, matching the source pipeline.
+        """
+        handler = FakeHandler()
+        edit_ctx = make_edit_ctx()
+        # Real handler hands us a list of dicts here.
+        edit_ctx["metas"] = [{"bpm": 120, "key": "C minor"}]
+        dispatch_flow_edit(
+            handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
+            seed_param=None, edit_ctx=edit_ctx,
+        )
+        self.assertTrue(any(
+            isinstance(m, str) and m.startswith("PARSED:")
+            for m in handler.captured_parsed_metas
+        ), f"target metas were not parsed: {handler.captured_parsed_metas}")
+
     def test_retake_seed_forwarded_from_generate_kwargs(self):
         """Regression for codex P2 round-2 finding.
 

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -1,103 +1,35 @@
 """Unit tests for the flow-edit dispatch helper (#1156 PR-B).
 
-Verifies that:
-* ``dispatch_flow_edit`` invokes ``model.flowedit_generate_audio`` with
-  the right paired-condition kwargs (source from payload, target built
-  from ``edit_ctx``).
-* Models without ``flowedit_generate_audio`` raise a clear error.
+Regression coverage for codex round-1 P1 + 2×P2 findings:
+* device-mismatch on CUDA / MPS / XPU (token IDs not moved off CPU)
+* dispatch returning raw embeddings instead of ``prepare_condition``
+  outputs (breaks downstream auto-LRC / DiT alignment scoring)
+* LM Phase 1 still ran in edit mode (replaced src_audio with codes)
 """
 
 import unittest
-from contextlib import contextmanager
-from unittest.mock import MagicMock
 
 import torch
 
 from acestep.core.generation.handler.service_generate_flow_edit import (
     dispatch_flow_edit,
 )
-
-
-class _FakeHandler:
-    """Minimal handler stand-in that exposes the surface ``dispatch_flow_edit`` needs."""
-
-    def __init__(self, model_has_flowedit: bool = True):
-        self.model = MagicMock()
-        if not model_has_flowedit:
-            del self.model.flowedit_generate_audio
-        else:
-            self.model.flowedit_generate_audio.return_value = {
-                "target_latents": torch.zeros(1, 8, 16),
-                "time_costs": {},
-            }
-        self.silence_latent = torch.zeros(1, 8, 16)
-
-    @contextmanager
-    def _load_model_context(self, name):
-        yield
-
-    def _prepare_text_conditioning_inputs(self, *, batch_size, instructions,
-                                          captions, lyrics, parsed_metas,
-                                          vocal_languages, audio_cover_strength):
-        # Return fake padded tensors matching the contract.
-        seq = 4
-        return (
-            ["fake-text-input"] * batch_size,
-            torch.zeros(batch_size, seq, dtype=torch.long),
-            torch.ones(batch_size, seq),
-            torch.zeros(batch_size, seq, dtype=torch.long),
-            torch.ones(batch_size, seq),
-            None, None,
-        )
-
-    def infer_text_embeddings(self, ids):
-        return torch.zeros(ids.shape[0], ids.shape[1], 16)
-
-    def infer_lyric_embeddings(self, ids):
-        return torch.zeros(ids.shape[0], ids.shape[1], 16)
-
-
-def _make_payload(bsz: int = 1, seq: int = 8, ch: int = 16):
-    return {
-        "src_latents": torch.randn(bsz, seq, ch),
-        "text_hidden_states": torch.randn(bsz, 4, ch),
-        "text_attention_mask": torch.ones(bsz, 4),
-        "lyric_hidden_states": torch.randn(bsz, 4, ch),
-        "lyric_attention_mask": torch.ones(bsz, 4),
-        "refer_audio_acoustic_hidden_states_packed": torch.zeros(0, 4, ch),
-        "refer_audio_order_mask": torch.zeros(0, dtype=torch.long),
-        "chunk_mask": torch.ones(bsz, seq, ch),
-        "is_covers": torch.zeros(bsz, dtype=torch.long),
-        "precomputed_lm_hints_25Hz": None,
-    }
-
-
-def _make_edit_ctx(target_caption="my new caption", target_lyrics="new lyrics"):
-    return {
-        "task_type": "edit",
-        "edit_target_caption": target_caption,
-        "edit_target_lyrics": target_lyrics,
-        "vocal_languages": ["en"],
-        "metas": [""],
-        "instructions": ["Fill the audio semantic mask based on the given conditions:"],
-        "edit_n_min": 0.2,
-        "edit_n_max": 0.8,
-        "edit_n_avg": 1,
-    }
+from acestep.core.generation.handler._flow_edit_dispatch_test_support import (
+    FakeHandler,
+    make_edit_ctx,
+    make_payload,
+)
 
 
 class DispatchFlowEditTests(unittest.TestCase):
 
     def test_calls_flowedit_with_paired_conditions(self):
-        handler = _FakeHandler()
-        payload = _make_payload()
-        edit_ctx = _make_edit_ctx()
-
+        handler = FakeHandler()
+        payload = make_payload()
         dispatch_flow_edit(
             handler, payload=payload, generate_kwargs={"infer_steps": 4},
-            seed_param=42, edit_ctx=edit_ctx,
+            seed_param=42, edit_ctx=make_edit_ctx(),
         )
-
         self.assertEqual(handler.model.flowedit_generate_audio.call_count, 1)
         call_kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
         # Source side comes from payload.
@@ -112,42 +44,71 @@ class DispatchFlowEditTests(unittest.TestCase):
         self.assertEqual(call_kwargs["edit_n_avg"], 1)
         self.assertEqual(call_kwargs["seed"], 42)
 
-    def test_returns_4_tuple_with_source_encoder_state(self):
-        handler = _FakeHandler()
-        payload = _make_payload()
-        out = dispatch_flow_edit(
-            handler, payload=payload, generate_kwargs={"infer_steps": 4},
-            seed_param=None, edit_ctx=_make_edit_ctx(),
+    def test_returns_prepare_condition_tensors_not_raw_embeddings(self):
+        """Regression for codex P2 round-1 finding."""
+        handler = FakeHandler()
+        outputs, enc_hs, enc_am, ctx = dispatch_flow_edit(
+            handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
+            seed_param=None, edit_ctx=make_edit_ctx(),
         )
-        outputs, enc_hs, enc_am, ctx = out
         self.assertIn("target_latents", outputs)
-        # Source encoder state passed through unchanged so downstream
-        # metadata persistence still sees the source-side view.
-        self.assertIs(enc_hs, payload["text_hidden_states"])
-        self.assertIs(enc_am, payload["text_attention_mask"])
-        self.assertIs(ctx, payload["src_latents"])
+        # Sentinel-7 tensors come from the mocked prepare_condition.
+        self.assertIs(enc_hs, handler.prepared_enc_hs)
+        self.assertIs(enc_am, handler.prepared_enc_am)
+        self.assertIs(ctx, handler.prepared_ctx)
 
     def test_missing_flowedit_method_raises(self):
-        handler = _FakeHandler(model_has_flowedit=False)
+        handler = FakeHandler(model_has_flowedit=False)
         with self.assertRaises(RuntimeError) as cm:
             dispatch_flow_edit(
-                handler, payload=_make_payload(),
+                handler, payload=make_payload(),
                 generate_kwargs={"infer_steps": 4}, seed_param=None,
-                edit_ctx=_make_edit_ctx(),
+                edit_ctx=make_edit_ctx(),
             )
         self.assertIn("flowedit_generate_audio", str(cm.exception))
 
+    def test_token_ids_moved_to_handler_device(self):
+        """Regression for codex P1 round-1 finding."""
+        handler = FakeHandler()
+        captured_device = []
+
+        def _capture(ids):
+            captured_device.append(ids.device)
+            return torch.zeros(ids.shape[0], ids.shape[1], 16)
+
+        handler.infer_text_embeddings = _capture
+        handler.infer_lyric_embeddings = _capture
+        dispatch_flow_edit(
+            handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
+            seed_param=None, edit_ctx=make_edit_ctx(),
+        )
+        self.assertEqual(len(captured_device), 2)
+        for d in captured_device:
+            self.assertEqual(d, handler.device)
+
     def test_default_window_params_when_missing(self):
-        handler = _FakeHandler()
-        # Empty edit_ctx (other than task_type) should default to full window.
-        out = dispatch_flow_edit(
-            handler, payload=_make_payload(), generate_kwargs={"infer_steps": 4},
+        handler = FakeHandler()
+        dispatch_flow_edit(
+            handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
             seed_param=None, edit_ctx={"task_type": "edit"},
         )
         kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
         self.assertEqual(kwargs["edit_n_min"], 0.0)
         self.assertEqual(kwargs["edit_n_max"], 1.0)
         self.assertEqual(kwargs["edit_n_avg"], 1)
+
+
+class EditSkipsLmPhaseTests(unittest.TestCase):
+    """Verify ``inference.generate_music`` skips LM Phase 1 for ``edit``."""
+
+    def test_edit_in_skip_lm_tasks_set(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[3] / "inference.py").read_text()
+        self.assertIn(
+            'skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract", "edit"}',
+            src,
+            "edit must be in skip_lm_tasks so LM Phase 1 doesn't replace src_audio",
+        )
 
 
 if __name__ == "__main__":

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -1,0 +1,154 @@
+"""Unit tests for the flow-edit dispatch helper (#1156 PR-B).
+
+Verifies that:
+* ``dispatch_flow_edit`` invokes ``model.flowedit_generate_audio`` with
+  the right paired-condition kwargs (source from payload, target built
+  from ``edit_ctx``).
+* Models without ``flowedit_generate_audio`` raise a clear error.
+"""
+
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import torch
+
+from acestep.core.generation.handler.service_generate_flow_edit import (
+    dispatch_flow_edit,
+)
+
+
+class _FakeHandler:
+    """Minimal handler stand-in that exposes the surface ``dispatch_flow_edit`` needs."""
+
+    def __init__(self, model_has_flowedit: bool = True):
+        self.model = MagicMock()
+        if not model_has_flowedit:
+            del self.model.flowedit_generate_audio
+        else:
+            self.model.flowedit_generate_audio.return_value = {
+                "target_latents": torch.zeros(1, 8, 16),
+                "time_costs": {},
+            }
+        self.silence_latent = torch.zeros(1, 8, 16)
+
+    @contextmanager
+    def _load_model_context(self, name):
+        yield
+
+    def _prepare_text_conditioning_inputs(self, *, batch_size, instructions,
+                                          captions, lyrics, parsed_metas,
+                                          vocal_languages, audio_cover_strength):
+        # Return fake padded tensors matching the contract.
+        seq = 4
+        return (
+            ["fake-text-input"] * batch_size,
+            torch.zeros(batch_size, seq, dtype=torch.long),
+            torch.ones(batch_size, seq),
+            torch.zeros(batch_size, seq, dtype=torch.long),
+            torch.ones(batch_size, seq),
+            None, None,
+        )
+
+    def infer_text_embeddings(self, ids):
+        return torch.zeros(ids.shape[0], ids.shape[1], 16)
+
+    def infer_lyric_embeddings(self, ids):
+        return torch.zeros(ids.shape[0], ids.shape[1], 16)
+
+
+def _make_payload(bsz: int = 1, seq: int = 8, ch: int = 16):
+    return {
+        "src_latents": torch.randn(bsz, seq, ch),
+        "text_hidden_states": torch.randn(bsz, 4, ch),
+        "text_attention_mask": torch.ones(bsz, 4),
+        "lyric_hidden_states": torch.randn(bsz, 4, ch),
+        "lyric_attention_mask": torch.ones(bsz, 4),
+        "refer_audio_acoustic_hidden_states_packed": torch.zeros(0, 4, ch),
+        "refer_audio_order_mask": torch.zeros(0, dtype=torch.long),
+        "chunk_mask": torch.ones(bsz, seq, ch),
+        "is_covers": torch.zeros(bsz, dtype=torch.long),
+        "precomputed_lm_hints_25Hz": None,
+    }
+
+
+def _make_edit_ctx(target_caption="my new caption", target_lyrics="new lyrics"):
+    return {
+        "task_type": "edit",
+        "edit_target_caption": target_caption,
+        "edit_target_lyrics": target_lyrics,
+        "vocal_languages": ["en"],
+        "metas": [""],
+        "instructions": ["Fill the audio semantic mask based on the given conditions:"],
+        "edit_n_min": 0.2,
+        "edit_n_max": 0.8,
+        "edit_n_avg": 1,
+    }
+
+
+class DispatchFlowEditTests(unittest.TestCase):
+
+    def test_calls_flowedit_with_paired_conditions(self):
+        handler = _FakeHandler()
+        payload = _make_payload()
+        edit_ctx = _make_edit_ctx()
+
+        dispatch_flow_edit(
+            handler, payload=payload, generate_kwargs={"infer_steps": 4},
+            seed_param=42, edit_ctx=edit_ctx,
+        )
+
+        self.assertEqual(handler.model.flowedit_generate_audio.call_count, 1)
+        call_kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
+        # Source side comes from payload.
+        self.assertIs(call_kwargs["text_hidden_states"], payload["text_hidden_states"])
+        self.assertIs(call_kwargs["src_latents"], payload["src_latents"])
+        # Target side was built fresh.
+        self.assertIsNotNone(call_kwargs["target_text_hidden_states"])
+        self.assertIsNotNone(call_kwargs["target_lyric_hidden_states"])
+        # Window params propagated.
+        self.assertEqual(call_kwargs["edit_n_min"], 0.2)
+        self.assertEqual(call_kwargs["edit_n_max"], 0.8)
+        self.assertEqual(call_kwargs["edit_n_avg"], 1)
+        self.assertEqual(call_kwargs["seed"], 42)
+
+    def test_returns_4_tuple_with_source_encoder_state(self):
+        handler = _FakeHandler()
+        payload = _make_payload()
+        out = dispatch_flow_edit(
+            handler, payload=payload, generate_kwargs={"infer_steps": 4},
+            seed_param=None, edit_ctx=_make_edit_ctx(),
+        )
+        outputs, enc_hs, enc_am, ctx = out
+        self.assertIn("target_latents", outputs)
+        # Source encoder state passed through unchanged so downstream
+        # metadata persistence still sees the source-side view.
+        self.assertIs(enc_hs, payload["text_hidden_states"])
+        self.assertIs(enc_am, payload["text_attention_mask"])
+        self.assertIs(ctx, payload["src_latents"])
+
+    def test_missing_flowedit_method_raises(self):
+        handler = _FakeHandler(model_has_flowedit=False)
+        with self.assertRaises(RuntimeError) as cm:
+            dispatch_flow_edit(
+                handler, payload=_make_payload(),
+                generate_kwargs={"infer_steps": 4}, seed_param=None,
+                edit_ctx=_make_edit_ctx(),
+            )
+        self.assertIn("flowedit_generate_audio", str(cm.exception))
+
+    def test_default_window_params_when_missing(self):
+        handler = _FakeHandler()
+        # Empty edit_ctx (other than task_type) should default to full window.
+        out = dispatch_flow_edit(
+            handler, payload=_make_payload(), generate_kwargs={"infer_steps": 4},
+            seed_param=None, edit_ctx={"task_type": "edit"},
+        )
+        kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
+        self.assertEqual(kwargs["edit_n_min"], 0.0)
+        self.assertEqual(kwargs["edit_n_max"], 1.0)
+        self.assertEqual(kwargs["edit_n_avg"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -97,6 +97,24 @@ class DispatchFlowEditTests(unittest.TestCase):
         self.assertEqual(kwargs["edit_n_max"], 1.0)
         self.assertEqual(kwargs["edit_n_avg"], 1)
 
+    def test_retake_seed_forwarded_from_generate_kwargs(self):
+        """Regression for codex P2 round-2 finding.
+
+        Pre-fix the dispatch only forwarded the main ``seed`` and dropped
+        ``retake_seed`` from ``generate_kwargs``, so retake variation /
+        reproducibility silently fell back to the main seed under
+        ``task_type="edit"``.
+        """
+        handler = FakeHandler()
+        dispatch_flow_edit(
+            handler, payload=make_payload(),
+            generate_kwargs={"infer_steps": 4, "retake_seed": [99, 100]},
+            seed_param=42, edit_ctx=make_edit_ctx(),
+        )
+        kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
+        self.assertEqual(kwargs["seed"], 42)
+        self.assertEqual(kwargs["retake_seed"], [99, 100])
+
 
 class EditSkipsLmPhaseTests(unittest.TestCase):
     """Verify ``inference.generate_music`` skips LM Phase 1 for ``edit``."""

--- a/acestep/core/generation/handler/task_utils.py
+++ b/acestep/core/generation/handler/task_utils.py
@@ -96,6 +96,8 @@ class TaskUtilsMixin:
                     TRACK_CLASSES=" | ".join(track_classes_upper)
                 )
             return TASK_INSTRUCTIONS["complete_default"]
+        if task_type == "edit":
+            return TASK_INSTRUCTIONS["edit"]
         return TASK_INSTRUCTIONS["text2music"]
 
     def determine_task_type(self, task_type, audio_code_string):

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -439,7 +439,11 @@ def generate_music(
         # and don't need LM to generate audio codes or metadata.
         # For extract tasks, LLM-generated captions can conflict with the extract instruction
         # and cause the DiT model to reconstruct input audio instead of extracting stems.
-        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract"}
+        # Flow-edit (#1156) needs the user's source audio verbatim; running
+        # LM Phase 1 would replace ``audio_code_string_to_use`` and the
+        # handler would feed the LM-generated codes as source instead of
+        # ``src_audio``.  Add ``edit`` here to keep the source path clean.
+        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract", "edit"}
         
         # Determine if we should use LLM
         # LLM is needed for:

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -165,6 +165,16 @@ class GenerationParams:
     # retake_variance=0 is a no-op; the retake_seed is only consumed when variance>0.
     retake_seed: Optional[Union[str, int]] = None
     retake_variance: float = 0.0
+    # Flow-edit (issue #1156): morph the source toward a new prompt/lyrics by
+    # integrating V_delta = V_tar - V_src over [edit_n_min, edit_n_max].
+    # Activated only when ``task_type == "edit"``; supported on the four
+    # base DiT variants (xl_base / xl_sft / sft / base).  v1 disables
+    # DCW / heun / ADG inside the loop — see #1156 for the follow-up plan.
+    edit_target_caption: str = ""
+    edit_target_lyrics: str = ""
+    edit_n_min: float = 0.0
+    edit_n_max: float = 1.0
+    edit_n_avg: int = 1
     audio_cover_strength: float = 1.0
     cover_noise_strength: float = 0.0  # 0=pure noise (no cover), 1=closest to src audio
 
@@ -655,6 +665,11 @@ def generate_music(
             "repaint_strength": params.repaint_strength,
             "retake_seed": params.retake_seed,
             "retake_variance": params.retake_variance,
+            "edit_target_caption": params.edit_target_caption,
+            "edit_target_lyrics": params.edit_target_lyrics,
+            "edit_n_min": params.edit_n_min,
+            "edit_n_max": params.edit_n_max,
+            "edit_n_avg": params.edit_n_avg,
             "instruction": params.instruction,
             "audio_cover_strength": params.audio_cover_strength,
             "cover_noise_strength": params.cover_noise_strength,


### PR DESCRIPTION
## Summary

Builds on the merged #1162 math layer.  Adds the dispatch path so flow-edit (#1156) is reachable end-to-end via the Python API.  Gradio UI is **PR-C**.

After this lands a developer can:

\`\`\`python
from acestep.inference import GenerationParams, generate_music
params = GenerationParams(
    task_type=\"edit\",
    src_audio=\"input.wav\",
    caption=\"original style description\",
    lyrics=\"original lyrics\",
    edit_target_caption=\"new style\",
    edit_target_lyrics=\"new lyrics\",
    edit_n_min=0.2, edit_n_max=0.8, edit_n_avg=1,
)
\`\`\`

…and the loaded model (xl_base / xl_sft / sft / base) routes to \`flowedit_generate_audio\` instead of regular generation.

## Surface

| File | What changes |
|---|---|
| \`constants.py\` | \`edit\` joins TASK_TYPES + TASK_TYPES_BASE; new TASK_INSTRUCTIONS entry |
| \`inference.GenerationParams\` | 5 new fields, forwarded in \`dit_generate_kwargs\` |
| \`handler.generate_music\` | accepts edit params, threads to service_generate; src-audio required, duration locked, warning when target prompt+lyrics empty |
| \`task_utils.generate_instruction\` | returns edit instruction |
| \`service_generate.service_generate\` | accepts edit params, builds \`edit_ctx\` dict |
| \`service_generate_execute._execute_service_generate_diffusion\` | routes to new dispatch module when \`task_type==\"edit\"\` |
| **NEW** \`service_generate_flow_edit.dispatch_flow_edit\` | builds target text/lyric embeddings inline (reuses existing tokenizer + encoder helpers), calls \`model.flowedit_generate_audio\` |

## Mutual exclusion

* \`task_type==\"edit\"\` requires \`src_audio\` (joins existing \`_src_audio_required_tasks\` set)
* duration locked to source audio length (matches cover/repaint/lego/extract behaviour)
* repaint_start/end ignored with a single info log if non-default
* Empty target caption + lyrics warns once (output will closely match source)

## Tests

* \`service_generate_flow_edit_test.py\` — 4 unit tests on dispatch:
  - paired-condition wiring (source from payload, target from edit_ctx)
  - return-tuple contract (source-side encoder state passed through)
  - missing \`flowedit_generate_audio\` guards with clear error
  - default window params when edit_ctx is sparse
* All existing \`generate_music_test\` / \`retake_test\` / flow_edit tests still pass (49 total)

\`\`\`
$ python -m unittest discover -s acestep/core/generation/handler -p '*_test.py'
Ran 288 tests — only 3 pre-existing failures from main
\`\`\`

## Module size

* \`service_generate_flow_edit.py\` 180 LOC (under cap)
* \`service_generate.py\` trimmed from 197→168 (compacted docstring; my change was net +14, but I removed a 35-line stale Args block while I was in there)
* \`service_generate_execute.py\` ~262 (was 254 on main; added 16 lines for the edit branch.  This file pre-existed over the cap; not a fix-on-PR target)
* \`generate_music.py\` ~487 (was 460+ on main, similar pre-existing condition; +12 LOC for edit guards)

## Out of scope (deferred)

- **Gradio UI** — Edit tab + wiring is PR-C
- **VRAM preflight 4×** — current preflight uses a fixed factor.  Paired CFG ≈ 4× decoder forwards/step; needs a per-task adjustment.  Filing as a follow-up so this PR stays focused on dispatch correctness
- **MLX backend** — flow-edit is PyTorch-only in v1; the dispatch raises a clear error if MLX is attempted (the helper checks for \`flowedit_generate_audio\`, which only the PyTorch base variants expose)
- **HTTP \`/release_task\` API exposure** — follow the retake precedent

## Risk

Medium.  The dispatch path is new but the math layer it calls (#1162) was already validated by 27 tests.  The biggest exposure is in the conditioning-pipeline reuse — \`_prepare_text_conditioning_inputs\` is called twice now per edit request (once in \`prepare_batch\` for source, once in \`dispatch_flow_edit\` for target).  Token-equivalent target prompts will be tokenized identically; mismatches would surface as embedding shape mismatches (caught by the model's strict shape check inside \`flowedit_generate_audio\`).

A real-audio smoke test on jieyue follows in a separate commit before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "edit" generation mode: users can supply target caption/lyrics and edit-range controls (min/max/avg).
  * Edit mode preserves source audio by default and requires source input when applicable.
  * Sensible defaults applied when edit-range or targets are omitted; warnings surface for empty targets.

* **Tests**
  * Added comprehensive unit tests and test helpers covering the new edit flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->