### PR TITLE
fix: stale DiT instruction after Simple Mode sample creation + add setuptools dep

### DIFF
--- a/acestep/ui/gradio/events/wiring/generation_mode_wiring.py
+++ b/acestep/ui/gradio/events/wiring/generation_mode_wiring.py
@@ -10,6 +10,7 @@ import gradio as gr
 
 from .. import generation_handlers as gen_h
 from .context import GenerationWiringContext
+from acestep.constants import MODE_TO_TASK_TYPE
 
 
 def _on_repaint_mode_change(mode, current_strength, memory):
@@ -44,6 +45,7 @@ def register_generation_mode_handlers(
 
     generation_section = context.generation_section
     results_section = context.results_section
+    dit_handler = context.dit_handler
     llm_handler = context.llm_handler
 
     # Shared handler for mode-change and initial page load — extracted to
@@ -173,6 +175,17 @@ def register_generation_mode_handlers(
         fn=gen_h.uncheck_auto_for_populated_fields,
         inputs=list(auto_checkbox_inputs),
         outputs=list(auto_checkbox_outputs),
+    ).then(
+        # After creating a sample the generation_mode is set to "Custom"
+        # (task_type="text2music"). If task_type was already "text2music" the
+        # task_type.change event does not fire, leaving instruction_display_gen
+        # stale (e.g. the LM instruction from a previous Remix session). Force
+        # it to the correct DiT text2music instruction unconditionally.
+        fn=lambda: gen_h.update_instruction_ui(
+            dit_handler, MODE_TO_TASK_TYPE["Custom"], None, [], False, None
+        ),
+        inputs=[],
+        outputs=[generation_section["instruction_display_gen"]],
     )
 
     generation_section["repaint_mode"].change(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "typer-slim>=0.21.1",
     "pytorch-wavelets>=1.3.0",
     "pywavelets>=1.9.0",
+    "setuptools<72",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
To reproduce: Start the UI, switch to Remix mode (which sets instruction to the LM/cover value), then switch to Simple mode, create a sample, and click Generate. Without this fix, instruction_display_gen remains stale and the DiT receives cover-mode conditioning, producing white noise.

Two related fixes:

1. **Stale instruction_display_gen in Simple Mode → Generate Full Song** When create_sample_btn fires it sets generation_mode="Custom" (task_type="text2music"). If task_type was already "text2music" the task_type.change event never fires, leaving instruction_display_gen holding a stale value — typically the LM instruction "Generate audio semantic tokens based on the given conditions:" from a prior Remix/Cover session. The DiT then receives cover-mode text conditioning while operating in text2music mode, which produces near-silent latents (peak ~0.003) that normalization amplifies into audible white noise.

   Fix: chain a .then() on create_sample_btn.click that unconditionally resets instruction_display_gen to TASK_INSTRUCTIONS["text2music"] after the sample is created, regardless of prior mode state.

2. **pytorch_wavelets fails to import on Python 3.12+ (pkg_resources missing)** pytorch_wavelets' DTCWT coefficient loader uses pkg_resources from setuptools, which is no longer implicitly available in Python 3.12+ environments (e.g. uv-managed venvs). This causes the DCW wavelet correction to silently fall back to a no-op even when enabled.

   Fix: add setuptools as an explicit dependency in pyproject.toml so it is always present alongside pytorch-wavelets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the instruction display refreshes immediately after creating a sample for text2music, so the UI shows current generation parameters reliably.

* **Chores**
  * Pinned build dependency: setuptools version restricted to <72.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1194)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->