### PR TITLE
fix(api): use per-run seeds in sequential MPS cover mode

### DIFF
--- a/acestep/api/job_generation_runtime.py
+++ b/acestep/api/job_generation_runtime.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from typing import Any, Callable
 
 
+def _sequential_seed_slices(config: Any, sequential_runs: int) -> list:
+    """Split requested seeds into per-run slices for sequential cover mode.
+
+    Runs beyond the provided seed list fall back to ``None`` so downstream
+    seed preparation draws a random seed, matching batched behavior.
+    """
+    if getattr(config, "use_random_seed", True):
+        return [getattr(config, "seeds", None)] * sequential_runs
+    seeds = getattr(config, "seeds", None)
+    if isinstance(seeds, int):
+        seeds = [seeds]
+    if not isinstance(seeds, list) or len(seeds) == 0:
+        return [seeds] * sequential_runs
+    return [[seeds[run_idx]] if run_idx < len(seeds) else None for run_idx in range(sequential_runs)]
+
+
 def run_generation_with_optional_sequential_cover_mode(
     *,
     req: Any,
@@ -42,10 +58,12 @@ def run_generation_with_optional_sequential_cover_mode(
     """
 
     sequential_runs = 1
+    sequential_seed_slices = None
     if req.task_type in ("cover", "cover-nofsq") and handler_device == "mps":
         if config.batch_size is not None and config.batch_size > 1:
             sequential_runs = int(config.batch_size)
             config.batch_size = 1
+            sequential_seed_slices = _sequential_seed_slices(config, sequential_runs)
             log_fn(
                 f"[API Server] Job {job_id}: MPS cover sequential mode enabled "
                 f"(runs={sequential_runs})"
@@ -75,6 +93,11 @@ def run_generation_with_optional_sequential_cover_mode(
     aggregated_result = None
     all_audios = []
     for run_idx in range(sequential_runs):
+        if sequential_seed_slices is not None:
+            # Each sequential batch-1 run must consume its own seed; reusing the
+            # full seed list makes prepare_seeds pick the first seed every run
+            # and produces identical variants.
+            config.seeds = sequential_seed_slices[run_idx]
         if sequential_runs > 1:
             log_fn(f"[API Server] Job {job_id}: Sequential cover run {run_idx + 1}/{sequential_runs}")
         if sequential_runs > 1:

--- a/acestep/api/job_generation_runtime_test.py
+++ b/acestep/api/job_generation_runtime_test.py
@@ -69,6 +69,73 @@ class JobGenerationRuntimeTests(unittest.TestCase):
         self.assertEqual(2, len(out.audios))
         self.assertTrue(any("Sequential cover run" in str(call.args[0]) for call in log_fn.call_args_list))
 
+    def _run_sequential_cover(self, *, seeds, use_random_seed=False, batch_size=2, task_type="cover"):
+        req = SimpleNamespace(task_type=task_type)
+        config = SimpleNamespace(batch_size=batch_size, seeds=seeds, use_random_seed=use_random_seed)
+        seen_seeds = []
+
+        def _generate(**kwargs):
+            cfg = kwargs["config"]
+            seen_seeds.append(list(cfg.seeds) if isinstance(cfg.seeds, list) else cfg.seeds)
+            return SimpleNamespace(
+                success=True,
+                audios=[{"audio_path": f"{len(seen_seeds)}.wav"}],
+                error=None,
+                status_message="",
+            )
+
+        out = run_generation_with_optional_sequential_cover_mode(
+            req=req,
+            job_id="job-seeds",
+            handler_device="mps",
+            config=config,
+            params=SimpleNamespace(),
+            dit_handler=MagicMock(),
+            llm_handler=MagicMock(),
+            temp_audio_dir="tmp",
+            generate_music_fn=_generate,
+            progress_cb=MagicMock(),
+            log_fn=MagicMock(),
+        )
+        return out, seen_seeds
+
+    def test_sequential_cover_uses_one_seed_per_run(self) -> None:
+        """MPS cover runs must consume per-run seeds instead of repeating the first."""
+
+        out, seen_seeds = self._run_sequential_cover(seeds=[111, 222])
+
+        self.assertEqual([[111], [222]], seen_seeds)
+        self.assertEqual(2, len(out.audios))
+
+    def test_sequential_cover_pads_missing_seeds_with_none(self) -> None:
+        """Runs beyond the provided seed list should fall back to unseeded generation."""
+
+        _, seen_seeds = self._run_sequential_cover(seeds=[111])
+
+        self.assertEqual([111], seen_seeds[0])
+        self.assertIsNone(seen_seeds[1])
+
+    def test_sequential_cover_nofsq_uses_one_seed_per_run(self) -> None:
+        """cover-nofsq takes the same sequential path and must slice seeds too."""
+
+        _, seen_seeds = self._run_sequential_cover(seeds=[111, 222], task_type="cover-nofsq")
+
+        self.assertEqual([[111], [222]], seen_seeds)
+
+    def test_sequential_cover_ignores_extra_seeds_beyond_batch(self) -> None:
+        """Extra seeds past batch_size are dropped, matching batched truncation."""
+
+        _, seen_seeds = self._run_sequential_cover(seeds=[111, 222, 333])
+
+        self.assertEqual([[111], [222]], seen_seeds)
+
+    def test_sequential_cover_random_seed_leaves_seeds_untouched(self) -> None:
+        """Random-seed requests should keep the original config value for every run."""
+
+        _, seen_seeds = self._run_sequential_cover(seeds=None, use_random_seed=True)
+
+        self.assertEqual([None, None], seen_seeds)
+
     def test_raises_when_generation_fails(self) -> None:
         """Generation failure should raise with original error message format."""
 


### PR DESCRIPTION
## Problem

On MPS, cover-family tasks (`cover`, `cover-nofsq`) with `batch_size > 1` are split into sequential batch-1 runs by `run_generation_with_optional_sequential_cover_mode`. Each sequential run, however, receives the **full** requested seed list, so downstream seed preparation picks the first seed every time. All "variants" of the batch are generated with the same seed and come out byte-identical.

The batched path (CUDA and other devices that don't enter sequential mode) consumes one seed per batch item correctly, so this only affects the MPS sequential branch.

## Reproduction

- Device: MPS (Apple Silicon)
- Request: `task_type=cover`, `batch_size=2`, `use_random_seed=false`, `seeds=[20260713, 20260714]`
- Actual: both outputs are generated with seed `20260713` (identical audio files)
- Expected: run 1 uses `20260713`, run 2 uses `20260714` (matching batched behavior)

## Fix

Add `_sequential_seed_slices`, which splits the requested seeds into per-run slices before the sequential loop, and assign each run its own slice:

- explicit seed list → run *i* gets `[seeds[i]]`; extra seeds past `batch_size` are dropped, matching batched truncation
- a single int seed is treated as a one-element list
- more runs than seeds → extra runs get `None`, so seed preparation falls back to a random seed (matching batched behavior)
- `use_random_seed=true` or missing/empty seeds → config value passed through unchanged for every run

## Blast radius

- Product code touched: only the MPS sequential cover branch in `acestep/api/job_generation_runtime.py` (plus its unit test file); the helper is invoked exclusively inside the `handler_device == "mps"` block.
- **Non-target platforms unchanged** — code path is unreachable for CUDA/CPU/XPU (they never enter sequential mode).
- No behavior change for `use_random_seed=true` requests or for `batch_size == 1`.
- Additive change only (no lines removed).

## Regression checklist

- [x] `python -m unittest acestep.api.job_generation_runtime_test` — 8 tests OK (5 new + 3 pre-existing)
- [x] New tests cover: per-run seed consumption (`cover` and `cover-nofsq`), fallback past the seed list, extra seeds beyond `batch_size`, `use_random_seed` passthrough
- [x] Verified end-to-end on MPS (M-series): `batch_size=2` cover request with two fixed seeds now produces two distinct outputs; previously byte-identical
- [x] Based on current `main`; the fix applies to both `cover` and `cover-nofsq`

## Reviewer notes

- `config.seeds` is reassigned in place across sequential runs; this follows the pre-existing pattern in this function (`config.batch_size` is already mutated the same way), and `config` is rebuilt per job so nothing reads the original list afterwards. The per-audio seed echo in the response comes from each run's actual seed, so it stays accurate.
- Out of scope: seed handling on non-MPS paths and LM chunk seeding are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequential cover generation on Apple silicon devices by ensuring each run uses its assigned seed.
  * Prevented missing seeds from causing inconsistent runs by safely filling unavailable values.
  * Preserved existing random-seed behavior and ignored excess seeds beyond the requested batch size.

* **Tests**
  * Added coverage for seeded, random-seeded, and no-frequency-separation cover generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->