### PR TITLE
docs(inference): clarify turbo guidance_scale/shift handling

### DIFF
--- a/docs/en/INFERENCE.md
+++ b/docs/en/INFERENCE.md
@@ -350,6 +350,16 @@ class FormatSampleResult:
 
 ### Generation Parameters
 
+> **💡 Turbo parameter handling.** The defaults in the tables below (`guidance_scale=7.0`, `shift=1.0`) target the **base/SFT** models. When you select a **turbo** model (`acestep-v15-turbo`, `acestep-v15-xl-turbo`), note that the two CFG/timestep parameters are handled differently:
+>
+> | Parameter | Turbo behavior |
+> |-----------|----------------|
+> | `inference_steps` | `8` is already the turbo default. |
+> | `guidance_scale` | **Auto-corrected** to `1.0` by the pipeline — turbo bakes guidance into distillation and does not use CFG, so any value you pass is overridden (see `acestep/core/generation/handler/generate_music.py`). No action needed. |
+> | `shift` | **Not** auto-corrected. The default `1.0` is applied as-is; set **`shift=3.0`** for turbo (as the `shift` row below recommends). |
+>
+> In other words, the only timestep/guidance parameter you need to set manually for turbo is `shift=3.0`.
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `inference_steps` | `int` | `8` | Number of denoising steps. Turbo model: 1-20 (recommended 8). Base model: 1-200 (recommended 32-64). Higher = better quality but slower. |


### PR DESCRIPTION
## Summary

For **turbo** models, the two CFG/timestep parameters behave differently, and that asymmetry is easy to miss from the scattered per-row notes in the parameter tables:

- **`guidance_scale`** is **auto-corrected to `1.0`** by the pipeline — turbo bakes guidance into distillation and does not use CFG, so the documented default `7.0` is overridden at runtime and is harmless. Source: `acestep/core/generation/handler/generate_music.py`:
  ```python
  if self.is_turbo_model() and guidance_scale != 1.0:
      logger.info("[generate_music] Turbo model detected: overriding guidance_scale {:.1f} -> 1.0 ...", guidance_scale)
      guidance_scale = 1.0
  ```
- **`shift`** is **not** auto-corrected: the default `1.0` is applied as-is even though the `shift` row recommends `3.0` for turbo, so it must be set manually.

## Change

Adds a short callout at the top of the **Generation Parameters** section in `docs/en/INFERENCE.md` making the turbo handling explicit: `inference_steps=8` is the turbo default, `guidance_scale` is auto-corrected (no action needed), and the **only** value to set manually for turbo is **`shift=3.0`**. Docs-only, no behavior change.

## Verification

Confirmed empirically on a Tesla T4 by running `acestep-v15-turbo`: the runtime log shows `Turbo model detected: overriding guidance_scale 7.0 -> 1.0`, while `shift` is passed through unchanged. The callout reflects the actual code path, not just the table text.

> Note: I initially framed this around `guidance_scale` needing a manual override; on verifying against the code I corrected it — the pipeline already handles `guidance_scale`, and `shift` is the genuinely-manual one. This PR reflects the corrected, verified behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Generation Parameters with Turbo model-specific recommendations.
  * Added a reference table showing recommended defaults for inference_steps, guidance_scale, and shift when using Turbo models.
  * Noted which parameters are auto-corrected by the pipeline and which require explicit user values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->