### PR TITLE
Add missing parameter which is needed for lego mode.

### DIFF
--- a/docs/en/INFERENCE.md
+++ b/docs/en/INFERENCE.md
@@ -546,6 +546,7 @@ params = GenerationParams(
     caption="lead guitar melody with bluesy feel",
     repainting_start=0.0,
     repainting_end=-1,
+    dcw_enabled=False
 )
 ```
 


### PR DESCRIPTION
This updates the documentation to address the problem in #1255 where random noise is generated instead of the additional track in lego mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Lego base model inference example to include the `dcw_enabled=False` generation parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->