### PR TITLE
feat(flow-edit): add turbo + XL-turbo support to flow-edit (PR-D)

### DIFF
--- a/acestep/models/common/turbo_schedule.py
+++ b/acestep/models/common/turbo_schedule.py
@@ -13,9 +13,12 @@ the list this module returns.
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    import torch
 
 # Discrete shift values supported by the turbo distillation.
 VALID_TURBO_SHIFTS: List[float] = [1.0, 2.0, 3.0]
@@ -60,7 +63,7 @@ def build_turbo_timestep_schedule(
     *,
     infer_steps: Optional[int] = None,
     shift: float = 3.0,
-    timesteps: Optional[Union[Sequence[float], "torch.Tensor"]] = None,
+    timesteps: Optional[Union[Sequence[float], torch.Tensor]] = None,
 ) -> List[float]:
     """Return the turbo timestep schedule (without the trailing 0).
 

--- a/acestep/models/common/turbo_schedule.py
+++ b/acestep/models/common/turbo_schedule.py
@@ -1,0 +1,121 @@
+"""Turbo-variant timestep schedule construction (#1156 PR-D).
+
+Turbo / XL-turbo DiT variants are CFG-distilled and use a fixed
+``fix_nfe=8`` table mapped onto discrete shift values (1.0, 2.0, 3.0).
+The regular ``generate_audio`` path on those variants computes the
+schedule inline using the constants here; the new flow-edit delegate
+needs the same logic, so we centralise it.
+
+The shared :func:`flow_edit_helpers.build_timestep_schedule` accepts a
+``timesteps`` tensor and pads a trailing zero, so callers just hand it
+the list this module returns.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Union
+
+from loguru import logger
+
+# Discrete shift values supported by the turbo distillation.
+VALID_TURBO_SHIFTS: List[float] = [1.0, 2.0, 3.0]
+
+# Union of the 8-step schedules for shift ∈ {1, 2, 3} — 20 unique values.
+# Used to snap user-supplied custom timesteps to the nearest trained
+# value (training only saw these specific schedules).
+VALID_TURBO_TIMESTEPS: List[float] = [
+    1.0, 0.9545454545454546, 0.9333333333333333, 0.9, 0.875,
+    0.8571428571428571, 0.8333333333333334, 0.7692307692307693, 0.75,
+    0.6666666666666666, 0.6428571428571429, 0.625, 0.5454545454545454,
+    0.5, 0.4, 0.375, 0.3, 0.25, 0.2222222222222222, 0.125,
+]
+
+# Fixed 8-step schedules per shift (excluding the trailing 0 — callers
+# add it themselves where needed).
+TURBO_SHIFT_TIMESTEPS = {
+    1.0: [1.0, 0.875, 0.75, 0.625, 0.5, 0.375, 0.25, 0.125],
+    2.0: [
+        1.0, 0.9333333333333333, 0.8571428571428571, 0.7692307692307693,
+        0.6666666666666666, 0.5454545454545454, 0.4, 0.2222222222222222,
+    ],
+    3.0: [
+        1.0, 0.9545454545454546, 0.9, 0.8333333333333334, 0.75,
+        0.6428571428571429, 0.5, 0.3,
+    ],
+}
+
+
+def _snap_timesteps(values: Sequence[float]) -> List[float]:
+    """Map each value to the nearest entry in ``VALID_TURBO_TIMESTEPS``."""
+    snapped = [min(VALID_TURBO_TIMESTEPS, key=lambda x: abs(x - t)) for t in values]
+    if list(values) != snapped:
+        logger.warning(
+            "[turbo_schedule] timesteps mapped to nearest valid values: %s -> %s",
+            list(values), snapped,
+        )
+    return snapped
+
+
+def build_turbo_timestep_schedule(
+    *,
+    infer_steps: Optional[int] = None,
+    shift: float = 3.0,
+    timesteps: Optional[Union[Sequence[float], "torch.Tensor"]] = None,
+) -> List[float]:
+    """Return the turbo timestep schedule (without the trailing 0).
+
+    Mirrors the inline logic in turbo / xl_turbo ``generate_audio``:
+
+    1. If ``timesteps`` is supplied, drop trailing zeros, clamp length
+       to 20, and snap each value to ``VALID_TURBO_TIMESTEPS``.
+    2. Else if ``infer_steps`` is set, build a linspace-style schedule
+       of length ``min(infer_steps, 20)`` and apply the shift transform.
+    3. Else use the fixed ``TURBO_SHIFT_TIMESTEPS[round_to_valid(shift)]``.
+    """
+    # Case 1: explicit timesteps.
+    if timesteps is not None:
+        try:
+            ts_list = timesteps.tolist()  # type: ignore[union-attr]
+        except AttributeError:
+            ts_list = list(timesteps)
+        # Drop trailing zeros (the loop appends one itself).
+        while ts_list and ts_list[-1] == 0:
+            ts_list.pop()
+        if not ts_list:
+            logger.warning(
+                "[turbo_schedule] empty timesteps after stripping zeros; "
+                "falling back to shift=%.1f schedule",
+                shift,
+            )
+        else:
+            if len(ts_list) > 20:
+                logger.warning(
+                    "[turbo_schedule] timesteps length=%d exceeds maximum 20; "
+                    "truncating.",
+                    len(ts_list),
+                )
+                ts_list = ts_list[:20]
+            return _snap_timesteps(ts_list)
+
+    # Case 2: variable-step linspace + shift transform (matches the
+    # per-step schedule in turbo's ``generate_audio``).
+    if infer_steps is not None and infer_steps > 0:
+        n = min(int(infer_steps), 20)
+        if n != int(infer_steps):
+            logger.warning(
+                "[turbo_schedule] infer_steps=%d exceeds maximum 20, clamping.",
+                infer_steps,
+            )
+        raw = [1.0 - i / n for i in range(n)]
+        if shift != 1.0:
+            raw = [shift * t / (1.0 + (shift - 1.0) * t) for t in raw]
+        return raw
+
+    # Case 3: fixed lookup by shift.
+    snapped_shift = min(VALID_TURBO_SHIFTS, key=lambda x: abs(x - shift))
+    if snapped_shift != shift:
+        logger.warning(
+            "[turbo_schedule] shift=%.2f not supported, rounded to %.1f.",
+            shift, snapped_shift,
+        )
+    return list(TURBO_SHIFT_TIMESTEPS[snapped_shift])

--- a/acestep/models/common/turbo_schedule_test.py
+++ b/acestep/models/common/turbo_schedule_test.py
@@ -1,0 +1,90 @@
+"""Unit tests for the turbo timestep-schedule helper (#1156 PR-D).
+
+Pins the three branches of ``build_turbo_timestep_schedule``:
+* explicit ``timesteps`` → snap to nearest valid value, drop trailing
+  zeros, clamp length to 20
+* ``infer_steps`` set → linspace + shift transform
+* both unset → fixed shift table (snapped to a valid shift)
+"""
+
+import unittest
+
+from acestep.models.common.turbo_schedule import (
+    TURBO_SHIFT_TIMESTEPS,
+    VALID_TURBO_SHIFTS,
+    VALID_TURBO_TIMESTEPS,
+    build_turbo_timestep_schedule,
+)
+
+
+class BuildTurboTimestepScheduleTests(unittest.TestCase):
+
+    # -- Case 1: explicit timesteps --------------------------------------
+
+    def test_explicit_timesteps_passthrough_when_already_valid(self):
+        ts = [1.0, 0.875, 0.75, 0.125]
+        out = build_turbo_timestep_schedule(timesteps=ts)
+        self.assertEqual(out, ts)
+
+    def test_explicit_timesteps_drops_trailing_zeros(self):
+        out = build_turbo_timestep_schedule(timesteps=[1.0, 0.875, 0.0, 0.0])
+        self.assertEqual(out, [1.0, 0.875])
+
+    def test_explicit_timesteps_snaps_to_valid(self):
+        # 0.5001 should snap to the nearest VALID_TURBO_TIMESTEPS entry.
+        out = build_turbo_timestep_schedule(timesteps=[1.0, 0.5001, 0.13])
+        self.assertEqual(len(out), 3)
+        for v in out:
+            self.assertIn(v, VALID_TURBO_TIMESTEPS)
+
+    def test_explicit_timesteps_clamped_to_20(self):
+        ts = [1.0 - i * 0.04 for i in range(30)]  # 30 entries
+        out = build_turbo_timestep_schedule(timesteps=ts)
+        self.assertEqual(len(out), 20)
+
+    def test_empty_timesteps_falls_through_to_shift_table(self):
+        # All zeros → empty after stripping → shift fallback.
+        out = build_turbo_timestep_schedule(timesteps=[0.0, 0.0], shift=3.0)
+        self.assertEqual(out, list(TURBO_SHIFT_TIMESTEPS[3.0]))
+
+    # -- Case 2: variable infer_steps ------------------------------------
+
+    def test_infer_steps_linspace_no_shift(self):
+        out = build_turbo_timestep_schedule(infer_steps=4, shift=1.0)
+        # 1.0, 0.75, 0.5, 0.25 (no shift transform).
+        self.assertEqual(out, [1.0, 0.75, 0.5, 0.25])
+
+    def test_infer_steps_with_shift_transforms(self):
+        out = build_turbo_timestep_schedule(infer_steps=4, shift=3.0)
+        # Shift transform: t' = 3t / (1 + 2t) — strictly less than t for t<1
+        # except at t=1.0.  All values must be in [0, 1].
+        self.assertEqual(len(out), 4)
+        self.assertAlmostEqual(out[0], 1.0)
+        for v in out:
+            self.assertGreaterEqual(v, 0.0)
+            self.assertLessEqual(v, 1.0)
+
+    def test_infer_steps_clamped_to_20(self):
+        out = build_turbo_timestep_schedule(infer_steps=30, shift=1.0)
+        self.assertEqual(len(out), 20)
+
+    # -- Case 3: shift fallback ------------------------------------------
+
+    def test_default_shift_uses_lookup_table(self):
+        out = build_turbo_timestep_schedule(shift=3.0)
+        self.assertEqual(out, list(TURBO_SHIFT_TIMESTEPS[3.0]))
+
+    def test_invalid_shift_snaps_to_nearest(self):
+        out = build_turbo_timestep_schedule(shift=2.7)
+        # 2.7 nearest to 3.0 in VALID_TURBO_SHIFTS.
+        self.assertEqual(out, list(TURBO_SHIFT_TIMESTEPS[3.0]))
+
+    def test_all_valid_shifts_produce_8_step_schedules(self):
+        for s in VALID_TURBO_SHIFTS:
+            out = build_turbo_timestep_schedule(shift=s)
+            self.assertEqual(len(out), 8, f"shift={s} should give 8 steps")
+            self.assertAlmostEqual(out[0], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/models/turbo/modeling_acestep_v15_turbo.py
+++ b/acestep/models/turbo/modeling_acestep_v15_turbo.py
@@ -2202,6 +2202,40 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156) on the turbo CFG-distilled DiT.
+
+        Turbo's ``generate_audio`` uses a fixed ``fix_nfe=8`` lookup
+        table snapped to discrete shifts (1/2/3); we mirror that
+        schedule here and pass it as ``timesteps=`` to the shared
+        pipeline.  Paired CFG is forced off (``guidance_scale=1.0``)
+        because turbo bakes guidance into the distillation — running a
+        second null-cond forward would just double compute for noise.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+        from acestep.models.common.turbo_schedule import build_turbo_timestep_schedule
+
+        gs = kwargs.get("diffusion_guidance_scale", 1.0)
+        if gs != 1.0:
+            logger.info(
+                "Turbo flow-edit ignores guidance_scale=%.2f (turbo is "
+                "CFG-distilled); forcing 1.0.", gs,
+            )
+        kwargs["diffusion_guidance_scale"] = 1.0
+
+        t_schedule_list = build_turbo_timestep_schedule(
+            infer_steps=kwargs.get("infer_steps"),
+            shift=kwargs.get("shift", 3.0),
+            timesteps=kwargs.get("timesteps"),
+        )
+        src_latents = kwargs["src_latents"]
+        kwargs["timesteps"] = torch.tensor(
+            t_schedule_list, device=src_latents.device, dtype=src_latents.dtype,
+        )
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility

--- a/acestep/models/xl_turbo/modeling_acestep_v15_xl_turbo.py
+++ b/acestep/models/xl_turbo/modeling_acestep_v15_xl_turbo.py
@@ -2214,6 +2214,38 @@ class AceStepConditionGenerationModel(AceStepPreTrainedModel):
             "time_costs": time_costs,
         }
 
+    def flowedit_generate_audio(self, **kwargs):
+        """Flow-edit (#1156) on the XL-turbo CFG-distilled DiT.
+
+        Same shape as the non-XL turbo delegate: build the fix_nfe=8
+        schedule via the shared ``build_turbo_timestep_schedule``
+        helper, force ``guidance_scale=1.0``, and dispatch into the
+        flow-edit pipeline.
+        """
+        from acestep.models.common.flow_edit_pipeline import (
+            flowedit_generate_audio as _flowedit_impl,
+        )
+        from acestep.models.common.turbo_schedule import build_turbo_timestep_schedule
+
+        gs = kwargs.get("diffusion_guidance_scale", 1.0)
+        if gs != 1.0:
+            logger.info(
+                "XL-Turbo flow-edit ignores guidance_scale=%.2f (turbo is "
+                "CFG-distilled); forcing 1.0.", gs,
+            )
+        kwargs["diffusion_guidance_scale"] = 1.0
+
+        t_schedule_list = build_turbo_timestep_schedule(
+            infer_steps=kwargs.get("infer_steps"),
+            shift=kwargs.get("shift", 3.0),
+            timesteps=kwargs.get("timesteps"),
+        )
+        src_latents = kwargs["src_latents"]
+        kwargs["timesteps"] = torch.tensor(
+            t_schedule_list, device=src_latents.device, dtype=src_latents.dtype,
+        )
+        return _flowedit_impl(self, **kwargs)
+
 
 def test_forward(model, seed=42):
     # Fix random seed for reproducibility

--- a/scripts/flow_edit_matrix.py
+++ b/scripts/flow_edit_matrix.py
@@ -1,0 +1,197 @@
+"""Flow-edit cross-model + cross-use-case smoke test (#1156, #1167).
+
+Purpose
+-------
+Verify that flow-edit produces non-silent, on-prompt audio across the 6
+DiT variants and the canonical use cases.  Designed to be runnable in
+small slices so we don't burn GPU time before listening to earlier tier
+results.
+
+Phases (recommended order — each is independent):
+
+  A. Turbo cross-model compat (PR #1167, NEW)
+       --models turbo,xl_turbo --use-cases only_lyrics
+  B. Base-tier cross-model compat
+       --models xl_base,xl_sft,sft,base --use-cases only_lyrics
+  C. Use-case sweep on representative model
+       --models xl_base --use-cases only_lyrics,remix,full,tiny,navg4,early
+  D. n_avg sensitivity
+       --models xl_base --use-cases navg1,navg2,navg4
+
+Usage (jieyue, GPU 1):
+    cd /root/data/repo/gongjunmin/workspace/ACE-Step-1.5
+    conda activate acestep_v15_train
+    CUDA_VISIBLE_DEVICES=1 python scripts/flow_edit_matrix.py \\
+        --models turbo,xl_turbo --use-cases only_lyrics \\
+        --output-dir flow_edit_matrix_outputs/
+
+Outputs:
+  {output_dir}/baseline_{model}.{ext}      generated once per model, reused
+  {output_dir}/edit_{model}_{use_case}.{ext}
+  {output_dir}/run_log.jsonl               one line per generation
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+from acestep.inference import GenerationConfig, GenerationParams, generate_music
+from acestep.handler import AceStepHandler
+from acestep.llm_inference import LLMHandler
+
+
+# Registered config_path → DiT variant alias
+MODEL_CONFIGS = {
+    "turbo":     "acestep-v15-turbo",
+    "xl_turbo":  "acestep-v15-xl-turbo",
+    "xl_base":   "acestep-v15-xl-base",
+    "xl_sft":    "acestep-v15-xl-sft",
+    "sft":       "acestep-v15-sft",
+    "base":      "acestep-v15-base",
+}
+
+
+# Source prompt — same as the local 3-WAV baseline so listening test
+# stays comparable.  Anime-pop, Chinese vocals, 160s, B minor, 100 BPM.
+SRC_CAPTION = (
+    "An explosive, high-energy pop-rock track with a strong anime theme song "
+    "feel.  The song kicks off with a catchy, synthesized brass fanfare over "
+    "a driving rock beat with punchy drums and a solid bassline.  A powerful, "
+    "clear male vocal enters with a theatrical and energetic delivery."
+)
+SRC_LYRICS = (
+    "[Verse]\n黑夜里的风吹过耳畔\n甜蜜时光转瞬即万\n"
+    "[Chorus]\n心电感应在震动间\n拥抱未来勇敢冒险\n"
+)
+SRC_BPM = 100
+SRC_DURATION = 160.0
+SRC_KEYSCALE = "B minor"
+SRC_LANG = "zh"
+SRC_TIMESIG = "4"
+SRC_SEED = 42
+
+
+# Target lyrics for "change-the-words" cases (only_lyrics, navg4).
+TGT_LYRICS = (
+    "[Verse]\n阳光洒落在街道上\n微风轻拂心情舒畅\n"
+    "[Chorus]\n那旋律飞向远方\n带着希望和梦想\n"
+)
+# Caption variants for "change-the-style" cases.
+LOFI = ("A mellow lo-fi hip-hop track with warm vinyl crackle, jazzy piano "
+        "chords, soft brushed drums, and dreamy atmospheric pads.")
+ORCH = ("A cinematic orchestral piece with sweeping strings, dramatic brass, "
+        "and timpani.")
+ROCK = ("A stadium-rock arena anthem with crunchy distorted guitars and huge "
+        "gang vocals on the chorus.")
+
+# Each preset: (n_min, n_max, n_avg, target_caption, target_lyrics).
+USE_CASES = {
+    "only_lyrics": (0.6, 1.0, 1, None, TGT_LYRICS),     # keep melody
+    "remix":       (0.2, 0.4, 1, LOFI, None),           # keep lyrics
+    "full":        (0.0, 1.0, 1, ORCH, "[Instrumental]"),
+    "tiny":        (0.4, 0.5, 1, None, None),           # near-identity
+    "navg4":       (0.6, 1.0, 4, None, TGT_LYRICS),     # n_avg sensitivity
+    "early":       (0.0, 0.3, 1, ROCK, None),           # early-only edit
+}
+
+
+def _baseline_params(model: str) -> GenerationParams:
+    return GenerationParams(
+        task_type="text2music",
+        caption=SRC_CAPTION,
+        lyrics=SRC_LYRICS,
+        bpm=SRC_BPM,
+        keyscale=SRC_KEYSCALE,
+        timesignature=SRC_TIMESIG,
+        vocal_language=SRC_LANG,
+        duration=SRC_DURATION,
+        inference_steps=8 if "turbo" in model else 32,
+        guidance_scale=1.0 if "turbo" in model else 7.0,
+        shift=3.0,
+        seed=SRC_SEED,
+        thinking=False,
+    )
+
+
+def _edit_params(model: str, src_audio: str, uc: str) -> GenerationParams:
+    n_min, n_max, n_avg, tgt_cap, tgt_lyr = USE_CASES[uc]
+    p = _baseline_params(model)
+    p.task_type = "edit"
+    p.src_audio = src_audio
+    p.edit_target_caption = tgt_cap if tgt_cap is not None else SRC_CAPTION
+    p.edit_target_lyrics = tgt_lyr if tgt_lyr is not None else SRC_LYRICS
+    p.edit_n_min, p.edit_n_max, p.edit_n_avg = n_min, n_max, n_avg
+    return p
+
+
+def _run_one(dit, llm, params: GenerationParams, save_dir: str, label: str):
+    cfg = GenerationConfig(batch_size=1, use_random_seed=False, seeds=[SRC_SEED])
+    t0 = time.time()
+    res = generate_music(dit, llm, params, cfg, save_dir=save_dir)
+    return {
+        "label": label,
+        "ok": bool(res.audio_paths),
+        "audio": res.audio_paths[0] if res.audio_paths else None,
+        "elapsed_s": round(time.time() - t0, 2),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models", required=True,
+                    help="comma-sep: turbo,xl_turbo,xl_base,xl_sft,sft,base")
+    ap.add_argument("--use-cases", required=True,
+                    help=f"comma-sep: {','.join(USE_CASES)}")
+    ap.add_argument("--output-dir", default="flow_edit_matrix_outputs")
+    ap.add_argument("--device", default="cuda:0")
+    args = ap.parse_args()
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    use_cases = [u.strip() for u in args.use_cases.split(",") if u.strip()]
+    out = Path(args.output_dir); out.mkdir(parents=True, exist_ok=True)
+    log = (out / "run_log.jsonl").open("a")
+
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for model in models:
+        cfg_path = MODEL_CONFIGS[model]
+        print(f"\n=== {model} (config={cfg_path}) ===")
+        dit = AceStepHandler()
+        llm = LLMHandler()
+        _, ok = dit.initialize_service(
+            project_root=project_root, config_path=cfg_path,
+            device=args.device, use_flash_attention=False,
+            compile_model=False, offload_to_cpu=False,
+            offload_dit_to_cpu=False, quantization=None,
+        )
+        if not ok:
+            print(f"  init failed for {model}; skipping"); continue
+
+        baseline_path = out / f"baseline_{model}.flac"
+        if not baseline_path.exists():
+            r = _run_one(dit, llm, _baseline_params(model), str(out),
+                         f"baseline_{model}")
+            log.write(json.dumps(r) + "\n"); log.flush()
+            print(f"  baseline → {r['audio']} ({r['elapsed_s']}s)")
+            if r["audio"]:
+                Path(r["audio"]).rename(baseline_path)
+
+        for uc in use_cases:
+            tag = f"edit_{model}_{uc}"
+            r = _run_one(dit, llm,
+                         _edit_params(model, str(baseline_path), uc),
+                         str(out), tag)
+            log.write(json.dumps(r) + "\n"); log.flush()
+            print(f"  {uc:14s} → {r['audio']} ({r['elapsed_s']}s)")
+            if r["audio"]:
+                Path(r["audio"]).rename(out / f"{tag}.flac")
+
+    log.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Earlier PRs (#1162, #1163, #1165) intentionally restricted flow-edit to the four base DiT variants on the (mistaken) assumption that turbo's CFG distillation made paired-CFG flow-edit impossible.

Reality: flow-edit's V_delta integration only needs **one forward per side** (V_src, V_tar) when ``guidance_scale == 1.0`` — which is exactly turbo's mode of operation.  No paired CFG, no doubled forwards, just plain Euler steps through the velocity-difference field.  The math layer already handled this (``do_cfg = guidance_scale > 1.0`` gates the doubling); only the delegate methods on turbo / xl_turbo were missing.

This PR adds them.

## Scope

| File | Purpose |
|---|---|
| **NEW** ``models/common/turbo_schedule.py`` | Shared helper: builds turbo's fix_nfe=8 lookup table (3 cases: explicit timesteps / infer_steps linspace / default shift table) |
| ``models/turbo/modeling_acestep_v15_turbo.py`` | New ``flowedit_generate_audio`` delegate — builds schedule, forces ``guidance_scale=1.0``, dispatches to the shared pipeline |
| ``models/xl_turbo/modeling_acestep_v15_xl_turbo.py`` | Same shape |
| **NEW** ``models/common/turbo_schedule_test.py`` | 11 unit tests on the schedule helper |

The sampling layer (``flow_edit.py``, ``flow_edit_pipeline.py``) is **unchanged** — turbo just rides the existing ``timesteps=`` path.

## Why this works

1. ``flow_edit_pipeline.flowedit_generate_audio`` already accepts ``timesteps=`` and forwards it.
2. ``flow_edit.flowedit_sampling_loop`` calls ``build_timestep_schedule(timesteps=...)`` which pads a trailing zero.
3. Inside the loop, ``do_cfg = guidance_scale > 1.0`` is False under turbo's forced ``1.0``, so:
   - No CFG packing (no batch doubling)
   - No APG momentum updates
   - 2 decoder forwards per step (one src, one tar) — same compute as turbo's regular ``generate_audio``

## What turbo flow-edit looks like

\`\`\`python
from acestep.inference import GenerationParams, generate_music
params = GenerationParams(
    task_type=\"edit\",
    src_audio=\"input.wav\",
    caption=\"original style\",
    lyrics=\"original lyrics\",
    edit_target_caption=\"new style\",
    edit_target_lyrics=\"new lyrics\",
    edit_n_min=0.4, edit_n_max=0.8,
    inference_steps=16,  # bump from default 8 — turbo has only 8 steps to fit the edit window
    seed=42,
)
\`\`\`

## Out of scope (intentional)

* **UI exposure** — Gradio Edit mode currently appears in ``GENERATION_MODES_BASE`` and ``GENERATION_MODES_SFT`` only (PR-C #1165).  Adding ``Edit`` to ``GENERATION_MODES_TURBO`` is a one-liner follow-up once we have human listening confirmation that turbo flow-edit sounds OK.
* **Default ``inference_steps`` bump for turbo edit** — at fix_nfe=8 the edit window is tight (only_lyrics with n_min=0.6, n_max=1.0 is just 3 steps).  Users should bump ``infer_steps`` to 16–24 manually for better edit quality; we don't override the default here.

## Test plan

\`\`\`
$ python -m unittest acestep.models.common.turbo_schedule_test
Ran 11 tests — OK

$ python -m unittest acestep.models.common.flow_edit_test acestep.models.common.flow_edit_helpers_test acestep.models.common.flow_edit_helpers_velocity_test acestep.models.common.flow_edit_pipeline_test acestep.core.generation.handler.service_generate_flow_edit_test
Ran 35 tests — OK (no regressions in the existing flow-edit suite)
\`\`\`

* [x] Schedule helper unit tests (11)
* [x] Existing flow-edit tests pass (35)
* [x] Syntax check on touched files
* [x] Both turbo variants expose ``flowedit_generate_audio``
* [ ] Real-audio smoke test on jieyue with turbo / xl-turbo + base model side-by-side — pending
* [ ] Human listening test — PR will NOT be merged until this happens (per the PR-B lesson)

## Risk

Low.  No changes to the math/sampling layer; pure additive code on the model variant side.  The schedule helper centralises logic already duplicated inline in both turbo files; no behaviour change to existing ``generate_audio`` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flow-Edit audio generation for turbo and XL‑turbo models with enforced guidance scale and flexible turbo timestep scheduling (shift/infer/snapping behaviors).
  * Added a CLI smoke-test to run cross-model Flow-Edit baseline and edit scenarios and record results.

* **Tests**
  * Added unit tests covering timestep schedule creation, snapping, length clamping, shift behaviors, and generation-path integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->