### PR TITLE
feat(docker): add generic Dockerfile and CI auto-build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,13 +51,13 @@ Thumbs.db
 # Large docs / assets not needed at runtime
 docs/pics/
 
-# UV lock file (deps are installed explicitly in Dockerfile)
-uv.lock
+# Test output
+output/
 
-# Windows scripts (not needed on Jetson ARM64)
+# Windows scripts
 *.bat
 *.ps1
 
-# nano-vllm build artifacts (not used on Jetson)
+# nano-vllm build artifacts
 acestep/third_parts/nano-vllm/build/
 acestep/third_parts/nano-vllm/nano_vllm.egg-info/

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,63 @@
+name: Build and Push Container Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag override (default: git tag or sha)"
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # For tagged releases: v0.1.8 -> 0.1.8, latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            # For workflow_dispatch with custom tag
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
+            # Fallback: short SHA
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,155 @@
+# =============================================================================
+# ACE-Step 1.5 — Generic CUDA Dockerfile
+# =============================================================================
+#
+# Builds ACE-Step 1.5 for x86_64 Linux servers with NVIDIA GPUs.
+# Uses uv for fast, reproducible dependency installation.
+#
+# Build:
+#   docker build -t acestep .
+#
+# Run (Gradio UI — default):
+#   docker run --gpus all -it --rm \
+#     -p 7860:7860 \
+#     -v $(pwd)/checkpoints:/app/checkpoints \
+#     -v $(pwd)/gradio_outputs:/app/gradio_outputs \
+#     acestep
+#
+# Run (REST API server):
+#   docker run --gpus all -it --rm \
+#     -p 8001:8001 \
+#     -v $(pwd)/checkpoints:/app/checkpoints \
+#     -e ACESTEP_MODE=api \
+#     acestep
+#
+# =============================================================================
+
+# ==================== Build arguments ====================
+ARG CUDA_VERSION=12.8.1
+ARG PYTHON_VERSION=3.11
+ARG UV_VERSION=0.7
+
+# ==================== Base image ====================
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# ==================== System packages ====================
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        build-essential \
+        git \
+        curl \
+        wget \
+        # Audio libraries
+        libsndfile1 \
+        libsndfile1-dev \
+        ffmpeg \
+        # Python build deps
+        libffi-dev \
+        libssl-dev \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-dev \
+        python3.11-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# ==================== uv ====================
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# ==================== Project source ====================
+WORKDIR /app
+COPY . /app/
+
+# ==================== Install dependencies via uv ====================
+# Use uv sync with the lockfile for reproducible builds.
+# --no-dev skips dev dependencies, --frozen uses exact lockfile versions.
+RUN uv sync --frozen --no-dev --python python3.11
+
+# ==================== Runtime directories ====================
+RUN mkdir -p /app/checkpoints /app/gradio_outputs /app/output
+
+# ==================== Environment ====================
+# Bind to all interfaces for Docker port-mapping
+ENV GRADIO_SERVER_NAME=0.0.0.0
+ENV ACESTEP_API_HOST=0.0.0.0
+
+# Default startup mode: "gradio" for the web UI, "api" for the REST server
+ENV ACESTEP_MODE=gradio
+
+# Auto-initialize models on startup
+ENV ACESTEP_INIT_SERVICE=true
+
+# Default models
+ENV ACESTEP_CONFIG_PATH=acestep-v15-turbo
+ENV ACESTEP_LM_MODEL_PATH=acestep-5Hz-lm-4B
+ENV ACESTEP_LLM_BACKEND=pt
+
+# Disable tokenizers parallelism warnings
+ENV TOKENIZERS_PARALLELISM=false
+
+# ==================== Ports ====================
+# 7860 = Gradio web UI | 8001 = REST API server
+EXPOSE 7860 8001
+
+# ==================== Health check ====================
+HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -sf http://localhost:${GRADIO_PORT:-7860}/ > /dev/null 2>&1 \
+     || curl -sf http://localhost:${ACESTEP_API_PORT:-8001}/health > /dev/null 2>&1 \
+     || exit 1
+
+# ==================== Entrypoint ====================
+COPY <<'ENTRYPOINT_EOF' /app/docker-entrypoint.sh
+#!/usr/bin/env bash
+set -e
+
+echo "==========================================="
+echo "  ACE-Step 1.5"
+echo "==========================================="
+echo "Mode      : ${ACESTEP_MODE}"
+echo "Python    : $(uv run python --version 2>&1)"
+echo "PyTorch   : $(uv run python -c 'import torch; print(torch.__version__)' 2>/dev/null || echo 'N/A')"
+
+if uv run python -c 'import torch; assert torch.cuda.is_available()' 2>/dev/null; then
+    echo "CUDA      : $(uv run python -c 'import torch; print(torch.version.cuda)')"
+    echo "GPU       : $(uv run python -c 'import torch; print(torch.cuda.get_device_name(0))')"
+    echo "Memory    : $(uv run python -c 'import torch; p=torch.cuda.get_device_properties(0); print(f"{p.total_memory/1024**3:.1f} GB")')"
+else
+    echo "CUDA      : NOT AVAILABLE — running on CPU"
+    echo "           (make sure you launched with --gpus all)"
+fi
+echo "==========================================="
+
+# Build --init_service flags
+INIT_ARGS=""
+if [ "${ACESTEP_INIT_SERVICE:-true}" = "true" ]; then
+    INIT_ARGS="--init_service true"
+    [ -n "${ACESTEP_CONFIG_PATH:-}" ]   && INIT_ARGS="${INIT_ARGS} --config_path ${ACESTEP_CONFIG_PATH}"
+    [ -n "${ACESTEP_LM_MODEL_PATH:-}" ] && INIT_ARGS="${INIT_ARGS} --init_llm true --lm_model_path ${ACESTEP_LM_MODEL_PATH}"
+    echo "Auto-init    : DiT=${ACESTEP_CONFIG_PATH:-auto}  LM=${ACESTEP_LM_MODEL_PATH:-none}"
+fi
+
+if [ "${ACESTEP_MODE}" = "api" ]; then
+    echo "Starting REST API server on 0.0.0.0:${ACESTEP_API_PORT:-8001} ..."
+    exec uv run python -m acestep.api_server \
+        --host "${ACESTEP_API_HOST:-0.0.0.0}" \
+        --port "${ACESTEP_API_PORT:-8001}" \
+        ${ACESTEP_EXTRA_ARGS:-}
+else
+    echo "Starting Gradio UI on 0.0.0.0:${GRADIO_PORT:-7860} ..."
+    exec uv run python -m acestep.acestep_v15_pipeline \
+        --server-name "${GRADIO_SERVER_NAME:-0.0.0.0}" \
+        --port "${GRADIO_PORT:-7860}" \
+        --backend "${ACESTEP_LLM_BACKEND:-pt}" \
+        ${INIT_ARGS} \
+        ${ACESTEP_EXTRA_ARGS:-}
+fi
+ENTRYPOINT_EOF
+
+RUN chmod +x /app/docker-entrypoint.sh
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+# =============================================================================
+# ACE-Step 1.5 — Docker Compose (generic CUDA)
+# =============================================================================
+#
+# Usage:
+#   docker compose up              # Start Gradio UI (default)
+#   docker compose up --build      # Build and start
+#   docker compose up -d           # Run in background
+#   docker compose down            # Stop
+#   docker compose logs -f         # View logs
+#
+#   # Start REST API server instead:
+#   ACESTEP_MODE=api docker compose up
+#
+# =============================================================================
+
+services:
+  acestep:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/ace-step/ace-step-1.5:latest
+    container_name: acestep
+
+    # ---- GPU access ----
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    # ---- Environment ----
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - ACESTEP_MODE=${ACESTEP_MODE:-gradio}
+      - ACESTEP_LLM_BACKEND=${ACESTEP_LLM_BACKEND:-pt}
+      - ACESTEP_INIT_SERVICE=${ACESTEP_INIT_SERVICE:-true}
+      - ACESTEP_CONFIG_PATH=${ACESTEP_CONFIG_PATH:-acestep-v15-turbo}
+      - ACESTEP_LM_MODEL_PATH=${ACESTEP_LM_MODEL_PATH:-acestep-5Hz-lm-4B}
+      - ACESTEP_EXTRA_ARGS=${ACESTEP_EXTRA_ARGS:-}
+      - TOKENIZERS_PARALLELISM=false
+
+    # ---- Ports ----
+    ports:
+      - "${GRADIO_PORT:-7860}:7860"
+      - "${API_PORT:-8001}:8001"
+
+    # ---- Persistent volumes ----
+    volumes:
+      - ./checkpoints:/app/checkpoints
+      - hf_cache:/root/.cache/huggingface
+      - ./gradio_outputs:/app/gradio_outputs
+      - ./output:/app/output
+
+    # ---- Shared memory for PyTorch DataLoader ----
+    shm_size: "2gb"
+
+    restart: unless-stopped
+
+    healthcheck:
+      test: >-
+        curl -sf http://localhost:7860/ > /dev/null 2>&1 ||
+        curl -sf http://localhost:8001/health > /dev/null 2>&1 ||
+        exit 1
+      interval: 30s
+      timeout: 10s
+      start_period: 300s
+      retries: 3
+
+volumes:
+  hf_cache:


### PR DESCRIPTION
## Summary
- Add generic `Dockerfile` for x86_64 CUDA servers (uses `uv sync` for reproducible deps)
- Add `docker-compose.yml` for one-command startup with GPU support
- Add `.github/workflows/container.yml` that auto-builds and pushes to `ghcr.io/ace-step/ace-step-1.5` on tag push (`v*`)
- Image tags: semver (`0.1.8`), minor (`0.1`), `latest`, and short SHA
- Update `.dockerignore` to include `output/` directory

## Usage
```bash
# Pull and run (after first tag push triggers CI)
docker run --gpus all -p 7860:7860 \
  -v ./checkpoints:/app/checkpoints \
  ghcr.io/ace-step/ace-step-1.5:latest

# Or build locally
docker compose up --build
```

## Test plan
- [x] Dockerfile syntax validated
- [x] Workflow YAML validated
- [ ] CI build will trigger on next tag push (v0.1.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerization support with Docker image builds and automatic publishing to container registry on version releases.
  * Enabled containerized deployment via Docker Compose with GPU support, configurable via environment variables.
  * Supports running the application in either Gradio or REST API mode within containers.
  * Added health checks and volume mounting for models and outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->