### PR TITLE
fix: avoid Gradio interface always being en

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -228,7 +228,7 @@ def main():
     parser.add_argument(
         "--language",
         type=str,
-        default="en",
+        default=os.environ.get("LANGUAGE", "en"),
         choices=[language[0] for language in available_languages],
         help="UI language:\n  "
         + "\n  ".join(


### PR DESCRIPTION
Fixed an issue where the `.env` language setting was ignored, causing the Gradio interface to always default to English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--language` CLI argument now defaults to the `LANGUAGE` environment variable instead of always using English. If the environment variable is not configured, the application falls back to English. This enables users to configure a preferred language globally without explicitly passing the CLI argument on each run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->