### PR TITLE
Fix MLX DiT static buffers across Gradio worker threads

### DIFF
--- a/acestep/core/generation/handler/mlx_dit_init.py
+++ b/acestep/core/generation/handler/mlx_dit_init.py
@@ -27,6 +27,7 @@ class MlxDitInitMixin:
 
             mlx_decoder = MLXDiTDecoder.from_config(self.config)
             convert_and_load(self.model, mlx_decoder)
+            mlx_decoder.materialize_static_buffers()
             self.mlx_decoder = mlx_decoder
             self.use_mlx_dit = True
             self.mlx_dit_compiled = compile_model

--- a/acestep/core/generation/handler/mlx_dit_init_test.py
+++ b/acestep/core/generation/handler/mlx_dit_init_test.py
@@ -70,11 +70,12 @@ class MlxDitInitMixinTests(unittest.TestCase):
         host = _DitHost()
         fake_mlx = types.ModuleType("acestep.models.mlx")
         fake_mlx.mlx_available = lambda: True
+        fake_decoder = Mock()
         fake_dit_model = types.ModuleType("acestep.models.mlx.dit_model")
         fake_dit_model.MLXDiTDecoder = type(
             "FakeDecoder",
             (),
-            {"from_config": classmethod(lambda _cls, _cfg: object())},
+            {"from_config": classmethod(lambda _cls, _cfg: fake_decoder)},
         )
         fake_dit_convert = types.ModuleType("acestep.models.mlx.dit_convert")
         fake_dit_convert.convert_and_load = Mock()
@@ -89,7 +90,9 @@ class MlxDitInitMixinTests(unittest.TestCase):
             self.assertTrue(host._init_mlx_dit(compile_model=True))
         self.assertTrue(host.use_mlx_dit)
         self.assertTrue(host.mlx_dit_compiled)
-        fake_dit_convert.convert_and_load.assert_called_once()
+        fake_dit_convert.convert_and_load.assert_called_once_with(host.model, fake_decoder)
+        fake_decoder.materialize_static_buffers.assert_called_once_with()
+        self.assertIs(host.mlx_decoder, fake_decoder)
 
 
 if __name__ == "__main__":

--- a/acestep/models/mlx/dit_model.py
+++ b/acestep/models/mlx/dit_model.py
@@ -83,6 +83,14 @@ class MLXRotaryEmbedding(nn.Module):
         sin = self._sin[:seq_len][None, None, :, :]
         return cos, sin
 
+    def materialize_static_buffers(self) -> None:
+        """Materialize cached RoPE tables on the current MLX stream.
+
+        The tables are not MLX module parameters, so parameter-only evaluation
+        does not force them before Gradio worker threads reuse the decoder.
+        """
+        mx.eval(self._cos, self._sin)
+
 
 # ---------------------------------------------------------------------------
 # Cross-Attention KV Cache
@@ -506,16 +514,24 @@ class MLXDiTDecoder(nn.Module):
         self.scale_shift_table = mx.zeros((1, 2, inner_dim))
 
         # Pre-compute sliding window mask (will be set on first forward)
-        self._sliding_masks: dict[int, mx.array] = {}
+        self._sliding_masks: dict[tuple[int, str], mx.array] = {}
         self._sliding_window = sliding_window
         self._layer_types = layer_types
 
+    def materialize_static_buffers(self) -> None:
+        """Materialize non-parameter MLX buffers before cross-thread use."""
+        self.rotary_emb.materialize_static_buffers()
+
     def _get_sliding_mask(self, seq_len: int, dtype: mx.Dtype) -> mx.array:
-        if seq_len not in self._sliding_masks:
-            self._sliding_masks[seq_len] = _create_sliding_window_mask(
+        """Return a materialized sliding-window mask for the requested sequence length."""
+        key = (seq_len, str(dtype))
+        if key not in self._sliding_masks:
+            mask = _create_sliding_window_mask(
                 seq_len, self._sliding_window, dtype
             )
-        return self._sliding_masks[seq_len]
+            mx.eval(mask)
+            self._sliding_masks[key] = mask
+        return self._sliding_masks[key]
 
     def __call__(
         self,

--- a/acestep/models/mlx/dit_model_static_buffers_test.py
+++ b/acestep/models/mlx/dit_model_static_buffers_test.py
@@ -1,0 +1,152 @@
+"""Tests for MLX DiT static buffer materialization."""
+
+import concurrent.futures
+import importlib.util
+import unittest
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("mlx.core") is not None,
+    "MLX is only available on supported Apple Silicon environments.",
+)
+class MLXStaticBufferMaterializationTests(unittest.TestCase):
+    """Regression coverage for MLX static buffers used from worker threads."""
+
+    def test_rotary_buffers_materialized_before_worker_thread_eval(self):
+        """Materialized RoPE tables can be sliced and evaluated in a worker."""
+        import mlx.core as mx
+
+        from acestep.models.mlx.dit_model import MLXRotaryEmbedding
+
+        rotary_emb = MLXRotaryEmbedding(head_dim=16, max_len=128)
+        rotary_emb.materialize_static_buffers()
+
+        def _worker_eval():
+            cos, sin = rotary_emb(32)
+            mx.eval(cos, sin)
+            return cos.shape, sin.shape
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            cos_shape, sin_shape = executor.submit(_worker_eval).result(timeout=10)
+
+        self.assertEqual(cos_shape, (1, 1, 32, 16))
+        self.assertEqual(sin_shape, (1, 1, 32, 16))
+
+    def test_decoder_static_buffer_materialization_is_idempotent(self):
+        """Decoder-level materialization delegates safely across repeated calls."""
+        from acestep.models.mlx.dit_model import MLXDiTDecoder
+
+        decoder = MLXDiTDecoder(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=16,
+            in_channels=96,
+            audio_acoustic_hidden_dim=64,
+            sliding_window=8,
+            max_position_embeddings=128,
+        )
+
+        decoder.materialize_static_buffers()
+        decoder.materialize_static_buffers()
+        self.assertIsNotNone(decoder.rotary_emb)
+
+    def test_decoder_forward_runs_from_worker_after_materialization(self):
+        """Materialized decoder static buffers support worker-thread forward passes."""
+        import mlx.core as mx
+
+        from acestep.models.mlx.dit_model import MLXDiTDecoder
+
+        decoder = MLXDiTDecoder(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=16,
+            in_channels=96,
+            audio_acoustic_hidden_dim=64,
+            sliding_window=8,
+            max_position_embeddings=128,
+            layer_types=["sliding_attention", "full_attention"],
+        )
+        mx.eval(decoder.parameters())
+        decoder.materialize_static_buffers()
+
+        hidden_states = mx.random.normal((1, 8, 64))
+        context_latents = mx.random.normal((1, 8, 32))
+        encoder_hidden_states = mx.random.normal((1, 4, 32))
+        timestep = mx.full((1,), 1.0)
+        mx.eval(hidden_states, context_latents, encoder_hidden_states, timestep)
+
+        def _worker_forward():
+            out, _ = decoder(
+                hidden_states=hidden_states,
+                timestep=timestep,
+                timestep_r=timestep,
+                encoder_hidden_states=encoder_hidden_states,
+                context_latents=context_latents,
+                cache=None,
+                use_cache=False,
+            )
+            mx.eval(out)
+            return out.shape
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            self.assertEqual(executor.submit(_worker_forward).result(timeout=20), (1, 8, 64))
+
+    def test_sliding_mask_cache_is_materialized_for_worker_reuse(self):
+        """Cached sliding masks can be evaluated safely from worker threads."""
+        import mlx.core as mx
+
+        from acestep.models.mlx.dit_model import MLXDiTDecoder
+
+        decoder = MLXDiTDecoder(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=16,
+            in_channels=96,
+            audio_acoustic_hidden_dim=64,
+            sliding_window=8,
+            max_position_embeddings=128,
+            layer_types=["sliding_attention"],
+        )
+        mask = decoder._get_sliding_mask(8, mx.float32)
+
+        def _worker_eval():
+            mx.eval(mask)
+            return mask.shape
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            self.assertEqual(executor.submit(_worker_eval).result(timeout=10), (1, 1, 8, 8))
+
+    def test_sliding_mask_cache_keys_by_dtype(self):
+        """Sliding mask cache keeps separate entries for different MLX dtypes."""
+        import mlx.core as mx
+
+        from acestep.models.mlx.dit_model import MLXDiTDecoder
+
+        decoder = MLXDiTDecoder(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=16,
+            in_channels=96,
+            audio_acoustic_hidden_dim=64,
+            sliding_window=8,
+            max_position_embeddings=128,
+            layer_types=["sliding_attention"],
+        )
+        mask_f32 = decoder._get_sliding_mask(8, mx.float32)
+        mask_f16 = decoder._get_sliding_mask(8, mx.float16)
+        mx.eval(mask_f32, mask_f16)
+
+        self.assertEqual(mask_f32.dtype, mx.float32)
+        self.assertEqual(mask_f16.dtype, mx.float16)


### PR DESCRIPTION
## Summary
- Materialize MLX DiT RoPE static buffers immediately after conversion/loading so Gradio worker threads do not evaluate lazy arrays created on another stream.
- Materialize cached sliding-window masks on insertion and key them by sequence length and dtype.
- Add Apple Silicon MLX regression coverage for worker-thread buffer reuse and init-time materialization.

Fixes #1161

## Validation
- `uv run python -m unittest acestep.models.mlx.dit_model_static_buffers_test acestep.core.generation.handler.mlx_dit_init_test`
- `git diff --check`
- Claude Code review: No blocking findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved MLX model initialization to properly materialize static buffers, ensuring more reliable performance in multithreaded execution environments. Enhanced cache handling for sliding-window attention with better type-specific caching and eager evaluation.

* **Tests**
  * Added comprehensive test suite for MLX static buffer materialization, covering multithreaded inference scenarios, cache behavior, and buffer initialization stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->