### PR TITLE
fix(mlx): add repaint step-injection and boundary blend to MLX diffusion path

### DIFF
--- a/acestep/core/generation/handler/diffusion.py
+++ b/acestep/core/generation/handler/diffusion.py
@@ -45,6 +45,10 @@ class DiffusionMixin:
         dcw_scaler: float = 0.05,
         dcw_high_scaler: float = 0.02,
         dcw_wavelet: str = "haar",
+        repaint_mask: Optional[torch.Tensor] = None,
+        clean_src_latents: Optional[torch.Tensor] = None,
+        repaint_crossfade_frames: int = 10,
+        repaint_injection_ratio: float = 0.5,
     ) -> Dict[str, Any]:
         """Run the MLX diffusion loop and return generated latents.
 
@@ -127,6 +131,15 @@ class DiffusionMixin:
             if context_latents_non_cover is not None else None
         )
 
+        repaint_mask_np = (
+            repaint_mask.detach().cpu().numpy().astype(bool)
+            if repaint_mask is not None else None
+        )
+        clean_src_np = (
+            clean_src_latents.detach().cpu().float().numpy()
+            if clean_src_latents is not None else None
+        )
+
         null_cond_np = (
             null_condition_emb.detach().cpu().float().numpy()
             if null_condition_emb is not None else None
@@ -168,6 +181,10 @@ class DiffusionMixin:
             dcw_scaler=dcw_scaler,
             dcw_high_scaler=dcw_high_scaler,
             dcw_wavelet=dcw_wavelet,
+            repaint_mask_np=repaint_mask_np,
+            clean_src_latents_np=clean_src_np,
+            repaint_crossfade_frames=repaint_crossfade_frames,
+            repaint_injection_ratio=repaint_injection_ratio,
         )
 
         target_np = result["target_latents"]

--- a/acestep/core/generation/handler/service_generate_execute.py
+++ b/acestep/core/generation/handler/service_generate_execute.py
@@ -245,6 +245,10 @@ class ServiceGenerateExecuteMixin:
                             dcw_wavelet=generate_kwargs.get("dcw_wavelet", "haar"),
                             retake_seed=retake_seed,
                             retake_variance=retake_variance,
+                            repaint_mask=generate_kwargs.get("repaint_mask"),
+                            clean_src_latents=generate_kwargs.get("clean_src_latents"),
+                            repaint_crossfade_frames=generate_kwargs.get("repaint_crossfade_frames", 10),
+                            repaint_injection_ratio=generate_kwargs.get("repaint_injection_ratio", 0.5),
                         )
                         _tc = outputs.get("time_costs", {})
                         logger.info(

--- a/acestep/models/mlx/dit_generate.py
+++ b/acestep/models/mlx/dit_generate.py
@@ -133,6 +133,40 @@ def _mlx_apg_forward(
     return pred_cond + (guidance_scale - 1) * orthogonal
 
 
+def _mlx_repaint_step_injection(xt, clean_src, mask, t_next, noise):
+    """Replace non-repaint regions of *xt* with noised source latents (MLX)."""
+    import mlx.core as mx
+    zt = t_next * noise + (1.0 - t_next) * clean_src
+    m = mx.expand_dims(mask, axis=-1)
+    return mx.where(m, xt, zt)
+
+
+def _mlx_repaint_boundary_blend(x_gen, clean_src, mask_np, cf_frames):
+    """Blend generated latents with source at repaint boundaries (MLX)."""
+    import mlx.core as mx
+    soft = mask_np.astype(np.float32).copy()
+    if cf_frames <= 0:
+        m = mx.expand_dims(mx.array(soft), axis=-1)
+        return m * x_gen + (1.0 - m) * clean_src
+    B, T = mask_np.shape
+    for b in range(B):
+        row = mask_np[b]
+        if row.all() or not row.any():
+            continue
+        idx = np.nonzero(row)[0]
+        if len(idx) == 0:
+            continue
+        left, right = int(idx[0]), int(idx[-1]) + 1
+        fs = max(left - cf_frames, 0)
+        if left - fs > 0:
+            soft[b, fs:left] = np.linspace(0, 1, left - fs + 2)[1:-1]
+        fe = min(right + cf_frames, T)
+        if fe - right > 0:
+            soft[b, right:fe] = np.linspace(1, 0, fe - right + 2)[1:-1]
+    m = mx.expand_dims(mx.array(soft), axis=-1)
+    return m * x_gen + (1.0 - m) * clean_src
+
+
 def mlx_generate_diffusion(
     mlx_decoder,
     encoder_hidden_states_np: np.ndarray,
@@ -162,6 +196,10 @@ def mlx_generate_diffusion(
     dcw_scaler: float = 0.05,
     dcw_high_scaler: float = 0.02,
     dcw_wavelet: str = "haar",
+    repaint_mask_np: Optional[np.ndarray] = None,
+    clean_src_latents_np: Optional[np.ndarray] = None,
+    repaint_crossfade_frames: int = 10,
+    repaint_injection_ratio: float = 0.5,
 ) -> Dict[str, object]:
     """Run the complete MLX diffusion loop with optional CFG guidance.
 
@@ -231,6 +269,11 @@ def mlx_generate_diffusion(
 
     enc_hs_nc = mx.array(encoder_hidden_states_non_cover_np) if encoder_hidden_states_non_cover_np is not None else None
     ctx_nc = mx.array(context_latents_non_cover_np) if context_latents_non_cover_np is not None else None
+
+    # ---- Repaint setup ----
+    do_repaint = repaint_mask_np is not None and clean_src_latents_np is not None
+    repaint_mask_mx = mx.array(repaint_mask_np) if do_repaint else None
+    clean_src_mx = mx.array(clean_src_latents_np) if do_repaint else None
 
     bsz = src_latents_shape[0]
     T = src_latents_shape[1]
@@ -456,6 +499,19 @@ def mlx_generate_diffusion(
             mx.eval(xt)
 
         prev_vt = vt  # store for EMA
+
+        # ---- Repaint step injection ----
+        if do_repaint:
+            injection_cutoff = round(repaint_injection_ratio * num_steps)
+            if step_idx < injection_cutoff:
+                t_after = t_schedule_list[step_idx + 1] if step_idx < num_steps - 1 else 0.0
+                xt = _mlx_repaint_step_injection(xt, clean_src_mx, repaint_mask_mx, t_after, noise)
+                mx.eval(xt)
+
+    # ---- Repaint boundary blend (post-loop) ----
+    if do_repaint and repaint_crossfade_frames > 0:
+        xt = _mlx_repaint_boundary_blend(xt, clean_src_mx, repaint_mask_np, repaint_crossfade_frames)
+        mx.eval(xt)
 
     diff_end = time.time()
     total_end = time.time()

--- a/run_generate_test.py
+++ b/run_generate_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Quick smoke test: generate 2 full songs via generate_music() with LM."""
+
+import json
+import os
+import sys
+import time
+
+os.environ.pop("http_proxy", None)
+os.environ.pop("https_proxy", None)
+os.environ.pop("HTTP_PROXY", None)
+os.environ.pop("HTTPS_PROXY", None)
+os.environ.pop("ALL_PROXY", None)
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from loguru import logger
+from acestep.handler import AceStepHandler
+from acestep.llm_inference import LLMHandler
+from acestep.inference import GenerationParams, GenerationConfig, generate_music
+
+PROJECT_ROOT = os.path.dirname(__file__)
+CHECKPOINT_DIR = os.path.join(PROJECT_ROOT, "checkpoints")
+SAVE_DIR = os.path.join(PROJECT_ROOT, "output", "test_generate")
+EXAMPLES = [
+    os.path.join(PROJECT_ROOT, "examples", "text2music", "example_01.json"),
+    os.path.join(PROJECT_ROOT, "examples", "text2music", "example_10.json"),
+]
+
+
+def main():
+    os.makedirs(SAVE_DIR, exist_ok=True)
+
+    # ---- 1. Init DiT handler (turbo) ----
+    logger.info("Initializing DiT handler (turbo)...")
+    t0 = time.time()
+    dit_handler = AceStepHandler()
+    status_msg, success = dit_handler.initialize_service(
+        project_root=PROJECT_ROOT,
+        config_path="acestep-v15-turbo",
+        device="auto",
+        offload_to_cpu=False,
+    )
+    if not success:
+        logger.error(f"DiT init failed: {status_msg}")
+        sys.exit(1)
+    logger.info(f"DiT loaded in {time.time() - t0:.1f}s — {status_msg}")
+
+    # ---- 2. Init LLM handler (0.6B, MLX) ----
+    logger.info("Initializing LLM handler (0.6B, MLX)...")
+    t0 = time.time()
+    llm_handler = LLMHandler()
+    status_msg, success = llm_handler.initialize(
+        checkpoint_dir=CHECKPOINT_DIR,
+        lm_model_path="acestep-5Hz-lm-0.6B",
+        backend="mlx",
+        device="auto",
+        offload_to_cpu=False,
+        dtype=None,
+    )
+    if not success:
+        logger.error(f"LLM init failed: {status_msg}")
+        sys.exit(1)
+    logger.info(f"LLM loaded in {time.time() - t0:.1f}s — {status_msg}")
+
+    # ---- 3. Generate songs ----
+    for i, example_path in enumerate(EXAMPLES):
+        logger.info(f"\n{'='*60}")
+        logger.info(f"Generating song {i+1}/{len(EXAMPLES)}: {os.path.basename(example_path)}")
+        logger.info(f"{'='*60}")
+
+        with open(example_path, "r", encoding="utf-8") as f:
+            ex = json.load(f)
+
+        params = GenerationParams(
+            task_type="text2music",
+            thinking=True,
+            caption=ex.get("caption", ""),
+            lyrics=ex.get("lyrics", ""),
+            bpm=ex.get("bpm"),
+            keyscale=ex.get("keyscale", ""),
+            timesignature=ex.get("timesignature", ""),
+            vocal_language=ex.get("language", "en"),
+            duration=ex.get("duration"),
+            inference_steps=8,
+            guidance_scale=1.0,
+            seed=-1,
+        )
+
+        config = GenerationConfig(
+            batch_size=1,
+            audio_format="wav",
+        )
+
+        t0 = time.time()
+        result = generate_music(
+            dit_handler,
+            llm_handler,
+            params=params,
+            config=config,
+            save_dir=SAVE_DIR,
+        )
+        elapsed = time.time() - t0
+
+        if result.success:
+            logger.info(f"Song {i+1} OK — {elapsed:.1f}s")
+            for audio in result.audios:
+                logger.info(f"  -> {audio.get('path', '(in-memory)')}")
+        else:
+            logger.error(f"Song {i+1} FAILED — {elapsed:.1f}s — {result.status_message}")
+
+    logger.info("\nDone. Output dir: " + SAVE_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Forward `repaint_mask`, `clean_src_latents`, `repaint_crossfade_frames`, and `repaint_injection_ratio` through all three MLX layers (caller → bridge → backend)
- Implement `_mlx_repaint_step_injection` and `_mlx_repaint_boundary_blend` in `dit_generate.py`, mirroring the PyTorch logic from `_repaint_step_injection` / `_repaint_boundary_blend`
- Step injection runs inside the diffusion loop (after DCW, matching PyTorch ordering); boundary blend runs post-loop

Closes #1196

## Root cause

The MLX diffusion path (`_mlx_run_diffusion` → `mlx_generate_diffusion`) did not accept or forward any repaint parameters. On Mac, repaint step injection and boundary blend were completely skipped, causing balanced/conservative modes to behave identically to aggressive mode.

## Test plan

- [ ] Mac (MLX backend): Repaint with `balanced` mode, strength 0.5 — verify the repaint region transitions smoothly into surrounding audio
- [ ] Mac (MLX backend): Repaint with `conservative` mode — verify output closely matches source with minimal variation in repaint region
- [ ] Mac (MLX backend): Repaint with `aggressive` mode — verify behavior unchanged (no step injection expected)
- [ ] CUDA (PyTorch backend): Repaint regression test — verify no change in output quality
- [ ] Verify `repaint_strength` slider has audible effect on MLX path (0.0 → conservative, 1.0 → aggressive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repaint support for diffusion generation: mask-based region selection, optional source-latent injection, boundary crossfading, and exposed tuning controls for crossfade frames and injection ratio.

* **Tests**
  * Added an executable smoke-test that generates sample outputs to validate end-to-end text-to-music generation and save artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1197)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->