### PR TITLE
Fix MP3 export TorchCodec dependency

### DIFF
--- a/acestep/audio_utils.py
+++ b/acestep/audio_utils.py
@@ -159,12 +159,16 @@ class AudioSaver:
             temp_wav_path = Path(temp_wav.name)
 
         try:
-            torchaudio.save(
+            import soundfile as sf
+
+            audio_np = tensor_to_save.detach().cpu()
+            if audio_np.dim() == 2:
+                audio_np = audio_np.transpose(0, 1)
+            sf.write(
                 str(temp_wav_path),
-                tensor_to_save,
+                audio_np.numpy(),
                 int(target_sample_rate),
-                channels_first=True,
-                backend='soundfile',
+                format="WAV",
             )
             cmd = [
                 'ffmpeg', '-y', '-hide_banner', '-loglevel', 'error',
@@ -615,4 +619,3 @@ def save_audio(
         mp3_bitrate,
         mp3_sample_rate,
     )
-

--- a/acestep/audio_utils.py
+++ b/acestep/audio_utils.py
@@ -164,6 +164,7 @@ class AudioSaver:
             audio_np = tensor_to_save.detach().cpu()
             if audio_np.dim() == 2:
                 audio_np = audio_np.transpose(0, 1)
+            audio_np = audio_np.contiguous()
             sf.write(
                 str(temp_wav_path),
                 audio_np.numpy(),

--- a/acestep/audio_utils_test.py
+++ b/acestep/audio_utils_test.py
@@ -138,6 +138,7 @@ class AudioSaverFormatTests(unittest.TestCase):
 
             mock_soundfile_write.assert_called_once()
             write_args = mock_soundfile_write.call_args[0]
+            self.assertTrue(write_args[1].flags["C_CONTIGUOUS"])
             self.assertEqual(write_args[2], 48000)
             self.assertEqual(mock_soundfile_write.call_args[1]["format"], "WAV")
 

--- a/acestep/audio_utils_test.py
+++ b/acestep/audio_utils_test.py
@@ -131,14 +131,15 @@ class AudioSaverFormatTests(unittest.TestCase):
         output_path = Path(self.temp_dir) / "test.mp3"
 
         with (
-            patch('acestep.audio_utils.torchaudio.save') as mock_torchaudio_save,
+            patch('soundfile.write') as mock_soundfile_write,
             patch('acestep.audio_utils.subprocess.run') as mock_subprocess_run,
         ):
             saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
 
-            mock_torchaudio_save.assert_called_once()
-            save_args = mock_torchaudio_save.call_args[0]
-            self.assertEqual(save_args[2], 48000)
+            mock_soundfile_write.assert_called_once()
+            write_args = mock_soundfile_write.call_args[0]
+            self.assertEqual(write_args[2], 48000)
+            self.assertEqual(mock_soundfile_write.call_args[1]["format"], "WAV")
 
             cmd = mock_subprocess_run.call_args[0][0]
             self.assertIn('libmp3lame', cmd)
@@ -153,7 +154,7 @@ class AudioSaverFormatTests(unittest.TestCase):
 
         with (
             patch('acestep.audio_utils.torchaudio.functional.resample', return_value=self.sample_audio) as mock_resample,
-            patch('acestep.audio_utils.torchaudio.save') as mock_torchaudio_save,
+            patch('soundfile.write') as mock_soundfile_write,
             patch('acestep.audio_utils.subprocess.run') as mock_subprocess_run,
         ):
             saver._save_mp3(
@@ -165,9 +166,10 @@ class AudioSaverFormatTests(unittest.TestCase):
             )
 
             mock_resample.assert_called_once_with(self.sample_audio, 48000, 44100)
-            mock_torchaudio_save.assert_called_once()
-            save_args = mock_torchaudio_save.call_args[0]
-            self.assertEqual(save_args[2], 44100)
+            mock_soundfile_write.assert_called_once()
+            write_args = mock_soundfile_write.call_args[0]
+            self.assertEqual(write_args[2], 44100)
+            self.assertEqual(mock_soundfile_write.call_args[1]["format"], "WAV")
 
             cmd = mock_subprocess_run.call_args[0][0]
             self.assertIn('320k', cmd)


### PR DESCRIPTION
## Summary

Fix MP3 export so it no longer depends on `torchaudio.save()` for the temporary WAV file used before ffmpeg encoding.

The MP3 path now writes that temporary WAV with `soundfile.write()`, then keeps the existing ffmpeg subprocess flow for encoding with `libmp3lame`.

## Why

The web UI defaults to MP3 output, so this save path runs after generation completes. On newer TorchAudio versions, `torchaudio.save()` is routed through TorchCodec internally, and the old `backend=` argument is accepted only for compatibility.

That means MP3 export can fail before the existing ffmpeg subprocess is invoked, because TorchCodec tries to load FFmpeg shared libraries inside the Python process. In environments with native library mismatches, this can surface as `RuntimeError: Could not load libtorchcodec` even though generation itself succeeded.

For MP3 export, ACE-Step only needs a temporary WAV before handing off to the ffmpeg executable. Writing that WAV with soundfile avoids the unnecessary TorchCodec dependency in this path.

## Scope

Changed:
- MP3 temporary WAV writing.
- MP3-specific unit test expectations.

Not changed:
- FLAC, WAV, WAV32, Opus, or AAC save paths.
- The ffmpeg MP3 command.
- MP3 bitrate or sample-rate behavior.
- Public save function signatures.
- UI defaults or controls.

## Validation

- `.venv/bin/python -m unittest acestep.audio_utils_test`
- Manual MP3 smoke export with `save_audio(..., format="mp3")`

## Risk

Low. The change is limited to the MP3 helper and preserves the existing output flow after the temporary WAV is written. If ffmpeg is missing or lacks `libmp3lame`, MP3 export will still fail through the existing explicit error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio export now correctly applies MP3 bitrate and sample rate parameters when saving.
* **Tests**
  * Updated MP3 export tests to reflect changes in how intermediate audio is written and to assert correct sample-rate/bitrate handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->