### PR TITLE
fix(training): unblock auto-label routes (drop dead chunk_size/batch_size, wire sample_labeled_callback)

### DIFF
--- a/acestep/api/train_api_dataset_auto_label_async_route.py
+++ b/acestep/api/train_api_dataset_auto_label_async_route.py
@@ -162,8 +162,6 @@ def register_training_dataset_auto_label_async_route(
                         transcribe_lyrics=request.transcribe_lyrics,
                         skip_metas=request.skip_metas,
                         only_unlabeled=request.only_unlabeled,
-                        chunk_size=request.chunk_size,
-                        batch_size=request.batch_size,
                         progress_callback=progress_callback,
                         sample_labeled_callback=sample_labeled_callback,
                     )

--- a/acestep/api/train_api_dataset_auto_label_sync_route.py
+++ b/acestep/api/train_api_dataset_auto_label_sync_route.py
@@ -97,8 +97,6 @@ def register_training_dataset_auto_label_sync_route(
                     transcribe_lyrics=request.transcribe_lyrics,
                     skip_metas=request.skip_metas,
                     only_unlabeled=request.only_unlabeled,
-                    chunk_size=request.chunk_size,
-                    batch_size=request.batch_size,
                     progress_callback=None,
                     sample_labeled_callback=sample_labeled_callback,
                 )

--- a/acestep/training/dataset_builder_modules/label_all.py
+++ b/acestep/training/dataset_builder_modules/label_all.py
@@ -15,6 +15,7 @@ class LabelAllMixin:
         skip_metas: bool = False,
         only_unlabeled: bool = False,
         progress_callback=None,
+        sample_labeled_callback=None,
     ) -> Tuple[List[AudioSample], str]:
         """Label all samples in the dataset."""
         if not self.samples:
@@ -52,6 +53,9 @@ class LabelAllMixin:
                 success_count += 1
             else:
                 fail_count += 1
+
+            if sample_labeled_callback:
+                sample_labeled_callback(i, sample, status)
 
         status_msg = f"✅ Labeled {success_count}/{total} samples"
         if fail_count > 0:


### PR DESCRIPTION
## Summary

`POST /v1/dataset/auto_label[_async]` is currently broken on `main` — every call fails immediately with:

```
TypeError: LabelAllMixin.label_all_samples() got an unexpected keyword argument 'chunk_size'
```

The decomposition of the dataset service into focused route modules (#769, commit d19c2f3, 2026-03-05) introduced three call-site kwargs that `LabelAllMixin.label_all_samples` (last updated 2026-02-06) does not accept: `chunk_size`, `batch_size`, and `sample_labeled_callback`. Because `AutoLabelRequest` defaults `chunk_size: int = 16` and `batch_size: int = 1`, clients cannot work around this from the request side.

This affects users driving training through the HTTP API; the Gradio UI takes a different path and is unaffected, which is why the regression has been live for ~3 months without surfacing.

## Fix

Three changes, ~4 lines:

1. **`acestep/training/dataset_builder_modules/label_all.py`** — accept `sample_labeled_callback=None` and invoke it once per labeled sample as `sample_labeled_callback(sample_idx, sample, status)`. Both routes already have incremental-save logic gated on this callback; it just never fired because the method didn't know about it. This **restores** the incremental-save behavior the route refactor intended.

2. **`acestep/api/train_api_dataset_auto_label_async_route.py`** and **`acestep/api/train_api_dataset_auto_label_sync_route.py`** — remove the dead `chunk_size=request.chunk_size` and `batch_size=request.batch_size` arguments from the `label_all_samples()` calls. The two fields on `AutoLabelRequest` are left in place so existing API callers don't break, but they have no effect; a follow-up could drop them from the schema if you prefer.

## Repro (pre-fix)

```bash
curl -X POST http://localhost:8001/v1/dataset/scan -H 'Content-Type: application/json' \\
  -d '{\"audio_dir\": \"./test_audio\"}'

curl -X POST http://localhost:8001/v1/dataset/auto_label_async \\
  -H 'Content-Type: application/json' -d '{}'

curl http://localhost:8001/v1/dataset/auto_label_status
# -> status: \"failed\", error: \"LabelAllMixin.label_all_samples() got an unexpected
#    keyword argument 'chunk_size'\"
```

## Verified

Tested locally against `POST /v1/dataset/auto_label_async` on `acestep-v15-xl-sft + acestep-5Hz-lm-4B`. Pre-patch: immediate `chunk_size` TypeError. Post-patch: auto-label completes, sample captions update, incremental saves fire.

## Test plan
- [ ] CI passes
- [ ] Manual: scan a small dataset, call `/v1/dataset/auto_label_async`, confirm the task transitions running → completed and captions are populated
- [ ] Manual: same via `/v1/dataset/auto_label` (sync route)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular progress tracking for individual sample labeling in dataset auto-labeling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ace-step/ACE-Step-1.5/pull/1226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->