### PR TITLE
fix(jetson): remove GPL video codecs, fix ffmpeg/examples/healthcheck

### DIFF
--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -81,8 +81,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         # FFmpeg build dependencies (we build FFmpeg 7 from source for torchcodec)
         nasm \
         yasm \
-        libx264-dev \
-        libx265-dev \
         libmp3lame-dev \
         libopus-dev \
         libvorbis-dev \
@@ -105,14 +103,10 @@ RUN cd /tmp \
         --prefix=/usr/local \
         --enable-shared \
         --disable-static \
-        --enable-gpl \
-        --enable-libx264 \
-        --enable-libx265 \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libvorbis \
         --disable-doc \
-        --disable-programs \
     && make -j$(nproc) \
     && make install \
     && ldconfig \
@@ -214,7 +208,7 @@ RUN pip install --no-cache-dir \
         "typer-slim>=0.21.1" \
         "xxhash" \
         "pyyaml" \
-        "bitsandbytes>=0.49.0"
+        "bitsandbytes>=0.49.0,<0.51"
 
 # torchao — DISABLED on Jetson.
 # The original diffusers 0.36.0 logger bug is fixed in 0.37.0+, but torchao
@@ -245,7 +239,10 @@ RUN pip install --no-cache-dir \
     && python -c "import nanovllm; print('nano-vllm OK')"
 
 # ==================== Runtime directories ====================
-RUN mkdir -p /app/checkpoints /app/gradio_outputs
+RUN mkdir -p /app/checkpoints /app/gradio_outputs \
+    # Symlink examples into the path where api_routes.py's _get_project_root()
+    # resolves (acestep/ui/) until the upstream bug is fixed.
+    && ln -sf /app/examples /app/acestep/ui/examples
 
 # ==================== Jetson environment defaults ====================
 
@@ -284,7 +281,7 @@ EXPOSE 7860 8001
 # Lightweight probe: the Gradio or API server must be listening.
 HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -sf http://localhost:${GRADIO_PORT:-7860}/ > /dev/null 2>&1 \
-     || curl -sf http://localhost:${ACESTEP_API_PORT:-8001}/health > /dev/null 2>&1 \
+     || curl -sf http://localhost:${API_PORT:-8001}/health > /dev/null 2>&1 \
      || exit 1
 
 # ==================== Entrypoint ====================

--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -281,7 +281,7 @@ EXPOSE 7860 8001
 # Lightweight probe: the Gradio or API server must be listening.
 HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -sf http://localhost:${GRADIO_PORT:-7860}/ > /dev/null 2>&1 \
-     || curl -sf http://localhost:${API_PORT:-8001}/health > /dev/null 2>&1 \
+     || curl -sf http://localhost:${API_PORT:-${ACESTEP_API_PORT:-8001}}/health > /dev/null 2>&1 \
      || exit 1
 
 # ==================== Entrypoint ====================
@@ -316,10 +316,10 @@ if [ "${ACESTEP_INIT_SERVICE:-true}" = "true" ]; then
 fi
 
 if [ "${ACESTEP_MODE}" = "api" ]; then
-    echo "Starting REST API server on 0.0.0.0:${ACESTEP_API_PORT:-8001} ..."
+    echo "Starting REST API server on 0.0.0.0:${API_PORT:-${ACESTEP_API_PORT:-8001}} ..."
     exec python -m acestep.api_server \
         --host "${ACESTEP_API_HOST:-0.0.0.0}" \
-        --port "${ACESTEP_API_PORT:-8001}" \
+        --port "${API_PORT:-${ACESTEP_API_PORT:-8001}}" \
         ${ACESTEP_EXTRA_ARGS:-}
 else
     echo "Starting Gradio UI on 0.0.0.0:${GRADIO_PORT:-7860} ..."

--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -239,9 +239,9 @@ RUN pip install --no-cache-dir \
     && python -c "import nanovllm; print('nano-vllm OK')"
 
 # ==================== Runtime directories ====================
+# Symlink examples into the path where api_routes.py's _get_project_root()
+# resolves (acestep/ui/) until the upstream bug is fixed.
 RUN mkdir -p /app/checkpoints /app/gradio_outputs \
-    # Symlink examples into the path where api_routes.py's _get_project_root()
-    # resolves (acestep/ui/) until the upstream bug is fixed.
     && ln -sf /app/examples /app/acestep/ui/examples
 
 # ==================== Jetson environment defaults ====================

--- a/docker-compose.jetson.yml
+++ b/docker-compose.jetson.yml
@@ -71,7 +71,8 @@ services:
       - ACESTEP_CONFIG_PATH=${ACESTEP_CONFIG_PATH:-acestep-v15-turbo}
       #
       # ---- LM model (ACESTEP_LM_MODEL_PATH) ----
-      # acestep-5Hz-lm-0.6B  — Smallest, ~3GB  (Orin Nano 4/8GB)
+      # ≤6GB devices: set ACESTEP_INIT_SERVICE=false, then initialize only the DiT.
+      # acestep-5Hz-lm-0.6B  — Smallest, ~3GB  (Orin Nano 8GB)
       # acestep-5Hz-lm-1.7B  — Mid-size, ~8GB  (Orin NX 16GB)
       # acestep-5Hz-lm-4B    — Best quality, ~12GB (AGX Orin ≥32GB)
       - ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:-acestep-5Hz-lm-4B}

--- a/docker-compose.jetson.yml
+++ b/docker-compose.jetson.yml
@@ -55,7 +55,25 @@ services:
       # CUDA graph capture is auto-disabled on Jetson (enforce_eager).
       - ACESTEP_LLM_BACKEND=${ACESTEP_LLM_BACKEND:-vllm}
       - ACESTEP_INIT_SERVICE=${ACESTEP_INIT_SERVICE:-true}
+      #
+      # ---- DiT model (ACESTEP_CONFIG_PATH) ----
+      # acestep-v15-turbo              — Fast turbo model (default, recommended)
+      # acestep-v15-base               — Full base model (Extract/Lego/Complete)
+      # acestep-v15-sft                — Supervised fine-tuned
+      # acestep-v15-base-sft-fix-inst  — Base-SFT with instruction fix
+      # acestep-v15-turbo-shift1       — Turbo shift-1 variant
+      # acestep-v15-turbo-shift3       — Turbo shift-3 variant
+      # acestep-v15-turbo-continuous   — Turbo continuous variant
+      # acestep-v15-turbo-rl           — Turbo reinforcement-learned
+      # acestep-v15-xl-base            — XL 4B DiT base (requires more VRAM)
+      # acestep-v15-xl-sft             — XL 4B DiT supervised fine-tuned
+      # acestep-v15-xl-turbo           — XL 4B DiT turbo
       - ACESTEP_CONFIG_PATH=${ACESTEP_CONFIG_PATH:-acestep-v15-turbo}
+      #
+      # ---- LM model (ACESTEP_LM_MODEL_PATH) ----
+      # acestep-5Hz-lm-0.6B  — Smallest, ~3GB  (Orin Nano 4/8GB)
+      # acestep-5Hz-lm-1.7B  — Mid-size, ~8GB  (Orin NX 16GB)
+      # acestep-5Hz-lm-4B    — Best quality, ~12GB (AGX Orin ≥32GB)
       - ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:-acestep-5Hz-lm-4B}
       - ACESTEP_EXTRA_ARGS=${ACESTEP_EXTRA_ARGS:-}
       - TOKENIZERS_PARALLELISM=false


### PR DESCRIPTION
Addresses review feedback from #793 and #735:

- Remove unused x264/x265 GPL video codecs from FFmpeg build (audio-only paths don't need them, avoids GPL license complexity)
- Remove `--disable-programs` so `ffmpeg` CLI binary is available for MP3 export in `audio_utils.py`
- Pin `bitsandbytes>=0.49.0,<0.51` for aarch64 stability
- Fix healthcheck port variable to `API_PORT` matching docker-compose.jetson.yml
- Add examples symlink workaround for `_get_project_root()` path resolution bug in `api_routes.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated Jetson media support to focus on MP3, Opus, and Vorbis formats.
  * Restricted the supported `bitsandbytes` version range for improved compatibility.

* **Improvements**
  * Healthchecks now verify both Gradio and API endpoints with configurable port fallbacks.
  * Runtime setup supports additional example paths and explicit API port configuration.
  * Added installation verification for nano-vLLM.

* **Documentation**
  * Documented supported model configurations and approximate VRAM requirements for Jetson deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->