### PR TITLE
chore: fix uv sync on macOS & add Apple Silicon setup guide

### DIFF
--- a/docs/SETUP_MACOS_APPLE_SILICON.md
+++ b/docs/SETUP_MACOS_APPLE_SILICON.md
@@ -1,0 +1,136 @@
+# ACE-Step 1.5 — macOS Apple Silicon Setup Guide
+
+This document records the environment setup for running ACE-Step 1.5 on macOS with Apple Silicon (M4 Max, 128 GB unified memory).
+
+## Prerequisites
+
+| Tool    | Version | Install                          |
+|---------|---------|----------------------------------|
+| Python  | 3.12.x  | `brew install python@3.12`       |
+| git     | 2.49+   | `brew install git`               |
+| ffmpeg  | 7.x     | `brew install ffmpeg`            |
+| uv      | 0.7+    | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+## Clone & Install
+
+```bash
+git clone https://github.com/ACE-Step/ACE-Step-1.5.git
+cd ACE-Step-1.5
+```
+
+### Google Drive workaround
+
+If your project directory lives on Google Drive, the virtual environment must be on a **local** filesystem. Google Drive's file-sync drops small Python files (e.g. `torchvision/models/densenet.py`), causing `ModuleNotFoundError` at runtime.
+
+```bash
+# Create a local directory for the venv
+mkdir -p ~/Dev/KYStudio/ace-step-venv
+
+# Symlink .venv to the local path
+ln -sf ~/Dev/KYStudio/ace-step-venv .venv
+```
+
+### pyproject.toml fix
+
+The upstream `required-environments` includes a Windows entry whose PyTorch wheel (`torch==2.7.1+cu128`) does not exist, causing `uv sync` to fail on **all** platforms. Comment it out:
+
+```toml
+# In [tool.uv]
+required-environments = [
+    # "sys_platform == 'win32' and platform_machine == 'AMD64'",
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
+```
+
+Then install:
+
+```bash
+uv sync
+```
+
+Key packages installed for macOS ARM:
+- `torch >= 2.9.1` (MPS backend)
+- `mlx >= 0.25.2`, `mlx-lm >= 0.20.0` (Apple Silicon native)
+
+## Model Download
+
+```bash
+# Core model (~10 GB): VAE, Qwen3-Embedding, turbo 2B DiT, 1.7B LM
+uv run acestep-download
+
+# XL turbo DiT (~19 GB) — highest quality DiT
+uv run acestep-download --model acestep-v15-xl-turbo
+
+# 4B LM (~7.8 GB) — highest quality LM
+uv run acestep-download --model acestep-5Hz-lm-4B
+```
+
+Total disk usage: **~36 GB** under `checkpoints/`.
+
+### Model Selection Guide (Apple Silicon)
+
+| Unified Memory | Recommended DiT        | Recommended LM       |
+|----------------|------------------------|----------------------|
+| ≤ 16 GB        | 2B turbo               | 0.6B (or none)       |
+| 16–36 GB       | 2B turbo/sft           | 1.7B                 |
+| 36–64 GB       | XL turbo               | 1.7B                 |
+| ≥ 64 GB        | XL turbo/sft           | 4B                   |
+
+## Inference Test
+
+Run the included test script to verify the full pipeline:
+
+```bash
+uv run python test_inference.py
+```
+
+This script:
+1. Initializes DiT (`acestep-v15-xl-turbo`) on MPS with MLX acceleration.
+2. Initializes LLM (`acestep-5Hz-lm-4B`) with MLX backend.
+3. Generates a 15-second instrumental test track.
+4. Saves `test_output.wav` in the project root.
+
+### Verify output
+
+```bash
+# File exists and is non-empty
+test -f test_output.wav && echo OK
+
+# Valid WAV format
+ffprobe -v error -show_entries format=format_name,duration test_output.wav
+```
+
+### Reference Timing (M4 Max, 128 GB)
+
+| Phase              | Time     |
+|--------------------|----------|
+| DiT model load     | ~17 s    |
+| LLM model load     | ~28 s    |
+| Inference (15s audio) | ~19 s |
+| — LM Phase 1       | ~4.2 s   |
+| — LM Phase 2       | ~2.9 s   |
+| — DiT diffusion    | ~3.3 s   |
+
+## Launch
+
+```bash
+# Gradio Web UI (MLX backend auto-enabled)
+./start_gradio_ui_macos.sh
+# or
+uv run acestep
+
+# REST API server
+./start_api_server_macos.sh
+# or
+uv run acestep-api
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `uv sync` fails with "no solution for win32" | `torch 2.7.1+cu128` has no Windows wheels | Comment out Windows in `required-environments` |
+| `ModuleNotFoundError: torchvision.models.densenet` | Google Drive drops files during sync | Symlink `.venv` to a local path |
+| LLM NaN/inf on MPS | bfloat16 not fully supported for autoregressive LLM | Handler auto-uses float32 for LLM on MPS |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ explicit = true
 
 [tool.uv]
 required-environments = [
-    "sys_platform == 'win32' and platform_machine == 'AMD64'",
+    # "sys_platform == 'win32' and platform_machine == 'AMD64'",  # commented out: torch 2.7.1+cu128 has no Windows wheels
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
     "sys_platform == 'linux' and platform_machine == 'aarch64'",
     "sys_platform == 'darwin' and platform_machine == 'arm64'",

--- a/test_inference.py
+++ b/test_inference.py
@@ -1,0 +1,134 @@
+"""
+ACE-Step 1.5 Inference Test
+- DiT: acestep-v15-xl-turbo (4B)
+- LM: acestep-5Hz-lm-4B
+- Backend: MLX (Apple Silicon)
+"""
+import os
+import sys
+import time
+import shutil
+
+# Disable tokenizers parallelism warning
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+CHECKPOINT_DIR = os.path.join(PROJECT_ROOT, "checkpoints")
+OUTPUT_DIR = PROJECT_ROOT
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "test_output.wav")
+
+def main():
+    from acestep.handler import AceStepHandler
+    from acestep.llm_inference import LLMHandler
+    from acestep.inference import GenerationParams, GenerationConfig, generate_music
+
+    # ── Step 1: Initialize DiT Handler ──
+    print("=" * 60)
+    print("[Phase 4] Initializing DiT handler (acestep-v15-xl-turbo)...")
+    print("=" * 60)
+
+    dit_handler = AceStepHandler()
+    t0 = time.time()
+    status_msg, success = dit_handler.initialize_service(
+        project_root=PROJECT_ROOT,
+        config_path="acestep-v15-xl-turbo",
+        device="mps",
+        use_mlx_dit=True,
+    )
+    dit_load_time = time.time() - t0
+
+    print(f"DiT status: {status_msg}")
+    if not success:
+        print("ERROR: DiT initialization failed!")
+        sys.exit(1)
+    print(f"DiT load time: {dit_load_time:.2f}s")
+
+    # ── Step 2: Initialize LLM Handler ──
+    print()
+    print("=" * 60)
+    print("[Phase 4] Initializing LLM handler (acestep-5Hz-lm-4B, MLX)...")
+    print("=" * 60)
+
+    llm_handler = LLMHandler()
+    t0 = time.time()
+    status_msg, success = llm_handler.initialize(
+        checkpoint_dir=CHECKPOINT_DIR,
+        lm_model_path="acestep-5Hz-lm-4B",
+        backend="mlx",
+        device="mps",
+    )
+    llm_load_time = time.time() - t0
+
+    print(f"LLM status: {status_msg}")
+    if not success:
+        print("ERROR: LLM initialization failed!")
+        sys.exit(1)
+    print(f"LLM load time: {llm_load_time:.2f}s")
+
+    # ── Step 3: Generate test audio ──
+    print()
+    print("=" * 60)
+    print("[Phase 4] Generating test audio (15s, instrumental)...")
+    print("=" * 60)
+
+    params = GenerationParams(
+        task_type="text2music",
+        caption="upbeat electronic dance music with synthesizer and drum machine, energetic and bright",
+        lyrics="[Instrumental]",
+        instrumental=True,
+        duration=15,
+        bpm=128,
+        keyscale="C Major",
+        inference_steps=8,
+        seed=42,
+    )
+
+    config = GenerationConfig(
+        batch_size=1,
+        use_random_seed=False,
+        audio_format="wav",
+    )
+
+    t0 = time.time()
+    result = generate_music(
+        dit_handler, llm_handler, params, config,
+        save_dir=OUTPUT_DIR,
+    )
+    inference_time = time.time() - t0
+
+    if not result.success:
+        print(f"ERROR: Generation failed: {result.error}")
+        sys.exit(1)
+
+    # ── Step 4: Save as test_output.wav ──
+    if result.audios:
+        generated_path = result.audios[0]["path"]
+        if generated_path != OUTPUT_FILE:
+            shutil.copy2(generated_path, OUTPUT_FILE)
+        file_size_kb = os.path.getsize(OUTPUT_FILE) / 1024
+        print(f"Output file: {OUTPUT_FILE}")
+        print(f"File size: {file_size_kb:.1f} KB")
+    else:
+        print("ERROR: No audio generated!")
+        sys.exit(1)
+
+    # ── Step 5: Print timing summary ──
+    time_costs = result.extra_outputs.get("time_costs", {})
+    print()
+    print("=" * 60)
+    print("[Phase 4] Inference Test Results")
+    print("=" * 60)
+    print(f"  DiT load time:      {dit_load_time:.2f}s")
+    print(f"  LLM load time:      {llm_load_time:.2f}s")
+    print(f"  Total model load:   {dit_load_time + llm_load_time:.2f}s")
+    print(f"  Inference time:     {inference_time:.2f}s")
+    if time_costs:
+        print(f"    LM Phase 1:       {time_costs.get('lm_phase1_time', 0):.2f}s")
+        print(f"    LM Phase 2:       {time_costs.get('lm_phase2_time', 0):.2f}s")
+        print(f"    DiT total:        {time_costs.get('dit_total_time_cost', 0):.2f}s")
+        print(f"    Pipeline total:   {time_costs.get('pipeline_total_time', 0):.2f}s")
+    print(f"  Output: {OUTPUT_FILE} ({file_size_kb:.1f} KB)")
+    print(f"  Status: PASS")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR fixes a `uv sync` resolution failure and adds documentation for macOS Apple Silicon setup.

### Changes

**`pyproject.toml`**
- Comment out Windows (`sys_platform == 'win32'`) from `required-environments` — `torch==2.7.1+cu128` has no AMD64 Windows wheels on the `pytorch-cu128` index, causing `uv sync` to fail on **all** platforms (not just Windows).

**`docs/SETUP_MACOS_APPLE_SILICON.md`** (new)
- Full setup guide for macOS Apple Silicon (tested on M4 Max, 128 GB)
- Google Drive venv workaround (symlink `.venv` to local filesystem)
- Model download instructions & selection guide by unified memory
- Inference test procedure with reference timings
- Troubleshooting table

**`test_inference.py`** (new)
- End-to-end inference test script using XL turbo DiT + 4B LM
- Generates a 15-second instrumental track and reports timing

### Test Results (M4 Max, 128 GB)
- DiT load: ~17s | LLM load: ~28s | Inference (15s audio): ~19s
- Output: valid WAV, 2.8 MB, 15.000s duration

---
[Warp conversation](https://app.warp.dev/conversation/5ef343e6-7aa3-4958-b6ab-f8e831438ae1)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup guide for macOS Apple Silicon systems, including installation prerequisites, configuration steps, model selection guidance, and troubleshooting tips.

* **Tests**
  * Added end-to-end inference test for verifying music generation functionality.

* **Chores**
  * Updated environment configuration for improved platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->