### PR TITLE
fix(test): adapt remix task_type assertion for gr.State

### DIFF
--- a/acestep/ui/gradio/events/generation/mode_ui_test.py
+++ b/acestep/ui/gradio/events/generation/mode_ui_test.py
@@ -101,7 +101,7 @@ class ModeUiStateClearingTests(unittest.TestCase):
         """Remix should keep the standard cover task and source-audio controls."""
         llm_handler = SimpleNamespace(llm_initialized=True)
         result = compute_mode_ui_updates("Remix", llm_handler=llm_handler, previous_mode="Custom")
-        self.assertEqual(result[_IDX_TASK_TYPE].get("value"), "cover")
+        self.assertEqual(result[_IDX_TASK_TYPE], "cover")
         self.assertTrue(result[_IDX_SRC_AUDIO_ROW].get("visible"))
         self.assertEqual(result[_IDX_AUDIO_CODES].get("value"), "")
         self.assertFalse(result[_IDX_AUDIO_CODES].get("visible"))


### PR DESCRIPTION
## Summary
- Follow-up to #1137: update existing test that still used `.get("value")` on `result[_IDX_TASK_TYPE]`, which is now a raw string after the `gr.Textbox` → `gr.State` change.

## Test plan
- [x] `mode_ui_test.py` — 31/31 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to correctly reflect task type output behavior in Remix mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->