### PR TITLE
feat: multi-GPU component placement (DiT / 5Hz LM on separate GPUs) for Gradio + CLI

### DIFF
--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -430,9 +430,20 @@ def main():
     # the DiT (via ACESTEP_*_DEVICE overrides OR free-VRAM auto-ranking), the LM no
     # longer competes for the DiT's VRAM, so the single-GPU offload/downgrade
     # heuristics below do not apply.
-    from acestep.core.generation.device_mapping import resolve_component_device_map as _rcdm
-    _cmap = _rcdm()
-    _multi_gpu_lm = bool(_cmap.dit and _cmap.lm and _cmap.lm != _cmap.dit)
+    # Resolve the component->device map ONCE here (before the DiT is loaded) and
+    # reuse it for the LM placement below so both stay consistent. Only consult the
+    # CUDA map when a CUDA/auto device is requested: an explicit cpu/mps/xpu device
+    # must not be silently overridden onto a cuda:N card. Validate env overrides
+    # (e.g. ACESTEP_LM_DEVICE=cuda:9) up front so they fail with a clear message.
+    from acestep.core.generation.device_mapping import (
+        resolve_component_device_map as _rcdm,
+        validate_component_device_map as _vcdm,
+    )
+    _device_kind = str(args.device).split(":", 1)[0]
+    _cmap = _rcdm() if _device_kind in {"auto", "cuda"} else None
+    if _cmap is not None:
+        _vcdm(_cmap)
+    _multi_gpu_lm = bool(_cmap and _cmap.dit and _cmap.lm and _cmap.lm != _cmap.dit)
 
     # Auto-enable CPU offload for tier6 GPUs (16-24GB) when using the 4B LM model
     # The 4B LM (~8GB) + DiT (~4.7GB) + VAE + text encoder exceeds 16-20GB with activations
@@ -574,11 +585,10 @@ def main():
                             file=sys.stderr,
                         )
 
-                    from acestep.core.generation.device_mapping import (
-                        resolve_component_device_map,
-                    )
-                    _dev_map = resolve_component_device_map()
-                    _lm_device = _dev_map.lm or args.device
+                    # Reuse the map resolved above (None when a non-CUDA device was
+                    # requested); re-resolving here would re-rank GPUs by free VRAM
+                    # after the DiT load and could disagree with the placement above.
+                    _lm_device = (_cmap.lm if _cmap is not None else None) or args.device
                     # In multi-GPU mode the LM has its own dedicated card, so it must
                     # stay resident there (do NOT offload it to CPU even if the DiT
                     # handler offloads VAE/text-encoder to free the DiT's VRAM).

--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -426,10 +426,13 @@ def main():
     if args.service_mode:
         print(f"  Backend: {args.backend}")
 
-    # Multi-GPU component placement (ACESTEP_LM_DEVICE): when the LM is pinned to
-    # its own dedicated GPU, the single-GPU offload/downgrade heuristics below do
-    # not apply (the LM no longer competes for the DiT's VRAM).
-    _multi_gpu_lm = bool(os.getenv("ACESTEP_LM_DEVICE"))
+    # Multi-GPU component placement: when the LM is mapped to a different GPU than
+    # the DiT (via ACESTEP_*_DEVICE overrides OR free-VRAM auto-ranking), the LM no
+    # longer competes for the DiT's VRAM, so the single-GPU offload/downgrade
+    # heuristics below do not apply.
+    from acestep.core.generation.device_mapping import resolve_component_device_map as _rcdm
+    _cmap = _rcdm()
+    _multi_gpu_lm = bool(_cmap.dit and _cmap.lm and _cmap.lm != _cmap.dit)
 
     # Auto-enable CPU offload for tier6 GPUs (16-24GB) when using the 4B LM model
     # The 4B LM (~8GB) + DiT (~4.7GB) + VAE + text encoder exceeds 16-20GB with activations

--- a/acestep/acestep_v15_pipeline.py
+++ b/acestep/acestep_v15_pipeline.py
@@ -426,9 +426,14 @@ def main():
     if args.service_mode:
         print(f"  Backend: {args.backend}")
 
+    # Multi-GPU component placement (ACESTEP_LM_DEVICE): when the LM is pinned to
+    # its own dedicated GPU, the single-GPU offload/downgrade heuristics below do
+    # not apply (the LM no longer competes for the DiT's VRAM).
+    _multi_gpu_lm = bool(os.getenv("ACESTEP_LM_DEVICE"))
+
     # Auto-enable CPU offload for tier6 GPUs (16-24GB) when using the 4B LM model
     # The 4B LM (~8GB) + DiT (~4.7GB) + VAE + text encoder exceeds 16-20GB with activations
-    if not args.offload_to_cpu and args.lm_model_path and "4B" in args.lm_model_path:
+    if not args.offload_to_cpu and args.lm_model_path and "4B" in args.lm_model_path and not _multi_gpu_lm:
         if 0 < gpu_memory_gb <= 24:
             args.offload_to_cpu = True
             print(
@@ -438,7 +443,7 @@ def main():
     # Safety: on 16GB GPUs, prevent selecting LM models that are too large.
     # Even with offloading, a 4B LM (8 GB weights + KV cache) leaves almost no
     # headroom for DiT activations on a 16 GB card.
-    if args.lm_model_path and 0 < gpu_memory_gb < VRAM_AUTO_OFFLOAD_THRESHOLD_GB:
+    if args.lm_model_path and 0 < gpu_memory_gb < VRAM_AUTO_OFFLOAD_THRESHOLD_GB and not _multi_gpu_lm:
         if "4B" in args.lm_model_path:
             # Downgrade to 1.7B if available
             fallback = args.lm_model_path.replace("4B", "1.7B")
@@ -566,15 +571,24 @@ def main():
                             file=sys.stderr,
                         )
 
+                    from acestep.core.generation.device_mapping import (
+                        resolve_component_device_map,
+                    )
+                    _dev_map = resolve_component_device_map()
+                    _lm_device = _dev_map.lm or args.device
+                    # In multi-GPU mode the LM has its own dedicated card, so it must
+                    # stay resident there (do NOT offload it to CPU even if the DiT
+                    # handler offloads VAE/text-encoder to free the DiT's VRAM).
+                    _lm_offload = False if _multi_gpu_lm else args.offload_to_cpu
                     print(
-                        f"Initializing 5Hz LM: {args.lm_model_path} on {args.device}..."
+                        f"Initializing 5Hz LM: {args.lm_model_path} on {_lm_device} (offload_to_cpu={_lm_offload})..."
                     )
                     lm_status, lm_success = llm_handler.initialize(
                         checkpoint_dir=checkpoint_dir,
                         lm_model_path=args.lm_model_path,
                         backend=args.backend,
-                        device=args.device,
-                        offload_to_cpu=args.offload_to_cpu,
+                        device=_lm_device,
+                        offload_to_cpu=_lm_offload,
                         dtype=None,
                     )
 

--- a/acestep/core/generation/device_mapping.py
+++ b/acestep/core/generation/device_mapping.py
@@ -1,0 +1,165 @@
+"""Utilities for dynamic multi-device component mapping.
+
+Based on PR #1149 (imsarang) — extended with explicit environment-variable
+overrides (ACESTEP_DIT_DEVICE / ACESTEP_VAE_DEVICE / ACESTEP_LM_DEVICE) so that
+users of asymmetric multi-GPU rigs can pin each component deterministically
+(e.g. DiT on the fast card, LM on the second card).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from loguru import logger  # type: ignore[reportMissingImports]
+
+try:
+    import torch  # type: ignore[reportMissingImports]
+except ImportError:  # pragma: no cover - fallback for minimal environments
+    torch = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class ComponentDeviceMap:
+    """Normalized component-to-device mapping."""
+
+    dit: Optional[str] = None
+    vae: Optional[str] = None
+    lm: Optional[str] = None
+
+
+def _rank_cuda_devices_by_free_vram() -> list[int]:
+    """Return CUDA device indices sorted by descending free VRAM."""
+    if torch is None or not torch.cuda.is_available():
+        return []
+
+    device_count = torch.cuda.device_count()
+    free_by_device: list[tuple[int, int]] = []
+    for idx in range(device_count):
+        free_bytes = 0
+        try:
+            free_bytes = int(torch.cuda.mem_get_info(idx)[0])
+        except RuntimeError as exc:
+            logger.debug(
+                "[device_mapping] mem_get_info({}) failed ({}); retrying with device context.",
+                idx,
+                exc,
+            )
+            try:
+                with torch.cuda.device(idx):
+                    free_bytes = int(torch.cuda.mem_get_info()[0])
+            except RuntimeError as exc2:
+                logger.warning(
+                    "[device_mapping] Unable to query free VRAM for cuda:{} ({}); ranking it last.",
+                    idx,
+                    exc2,
+                )
+                free_bytes = 0
+        free_by_device.append((idx, free_bytes))
+    free_by_device.sort(key=lambda pair: pair[1], reverse=True)
+    return [idx for idx, _free in free_by_device]
+
+
+def _env_device_overrides() -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Read explicit per-component device overrides from the environment."""
+    def _norm(val: Optional[str]) -> Optional[str]:
+        if val is None:
+            return None
+        val = val.strip()
+        return val or None
+
+    return (
+        _norm(os.getenv("ACESTEP_DIT_DEVICE")),
+        _norm(os.getenv("ACESTEP_VAE_DEVICE")),
+        _norm(os.getenv("ACESTEP_LM_DEVICE")),
+    )
+
+
+def resolve_component_device_map() -> ComponentDeviceMap:
+    """Auto-populate component mapping from available CUDA devices.
+
+    Explicit env overrides (ACESTEP_DIT_DEVICE / ACESTEP_VAE_DEVICE /
+    ACESTEP_LM_DEVICE) take precedence over the free-VRAM auto-ranking, allowing
+    deterministic pinning on asymmetric multi-GPU setups.
+    """
+    env_dit, env_vae, env_lm = _env_device_overrides()
+
+    if torch is None or not torch.cuda.is_available():
+        if env_dit or env_vae or env_lm:
+            return ComponentDeviceMap(dit=env_dit, vae=env_vae, lm=env_lm)
+        return ComponentDeviceMap()
+
+    ranked = _rank_cuda_devices_by_free_vram()
+    if not ranked:
+        if env_dit or env_vae or env_lm:
+            return ComponentDeviceMap(dit=env_dit, vae=env_vae, lm=env_lm)
+        return ComponentDeviceMap()
+
+    dit_idx = ranked[0]
+    vae_idx = ranked[1] if len(ranked) > 1 else ranked[0]
+    lm_idx = ranked[2] if len(ranked) > 2 else ranked[-1]
+
+    return ComponentDeviceMap(
+        dit=env_dit or f"cuda:{dit_idx}",
+        vae=env_vae or f"cuda:{vae_idx}",
+        lm=env_lm or f"cuda:{lm_idx}",
+    )
+
+
+def format_component_gpu_hint_text(
+    *,
+    default_device: str = "auto",
+    label: str = "Component GPU hint",
+) -> str:
+    """Format component placement hint for UI display.
+
+    Returns an empty string when all components resolve to the same final device,
+    which avoids noisy UI on non-CUDA and single-device hosts.
+    """
+    mapping = resolve_component_device_map()
+    resolved_devices = [
+        mapping.dit or default_device,
+        mapping.vae or default_device,
+        mapping.lm or default_device,
+    ]
+    if len(set(resolved_devices)) == 1:
+        return ""
+
+    return (
+        f"{label}: "
+        f"DiT={resolved_devices[0]}, "
+        f"VAE={resolved_devices[1]}, "
+        f"LM={resolved_devices[2]}"
+    )
+
+
+def validate_component_device_map(mapping: ComponentDeviceMap) -> None:
+    """Validate that mapped CUDA indices exist on the current host.
+
+    Args:
+        mapping: Component-to-device mapping to validate.
+
+    Raises:
+        ValueError: If any ``cuda:<idx>`` entry references an index out of range
+            for visible CUDA devices.
+    """
+    cuda_count = torch.cuda.device_count() if torch is not None and torch.cuda.is_available() else 0
+    for component, device in (
+        ("dit", mapping.dit),
+        ("vae", mapping.vae),
+        ("lm", mapping.lm),
+    ):
+        if not device or not device.startswith("cuda:"):
+            continue
+        try:
+            idx = int(device.split(":", 1)[1])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid {component} device '{device}': expected 'cuda:<int>' with "
+                f"0 <= idx < {cuda_count}."
+            ) from exc
+        if idx < 0 or idx >= cuda_count:
+            raise ValueError(
+                f"Invalid {component} device '{device}': only {cuda_count} CUDA device(s) available."
+            )

--- a/acestep/core/generation/device_mapping_test.py
+++ b/acestep/core/generation/device_mapping_test.py
@@ -1,0 +1,105 @@
+"""Unit tests for multi-GPU component device mapping."""
+
+import os
+import unittest
+from unittest import mock
+
+from acestep.core.generation import device_mapping as dm
+from acestep.core.generation.device_mapping import ComponentDeviceMap
+
+_ENV_KEYS = ("ACESTEP_DIT_DEVICE", "ACESTEP_VAE_DEVICE", "ACESTEP_LM_DEVICE")
+
+
+class _FakeCuda:
+    def __init__(self, count, free_by_idx):
+        self._count = count
+        self._free = free_by_idx
+
+    def is_available(self):
+        return True
+
+    def device_count(self):
+        return self._count
+
+    def mem_get_info(self, idx=0):
+        return (self._free[idx], 16 * 1024 ** 3)
+
+
+class _FakeTorch:
+    def __init__(self, count, free_by_idx):
+        self.cuda = _FakeCuda(count, free_by_idx)
+
+
+def _clear_env():
+    for k in _ENV_KEYS:
+        os.environ.pop(k, None)
+
+
+class DeviceMappingTest(unittest.TestCase):
+    def setUp(self):
+        _clear_env()
+
+    def tearDown(self):
+        _clear_env()
+
+    def test_env_overrides_take_precedence_over_ranking(self):
+        fake = _FakeTorch(2, {0: 5 * 1024 ** 3, 1: 10 * 1024 ** 3})
+        with mock.patch.object(dm, "torch", fake):
+            os.environ["ACESTEP_DIT_DEVICE"] = "cuda:0"
+            os.environ["ACESTEP_VAE_DEVICE"] = "cuda:0"
+            os.environ["ACESTEP_LM_DEVICE"] = "cuda:1"
+            m = dm.resolve_component_device_map()
+        self.assertEqual(m.dit, "cuda:0")
+        self.assertEqual(m.vae, "cuda:0")
+        self.assertEqual(m.lm, "cuda:1")
+
+    def test_auto_ranking_by_free_vram(self):
+        # idx 1 has more free VRAM -> DiT; idx 0 -> VAE and LM (2 GPUs).
+        fake = _FakeTorch(2, {0: 5 * 1024 ** 3, 1: 10 * 1024 ** 3})
+        with mock.patch.object(dm, "torch", fake):
+            m = dm.resolve_component_device_map()
+        self.assertEqual(m.dit, "cuda:1")
+        self.assertEqual(m.vae, "cuda:0")
+        self.assertEqual(m.lm, "cuda:0")
+
+    def test_single_gpu_maps_all_to_same_device(self):
+        fake = _FakeTorch(1, {0: 8 * 1024 ** 3})
+        with mock.patch.object(dm, "torch", fake):
+            m = dm.resolve_component_device_map()
+        self.assertEqual(m.dit, "cuda:0")
+        self.assertEqual(m.vae, "cuda:0")
+        self.assertEqual(m.lm, "cuda:0")
+
+    def test_no_cuda_returns_empty_map_without_env(self):
+        with mock.patch.object(dm, "torch", None):
+            m = dm.resolve_component_device_map()
+        self.assertEqual(m, ComponentDeviceMap())
+
+    def test_validate_raises_on_out_of_range_index(self):
+        fake = _FakeTorch(2, {0: 1, 1: 1})
+        with mock.patch.object(dm, "torch", fake):
+            with self.assertRaises(ValueError):
+                dm.validate_component_device_map(ComponentDeviceMap(dit="cuda:5"))
+
+    def test_validate_passes_on_valid_indices(self):
+        fake = _FakeTorch(2, {0: 1, 1: 1})
+        with mock.patch.object(dm, "torch", fake):
+            dm.validate_component_device_map(
+                ComponentDeviceMap(dit="cuda:0", vae="cuda:0", lm="cuda:1")
+            )
+
+    def test_hint_is_empty_when_single_device(self):
+        fake = _FakeTorch(1, {0: 8 * 1024 ** 3})
+        with mock.patch.object(dm, "torch", fake):
+            self.assertEqual(dm.format_component_gpu_hint_text(), "")
+
+    def test_hint_non_empty_when_components_differ(self):
+        fake = _FakeTorch(2, {0: 5 * 1024 ** 3, 1: 10 * 1024 ** 3})
+        with mock.patch.object(dm, "torch", fake):
+            hint = dm.format_component_gpu_hint_text(label="GPU map")
+        self.assertIn("DiT=cuda:1", hint)
+        self.assertIn("LM=cuda:0", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/core/generation/handler/init_service_loader.py
+++ b/acestep/core/generation/handler/init_service_loader.py
@@ -141,9 +141,14 @@ class InitServiceLoaderMixin(InitServiceLoaderComponentsMixin):
                     exc,
                 )
 
+        # Query bfloat16 support on the *mapped* CUDA device (e.g. cuda:1), not the
+        # current/default device, so mixed-generation multi-GPU rigs select the right
+        # attention backend. A bare "cuda" parses to index None (= current device).
+        _device_kind, _, _device_index = str(device).partition(":")
+        _cuda_index = int(_device_index) if _device_index.isdigit() else None
         if use_flash_attention and self.is_flash_attention_available(device):
             attn_implementation = "flash_attention_2"
-        elif str(device).split(":", 1)[0] == "cuda" and not gpu_config.cuda_supports_bfloat16():
+        elif _device_kind == "cuda" and not gpu_config.cuda_supports_bfloat16(_cuda_index):
             # Pre-Ampere GPUs (compute capability < 8.0) run in float16 which
             # can overflow in SDPA's fused softmax with longer sequences,
             # producing NaN/Inf latents (see issues #924, #927).  Eager

--- a/acestep/core/generation/handler/init_service_loader.py
+++ b/acestep/core/generation/handler/init_service_loader.py
@@ -143,7 +143,7 @@ class InitServiceLoaderMixin(InitServiceLoaderComponentsMixin):
 
         if use_flash_attention and self.is_flash_attention_available(device):
             attn_implementation = "flash_attention_2"
-        elif device == "cuda" and not gpu_config.cuda_supports_bfloat16():
+        elif str(device).split(":", 1)[0] == "cuda" and not gpu_config.cuda_supports_bfloat16():
             # Pre-Ampere GPUs (compute capability < 8.0) run in float16 which
             # can overflow in SDPA's fused softmax with longer sequences,
             # producing NaN/Inf latents (see issues #924, #927).  Eager

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -214,7 +214,7 @@ class InitServiceOrchestratorMixin:
             self.last_init_params = {
                 "project_root": project_root,
                 "config_path": config_path,
-                "device": dit_device,
+                "device": resolved_device,
                 "dit_device": dit_device,
                 "vae_device": vae_device,
                 "use_flash_attention": use_flash_attention,

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -107,7 +107,16 @@ class InitServiceOrchestratorMixin:
                     "(set ACESTEP_ROCM_DTYPE=bfloat16 or float16 to override)"
                 )
             elif resolved_device == "cuda":
-                if gpu_config.cuda_supports_bfloat16():
+                # Query bfloat16 support on the DiT's mapped card (e.g. cuda:1) rather
+                # than the current/default device, so the shared DiT/text-encoder dtype
+                # matches the real hardware on mixed-generation multi-GPU rigs.
+                _dit_str = str(dit_device)
+                _dit_index = (
+                    int(_dit_str.split(":", 1)[1])
+                    if _dit_str.startswith("cuda:") and _dit_str.split(":", 1)[1].isdigit()
+                    else None
+                )
+                if gpu_config.cuda_supports_bfloat16(_dit_index):
                     self.dtype = torch.bfloat16
                 else:
                     self.dtype = torch.float16

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -9,6 +9,11 @@ import torch
 from loguru import logger
 
 from acestep import gpu_config
+from acestep.core.generation.device_mapping import (
+    ComponentDeviceMap,
+    resolve_component_device_map,
+    validate_component_device_map,
+)
 
 _ROCM_DTYPE_MAP = {
     "float32": torch.float32,
@@ -50,6 +55,7 @@ class InitServiceOrchestratorMixin:
         project_root: str,
         config_path: str,
         device: str = "auto",
+        component_device_map: Optional[ComponentDeviceMap] = None,
         use_flash_attention: bool = False,
         compile_model: bool = False,
         offload_to_cpu: bool = False,
@@ -72,7 +78,19 @@ class InitServiceOrchestratorMixin:
                 )
 
             resolved_device = self._resolve_initialize_device(device)
-            self.device = resolved_device
+            if component_device_map is None:
+                component_device_map = resolve_component_device_map()
+            validate_component_device_map(component_device_map)
+            dit_device = component_device_map.dit or resolved_device
+            vae_device = component_device_map.vae or resolved_device
+            logger.info(
+                "[initialize_service] Resolved component GPU map: DiT={}, VAE={}, LM={}",
+                dit_device,
+                vae_device,
+                component_device_map.lm or resolved_device,
+            )
+
+            self.device = dit_device
             self.offload_to_cpu = offload_to_cpu
             self.offload_dit_to_cpu = offload_dit_to_cpu
 
@@ -155,24 +173,24 @@ class InitServiceOrchestratorMixin:
             model_path = os.path.join(checkpoint_dir, config_path)
             self._load_main_model_from_checkpoint(
                 model_checkpoint_path=model_path,
-                device=resolved_device,
+                device=dit_device,
                 use_flash_attention=use_flash_attention,
                 compile_model=normalized_compile,
                 quantization=self.quantization,
             )
             vae_path = self._load_vae_model(
                 checkpoint_dir=checkpoint_dir,
-                device=resolved_device,
+                device=vae_device,
                 compile_model=normalized_compile,
                 vae_variant=resolved_vae_variant,
             )
             text_encoder_path = self._load_text_encoder_and_tokenizer(
                 checkpoint_dir=checkpoint_dir,
-                device=resolved_device,
+                device=dit_device,
             )
 
             mlx_dit_status, mlx_vae_status = self._initialize_mlx_backends(
-                device=resolved_device,
+                device=dit_device,
                 use_mlx_dit=use_mlx_dit,
                 mlx_compile_requested=mlx_compile_requested,
             )
@@ -196,7 +214,9 @@ class InitServiceOrchestratorMixin:
             self.last_init_params = {
                 "project_root": project_root,
                 "config_path": config_path,
-                "device": resolved_device,
+                "device": dit_device,
+                "dit_device": dit_device,
+                "vae_device": vae_device,
                 "use_flash_attention": use_flash_attention,
                 "compile_model": normalized_compile,
                 "offload_to_cpu": offload_to_cpu,

--- a/acestep/core/generation/handler/init_service_orchestrator.py
+++ b/acestep/core/generation/handler/init_service_orchestrator.py
@@ -82,7 +82,7 @@ class InitServiceOrchestratorMixin:
                 component_device_map = resolve_component_device_map()
             validate_component_device_map(component_device_map)
             dit_device = component_device_map.dit or resolved_device
-            vae_device = component_device_map.vae or resolved_device
+            vae_device = component_device_map.vae or dit_device
             logger.info(
                 "[initialize_service] Resolved component GPU map: DiT={}, VAE={}, LM={}",
                 dit_device,

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -401,7 +401,10 @@ class LLMHandler:
     def _load_pytorch_model(self, model_path: str, device: str) -> Tuple[bool, str]:
         """Load PyTorch model from path and return (success, status_message)"""
         try:
-            self.llm = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True)
+            _pt_load_kwargs = {"trust_remote_code": True}
+            if self.dtype is not None:
+                _pt_load_kwargs["dtype"] = self.dtype
+            self.llm = AutoModelForCausalLM.from_pretrained(model_path, **_pt_load_kwargs)
             if not self.offload_to_cpu:
                 self.llm = self.llm.to(device).to(self.dtype)
             else:
@@ -569,7 +572,7 @@ class LLMHandler:
             # produce NaN/inf when naively converted to float16 (different exponent range).
             # The DiT and VAE use float16 on MPS where it actually helps throughput.
             if dtype is None:
-                if device in ["cuda", "xpu"]:
+                if device.split(":")[0] in ["cuda", "xpu"]:
                     self.dtype = torch.bfloat16
                 else:
                     self.dtype = torch.float32

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -100,13 +100,19 @@ def init_service_wrapper(
             )
             lm_device = "cpu"
         else:
-            from acestep.core.generation.device_mapping import (
-                resolve_component_device_map,
-                validate_component_device_map,
-            )
-            _dev_map = resolve_component_device_map()
-            validate_component_device_map(_dev_map)
-            lm_device = _dev_map.lm or device
+            # Only consult the CUDA component map for a CUDA/auto device; an explicit
+            # cpu/mps/xpu selection must not be silently placed onto a cuda:N card.
+            _device_kind = str(device).split(":", 1)[0]
+            if _device_kind in {"auto", "cuda"}:
+                from acestep.core.generation.device_mapping import (
+                    resolve_component_device_map,
+                    validate_component_device_map,
+                )
+                _dev_map = resolve_component_device_map()
+                validate_component_device_map(_dev_map)
+                lm_device = _dev_map.lm or device
+            else:
+                lm_device = device
 
     if init_llm and lm_model_path and gpu_config.available_lm_models:
         if not is_lm_model_size_allowed(lm_model_path, gpu_config.available_lm_models):

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -97,7 +97,11 @@ def init_service_wrapper(
             )
             lm_device = "cpu"
         else:
-            lm_device = device
+            from acestep.core.generation.device_mapping import (
+                resolve_component_device_map,
+            )
+            _dev_map = resolve_component_device_map()
+            lm_device = _dev_map.lm or device
 
     if init_llm and lm_model_path and gpu_config.available_lm_models:
         if not is_lm_model_size_allowed(lm_model_path, gpu_config.available_lm_models):
@@ -135,12 +139,14 @@ def init_service_wrapper(
     if init_llm:
         checkpoint_dir = os.path.join(project_root, "checkpoints")
 
+        # Multi-GPU: keep the LM resident on its dedicated card (no CPU offload).
+        _lm_offload = False if os.getenv("ACESTEP_LM_DEVICE") else offload_to_cpu
         lm_status, lm_success = llm_handler.initialize(
             checkpoint_dir=checkpoint_dir,
             lm_model_path=lm_model_path,
             backend=backend,
             device=lm_device,
-            offload_to_cpu=offload_to_cpu,
+            offload_to_cpu=_lm_offload,
             dtype=None,
         )
 

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -89,6 +89,9 @@ def init_service_wrapper(
     # Compute lm_device only when initializing the LLM to avoid overwriting a
     # previously-resolved device (e.g. "cuda") with the raw UI value ("auto").
     # "auto" is resolved to the concrete device inside llm_handler.initialize().
+    # Resolved once here (before the DiT is loaded) and reused for the offload
+    # decision below so both stay consistent; None means "not resolved / CPU LM".
+    _dev_map = None
     if init_llm:
         if not gpu_config.available_lm_models:
             logger.warning(
@@ -144,9 +147,12 @@ def init_service_wrapper(
         # Multi-GPU: keep the LM resident when it is mapped to a different GPU than
         # the DiT (env override OR free-VRAM auto-ranking) - it no longer competes
         # for the DiT card's VRAM, so it must not be offloaded to CPU.
-        from acestep.core.generation.device_mapping import resolve_component_device_map
-        _cmap = resolve_component_device_map()
-        _multi_gpu_lm = bool(_cmap.dit and _cmap.lm and _cmap.lm != _cmap.dit)
+        # Reuse the device map resolved above (before the DiT was loaded): re-resolving
+        # here would re-rank GPUs by free VRAM after the DiT occupies its card and could
+        # disagree with where the LM was actually placed, wrongly forcing offload off.
+        _multi_gpu_lm = bool(
+            _dev_map and _dev_map.dit and _dev_map.lm and _dev_map.lm != _dev_map.dit
+        )
         _lm_offload = False if _multi_gpu_lm else offload_to_cpu
         lm_status, lm_success = llm_handler.initialize(
             checkpoint_dir=checkpoint_dir,

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -99,8 +99,10 @@ def init_service_wrapper(
         else:
             from acestep.core.generation.device_mapping import (
                 resolve_component_device_map,
+                validate_component_device_map,
             )
             _dev_map = resolve_component_device_map()
+            validate_component_device_map(_dev_map)
             lm_device = _dev_map.lm or device
 
     if init_llm and lm_model_path and gpu_config.available_lm_models:
@@ -139,8 +141,13 @@ def init_service_wrapper(
     if init_llm:
         checkpoint_dir = os.path.join(project_root, "checkpoints")
 
-        # Multi-GPU: keep the LM resident on its dedicated card (no CPU offload).
-        _lm_offload = False if os.getenv("ACESTEP_LM_DEVICE") else offload_to_cpu
+        # Multi-GPU: keep the LM resident when it is mapped to a different GPU than
+        # the DiT (env override OR free-VRAM auto-ranking) - it no longer competes
+        # for the DiT card's VRAM, so it must not be offloaded to CPU.
+        from acestep.core.generation.device_mapping import resolve_component_device_map
+        _cmap = resolve_component_device_map()
+        _multi_gpu_lm = bool(_cmap.dit and _cmap.lm and _cmap.lm != _cmap.dit)
+        _lm_offload = False if _multi_gpu_lm else offload_to_cpu
         lm_status, lm_success = llm_handler.initialize(
             checkpoint_dir=checkpoint_dir,
             lm_model_path=lm_model_path,


### PR DESCRIPTION
## Summary

Enables **multi-GPU component placement** for the Gradio UI and command-line generation path, so the **DiT** and the **5Hz LM** can run on **separate GPUs**.

On dual mid-range cards (e.g. 2×16 GB) this makes it possible to run the **XL DiT + 4B LM** together at full diffusion speed — a setup that otherwise needs a single ≥24 GB card, or heavy CPU offload of the DiT (which cripples diffusion throughput and times out on long tracks).

Builds on the great groundwork in #1149 by @imsarang (the `ComponentDeviceMap` concept and `initialize_service` wiring, which covered the **API-server** path). This PR extends it to the **Gradio/CLI generation path** — where the LM was still initialized on the DiT's device — and adds the pieces needed for real asymmetric multi-GPU rigs.

## What's included

- **`device_mapping.py`** — component→device mapping with explicit env overrides (`ACESTEP_DIT_DEVICE`, `ACESTEP_VAE_DEVICE`, `ACESTEP_LM_DEVICE`) for deterministic pinning, on top of the free-VRAM auto-ranking.
- **`init_service_orchestrator.py`** — place DiT / VAE / text_encoder on the mapped devices.
- **`acestep_v15_pipeline.py`** & **`service_init.py`** — route the 5Hz LM to its mapped device in the CLI and Gradio init paths, and keep it **resident** on its dedicated card (no CPU offload) even when the DiT handler offloads VAE/text_encoder to free the DiT's VRAM.
- **`llm_inference.py`** — recognize `cuda:N` (not just `"cuda"`) when picking the LM dtype, and load the PyTorch LM **directly in bf16** instead of loading fp32 then converting — this removes a transient 2× VRAM peak that OOMs a dedicated 16 GB card for the 4B LM.

## Example config (2×16 GB: RTX 5080 + RTX 4060 Ti)
ACESTEP_DIT_DEVICE=cuda:0     # DiT + VAE + text_encoder on the fast card
ACESTEP_VAE_DEVICE=cuda:0
ACESTEP_LM_DEVICE=cuda:1      # 4B LM resident on the second card
MAX_CUDA_VRAM=24              # unlock the 4B LM in the tier logic
launch flags: --offload_to_cpu true --offload_dit_to_cpu false --backend pt

## Tested

RTX 5080 (16 GB) + RTX 4060 Ti (16 GB), Windows, torch 2.7.1+cu128:
- `initialize_service` places DiT on cuda:0, 4B LM (bf16) on cuda:1 — no OOM.
- Full generations up to **5 minutes** (300 s): peak ~10.7 GB on the DiT card, diffusion ~0.18 s/step (60 s) to ~0.9 s/step (300 s).
- Before this PR, the 4B LM on a single 16 GB card required `offload_dit_to_cpu`, which slowed diffusion to ~35–52 s/step and timed out on long tracks.

## Notes

- The LM uses the `pt` backend on its dedicated card (reliable device placement). Making nano-vLLM honor a non-default CUDA device would further speed the LM phase — left for a follow-up.
- If #1149 lands first, this can be rebased to drop the overlapping `device_mapping.py` / orchestrator bits and keep only the Gradio-path + dtype fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic multi-GPU component placement for the main model, VAE, and language model, with environment-variable overrides and UI GPU hinting.
* **Bug Fixes**
  * Improved multi-GPU language-model initialization by honoring the mapped LM device and skipping unnecessary CPU offload/downgrade when DiT and LM are on different GPUs.
  * Fixed dtype selection and attention-backend selection for indexed CUDA devices (e.g., `cuda:1`).
* **Tests**
  * Added unit tests covering override precedence, VRAM-based ranking, validation, hint formatting, and CUDA-unavailable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->