### PR TITLE
Add streamlined Simple UI music generation flow

### DIFF
--- a/acestep/ui/gradio/events/__init__.py
+++ b/acestep/ui/gradio/events/__init__.py
@@ -3,6 +3,7 @@ Gradio UI Event Handlers Module
 Main entry point for setting up all event handlers
 """
 # Import handler modules
+from .wiring.simple_ui_wiring import register_simple_ui_handlers as setup_simple_ui_handlers
 from .wiring import (
     GenerationWiringContext,
     TrainingWiringContext,

--- a/acestep/ui/gradio/events/results/generation_progress.py
+++ b/acestep/ui/gradio/events/results/generation_progress.py
@@ -36,6 +36,11 @@ from acestep.ui.gradio.events.results.lrc_utils import lrc_to_vtt_file
 from acestep.ui.gradio.events.results.session_artifacts import persist_sample_session_artifacts
 
 
+def _lyrics_are_instrumental(lyrics: str | None) -> bool:
+    """Return whether lyrics contain the generator's instrumental sentinel."""
+    return (lyrics or "").strip().lower() == "[instrumental]"
+
+
 def generate_with_progress(
     dit_handler, llm_handler,
     captions, lyrics, bpm, key_scale, time_signature, vocal_language,
@@ -140,7 +145,7 @@ def generate_with_progress(
         audio_codes=text2music_audio_code_string if not think_checkbox else "",
         caption=captions or "",
         lyrics=lyrics or "",
-        instrumental=False,
+        instrumental=_lyrics_are_instrumental(lyrics),
         vocal_language=vocal_language,
         bpm=bpm,
         keyscale=key_scale,

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -83,6 +83,15 @@ class TestSimpleUINavigation(unittest.TestCase):
         root_rule = css_source.split("#simple-ui-column {", 1)[1].split("}", 1)[0]
         self.assertIn("display: block", root_rule)
         self.assertIn("min-height: 0", root_rule)
+        self.assertIn("width: min(880px", root_rule)
+
+    def test_simple_ui_uses_neutral_outer_canvas(self):
+        """The desktop canvas should complement the light Simple UI card."""
+        interface_path = Path(__file__).parents[2] / "interfaces" / "__init__.py"
+        css_source = interface_path.read_text(encoding="utf-8")
+
+        self.assertIn(".gradio-container:has(#simple-ui-column)", css_source)
+        self.assertIn("background: #f1f0f5 !important", css_source)
 
 
 class TestSimpleUIHelpers(unittest.TestCase):

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -22,6 +22,7 @@ from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
     _result_card_updates,
     _resolve_simple_lyrics,
     _instrumental_lyrics_update,
+    _completion_message,
 )
 
 
@@ -122,6 +123,11 @@ class TestSimpleUIHelpers(unittest.TestCase):
     def test_instrumental_mode_disables_lyrics_input(self):
         self.assertFalse(_instrumental_lyrics_update(True)["interactive"])
         self.assertTrue(_instrumental_lyrics_update(False)["interactive"])
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.t")
+    def test_completion_message_falls_back_when_translation_is_missing(self, mock_t):
+        mock_t.return_value = "messages.generation_complete"
+        self.assertEqual(_completion_message(), "Generation complete")
 
 
 class TestSimpleUIStartGeneration(unittest.TestCase):

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -23,6 +23,7 @@ from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
     _instrumental_lyrics_update,
     _completion_message,
     _ignore_progress,
+    _save_audio_js,
 )
 
 
@@ -127,6 +128,11 @@ class TestSimpleUIHelpers(unittest.TestCase):
     def test_simple_progress_callback_is_silent(self):
         self.assertIsNone(_ignore_progress(0.5, desc="Generating"))
 
+    def test_save_audio_prefers_gradio_url_with_local_path_fallback(self):
+        javascript = _save_audio_js()
+        self.assertIn("audio.url || audio.data || audio.path", javascript)
+        self.assertIn("/gradio_api/file=", javascript)
+
 
 class TestSimpleUIStartGeneration(unittest.TestCase):
     """_start_generation should return values matching generation outputs."""
@@ -201,6 +207,7 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
         self.assertEqual(len(step1), 14)
         step2 = next(gen)
         self.assertEqual(len(step2), 14)
+        self.assertIs(mock_gen.call_args.kwargs["progress"], _ignore_progress)
 
     @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
     def test_generate_wrapper_with_audio_sets_cover_task(self, mock_gen):
@@ -327,6 +334,12 @@ class TestSimpleMenu(unittest.TestCase):
             components = build_simple_ui()
 
         self.assertTrue(components["simple_column"].visible)
+
+    def test_remix_create_button_uses_compact_size(self):
+        with gr.Blocks():
+            components = build_simple_ui()
+
+        self.assertEqual(components["simple_create_btn"].size, "sm")
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -24,6 +24,7 @@ from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
     _completion_message,
     _ignore_progress,
     _save_audio_js,
+    _initialize_simple_ui_models,
 )
 
 
@@ -140,6 +141,24 @@ class TestSimpleUIHelpers(unittest.TestCase):
         javascript = _save_audio_js()
         self.assertIn("audio.url || audio.data || audio.path", javascript)
         self.assertIn("/gradio_api/file=", javascript)
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring._init_llm_for_simple_ui")
+    def test_create_button_enables_after_dit_initializes(self, mock_init):
+        mock_init.return_value = ""
+        dit_handler = MagicMock()
+        dit_handler.model = MagicMock()
+        update = _initialize_simple_ui_models(MagicMock(), dit_handler)
+        self.assertTrue(update["interactive"])
+        self.assertIn("Create Music", update["value"])
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring._init_llm_for_simple_ui")
+    def test_create_button_stays_disabled_after_init_failure(self, mock_init):
+        mock_init.return_value = "initialization failed"
+        dit_handler = MagicMock()
+        dit_handler.model = None
+        update = _initialize_simple_ui_models(MagicMock(), dit_handler)
+        self.assertFalse(update["interactive"])
+        self.assertEqual(update["value"], "Models unavailable")
 
 
 class TestSimpleUIStartGeneration(unittest.TestCase):
@@ -348,6 +367,7 @@ class TestSimpleMenu(unittest.TestCase):
             components = build_simple_ui()
 
         self.assertEqual(components["simple_create_btn"].size, "sm")
+        self.assertFalse(components["simple_create_btn"].interactive)
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -19,10 +19,10 @@ from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
     _build_metadata_html,
     _format_duration,
     _go_random,
-    _result_card_updates,
     _resolve_simple_lyrics,
     _instrumental_lyrics_update,
     _completion_message,
+    _ignore_progress,
 )
 
 
@@ -105,11 +105,6 @@ class TestSimpleUIHelpers(unittest.TestCase):
         html = _build_status_html("Generation failed", False)
         self.assertNotIn("success", html)
 
-    def test_result_cards_follow_available_audio(self):
-        first, second = _result_card_updates("first.flac", None)
-        self.assertTrue(first["visible"])
-        self.assertFalse(second["visible"])
-
     def test_instrumental_mode_replaces_lyrics_with_sentinel(self):
         self.assertEqual(_resolve_simple_lyrics("written lyrics", True), "[Instrumental]")
 
@@ -129,13 +124,16 @@ class TestSimpleUIHelpers(unittest.TestCase):
         mock_t.return_value = "messages.generation_complete"
         self.assertEqual(_completion_message(), "Generation complete")
 
+    def test_simple_progress_callback_is_silent(self):
+        self.assertIsNone(_ignore_progress(0.5, desc="Generating"))
+
 
 class TestSimpleUIStartGeneration(unittest.TestCase):
     """_start_generation should return values matching generation outputs."""
 
-    def test_returns_16_values(self):
+    def test_returns_14_values(self):
         result = _start_generation()
-        self.assertEqual(len(result), 16)
+        self.assertEqual(len(result), 14)
 
     def test_step_3_hidden(self):
         result = _start_generation()
@@ -154,11 +152,6 @@ class TestSimpleUIStartGeneration(unittest.TestCase):
         html = result[2]["value"]
         self.assertIn("Creating", html)
         self.assertIn('filter="url(#glow)"', html)
-
-    def test_result_cards_hidden_while_generating(self):
-        result = _start_generation()
-        self.assertFalse(result[14]["visible"])
-        self.assertFalse(result[15]["visible"])
 
 
 class TestSimpleUIGenerateWrapper(unittest.TestCase):
@@ -187,9 +180,9 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
         )
 
         step1 = next(gen)
-        self.assertEqual(len(step1), 16)
+        self.assertEqual(len(step1), 14)
         step2 = next(gen)
-        self.assertEqual(len(step2), 16)
+        self.assertEqual(len(step2), 14)
 
     @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
     def test_generate_wrapper_with_lyrics_skips_sample_creation(self, mock_gen):
@@ -205,9 +198,9 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
         )
 
         step1 = next(gen)
-        self.assertEqual(len(step1), 16)
+        self.assertEqual(len(step1), 14)
         step2 = next(gen)
-        self.assertEqual(len(step2), 16)
+        self.assertEqual(len(step2), 14)
 
     @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
     def test_generate_wrapper_with_audio_sets_cover_task(self, mock_gen):
@@ -223,9 +216,9 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
         )
 
         step1 = next(gen)
-        self.assertEqual(len(step1), 16)
+        self.assertEqual(len(step1), 14)
         step2 = next(gen)
-        self.assertEqual(len(step2), 16)
+        self.assertEqual(len(step2), 14)
 
     @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
     @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.get_global_gpu_config")
@@ -256,11 +249,11 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
 
         # First yield: LLM init progress
         step1 = next(gen)
-        self.assertEqual(len(step1), 16)
+        self.assertEqual(len(step1), 14)
 
         # Second yield (and onwards): LLM init happens + rest of generation
         step2 = next(gen)
-        self.assertEqual(len(step2), 16)
+        self.assertEqual(len(step2), 14)
 
         # The initialize() method should have been called
         self.llm.initialize.assert_called_once()
@@ -292,9 +285,9 @@ class TestSimpleUIGenerateWrapper(unittest.TestCase):
         )
 
         step1 = next(gen)
-        self.assertEqual(len(step1), 16)
+        self.assertEqual(len(step1), 14)
         step2 = next(gen)
-        self.assertEqual(len(step2), 16)
+        self.assertEqual(len(step2), 14)
 
 
 class TestAboutOverlay(unittest.TestCase):
@@ -328,6 +321,12 @@ class TestSimpleMenu(unittest.TestCase):
             button = components[key]
             self.assertEqual(button.value, label)
             self.assertIn(icon_class, button.elem_classes)
+
+    def test_simple_ui_is_visible_by_default(self):
+        with gr.Blocks():
+            components = build_simple_ui()
+
+        self.assertTrue(components["simple_column"].visible)
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -75,6 +75,14 @@ class TestSimpleUINavigation(unittest.TestCase):
         results_rule = css_source.split(".simple-results-row {", 1)[1].split("}", 1)[0]
         self.assertIn("grid-template-columns: repeat(2", results_rule)
 
+    def test_simple_root_uses_content_height_block_layout(self):
+        """Simple screens should not distribute viewport height between sections."""
+        interface_path = Path(__file__).parents[2] / "interfaces" / "__init__.py"
+        css_source = interface_path.read_text(encoding="utf-8")
+        root_rule = css_source.split("#simple-ui-column {", 1)[1].split("}", 1)[0]
+        self.assertIn("display: block", root_rule)
+        self.assertIn("min-height: 0", root_rule)
+
 
 class TestSimpleUIHelpers(unittest.TestCase):
     """Utility functions should produce expected output."""

--- a/acestep/ui/gradio/events/wiring/simple_ui_test.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_test.py
@@ -1,0 +1,328 @@
+"""Tests for the simplified UI flow — generation and navigation."""
+
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
+
+import gradio as gr
+
+from acestep.ui.gradio.events.results.generation_progress import _lyrics_are_instrumental
+from acestep.ui.gradio.interfaces.simple_ui import (
+    _about_overlay_html,
+    _step_indicator_html,
+    build_simple_ui,
+)
+from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+    _navigate_to,
+    _start_generation,
+    _build_status_html,
+    _build_metadata_html,
+    _format_duration,
+    _go_random,
+    _result_card_updates,
+    _resolve_simple_lyrics,
+    _instrumental_lyrics_update,
+)
+
+
+class TestSimpleUINavigation(unittest.TestCase):
+    """Step navigation should return correct visibility state."""
+
+    def test_navigate_to_step_1_shows_step_1_hides_others(self):
+        result = _navigate_to(1, 1)
+        self.assertEqual(result[0], 1)  # target step
+        self.assertTrue(result[2]["visible"])  # step 1 visible
+        self.assertFalse(result[3]["visible"])  # step 2 hidden
+        self.assertFalse(result[4]["visible"])  # step 3 hidden
+        self.assertFalse(result[5]["visible"])  # step 4 hidden
+        self.assertFalse(result[6]["visible"])  # step 5 hidden
+
+    def test_navigate_to_step_3(self):
+        result = _navigate_to(3, 2)
+        self.assertEqual(result[0], 3)
+        self.assertFalse(result[2]["visible"])  # step 1 hidden
+        self.assertFalse(result[3]["visible"])  # step 2 hidden
+        self.assertTrue(result[4]["visible"])  # step 3 visible
+        self.assertFalse(result[5]["visible"])  # step 4 hidden
+        self.assertFalse(result[6]["visible"])  # step 5 hidden
+
+    def test_step_indicator_generates_svg(self):
+        html = _step_indicator_html(3)
+        self.assertIn("<svg", html)
+        self.assertIn("Describe Song", html)
+        self.assertIn("Lyrics", html)
+        self.assertIn("Remix", html)
+        self.assertIn("Creating", html)
+        self.assertIn("Done", html)
+
+    def test_step_indicator_current_step_is_highlighted(self):
+        html = _step_indicator_html(3)
+        self.assertIn('filter="url(#glow)"', html)
+
+    def test_step_wrapper_is_layout_transparent(self):
+        """Hidden Gradio Column shells must not render as empty bordered rows."""
+        interface_path = Path(__file__).parents[2] / "interfaces" / "__init__.py"
+        css_source = interface_path.read_text(encoding="utf-8")
+        step_rule = css_source.split(".simple-step {", 1)[1].split("}", 1)[0]
+        self.assertIn("display: contents", step_rule)
+
+    def test_results_use_two_column_desktop_grid(self):
+        """Done-screen cards should sit side by side on larger screens."""
+        interface_path = Path(__file__).parents[2] / "interfaces" / "__init__.py"
+        css_source = interface_path.read_text(encoding="utf-8")
+        results_rule = css_source.split(".simple-results-row {", 1)[1].split("}", 1)[0]
+        self.assertIn("grid-template-columns: repeat(2", results_rule)
+
+
+class TestSimpleUIHelpers(unittest.TestCase):
+    """Utility functions should produce expected output."""
+
+    def test_random_style_returns_string(self):
+        style = _go_random()
+        self.assertIsInstance(style, str)
+        self.assertGreater(len(style), 10)
+
+    def test_format_duration_seconds(self):
+        self.assertEqual(_format_duration(0), "")
+        self.assertEqual(_format_duration(15), "15s")
+        self.assertEqual(_format_duration(120), "2m 0s")
+
+    def test_build_metadata_html(self):
+        html = _build_metadata_html(15, "flac")
+        self.assertIn("15s", html)
+        self.assertIn("FLAC", html)
+
+    def test_build_metadata_html_no_duration(self):
+        html = _build_metadata_html(0, "mp3")
+        self.assertIn("MP3", html)
+
+    def test_status_html_success(self):
+        html = _build_status_html("Generation complete", True)
+        self.assertIn("success", html)
+
+    def test_status_html_failure(self):
+        html = _build_status_html("Generation failed", False)
+        self.assertNotIn("success", html)
+
+    def test_result_cards_follow_available_audio(self):
+        first, second = _result_card_updates("first.flac", None)
+        self.assertTrue(first["visible"])
+        self.assertFalse(second["visible"])
+
+    def test_instrumental_mode_replaces_lyrics_with_sentinel(self):
+        self.assertEqual(_resolve_simple_lyrics("written lyrics", True), "[Instrumental]")
+
+    def test_vocal_mode_preserves_lyrics(self):
+        self.assertEqual(_resolve_simple_lyrics("written lyrics", False), "written lyrics")
+
+    def test_generator_recognizes_instrumental_sentinel(self):
+        self.assertTrue(_lyrics_are_instrumental("[Instrumental]"))
+        self.assertFalse(_lyrics_are_instrumental("written lyrics"))
+
+    def test_instrumental_mode_disables_lyrics_input(self):
+        self.assertFalse(_instrumental_lyrics_update(True)["interactive"])
+        self.assertTrue(_instrumental_lyrics_update(False)["interactive"])
+
+
+class TestSimpleUIStartGeneration(unittest.TestCase):
+    """_start_generation should return values matching generation outputs."""
+
+    def test_returns_16_values(self):
+        result = _start_generation()
+        self.assertEqual(len(result), 16)
+
+    def test_step_3_hidden(self):
+        result = _start_generation()
+        self.assertFalse(result[3]["visible"])
+
+    def test_step_4_visible(self):
+        result = _start_generation()
+        self.assertTrue(result[4]["visible"])
+
+    def test_step_5_hidden(self):
+        result = _start_generation()
+        self.assertFalse(result[5]["visible"])
+
+    def test_indicator_shows_step_4(self):
+        result = _start_generation()
+        html = result[2]["value"]
+        self.assertIn("Creating", html)
+        self.assertIn('filter="url(#glow)"', html)
+
+    def test_result_cards_hidden_while_generating(self):
+        result = _start_generation()
+        self.assertFalse(result[14]["visible"])
+        self.assertFalse(result[15]["visible"])
+
+
+class TestSimpleUIGenerateWrapper(unittest.TestCase):
+    """_simple_generate_wrapper should yield correct number of values."""
+
+    def setUp(self):
+        self.dit = MagicMock()
+        self.dit.get_available_acestep_v15_models.return_value = ["acestep-v15-turbo"]
+        self.dit.initialize_service.return_value = ("ok", True)
+        self.llm = MagicMock()
+        self.llm.llm_initialized = True
+        self.llm.get_available_5hz_lm_models.return_value = []
+        self.llm.initialize.return_value = ("ok", True)
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
+    def test_generate_wrapper_yields_progress(self, mock_gen):
+        """Verify the generator yields tuples of the expected length."""
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _simple_generate_wrapper,
+        )
+
+        gen = _simple_generate_wrapper(
+            self.dit, self.llm,
+            "test song", "", False, None,
+            0, 1, {}, {},
+        )
+
+        step1 = next(gen)
+        self.assertEqual(len(step1), 16)
+        step2 = next(gen)
+        self.assertEqual(len(step2), 16)
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
+    def test_generate_wrapper_with_lyrics_skips_sample_creation(self, mock_gen):
+        """When lyrics are provided, no create_sample call."""
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _simple_generate_wrapper,
+        )
+
+        gen = _simple_generate_wrapper(
+            self.dit, self.llm,
+            "test song", "my lyrics", False, None,
+            0, 1, {}, {},
+        )
+
+        step1 = next(gen)
+        self.assertEqual(len(step1), 16)
+        step2 = next(gen)
+        self.assertEqual(len(step2), 16)
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
+    def test_generate_wrapper_with_audio_sets_cover_task(self, mock_gen):
+        """When src_audio is provided, task_type should be 'cover'."""
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _simple_generate_wrapper,
+        )
+
+        gen = _simple_generate_wrapper(
+            self.dit, self.llm,
+            "", "", False, "/path/to/audio.wav",
+            0, 1, {}, {},
+        )
+
+        step1 = next(gen)
+        self.assertEqual(len(step1), 16)
+        step2 = next(gen)
+        self.assertEqual(len(step2), 16)
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.get_global_gpu_config")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.find_best_lm_model_on_disk")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.resolve_lm_backend")
+    def test_generate_wrapper_auto_inits_llm(self, mock_resolve, mock_find, mock_config, mock_gen):
+        """When LLM is not initialized, it should be auto-initialized."""
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _simple_generate_wrapper,
+        )
+
+        self.llm.llm_initialized = False
+        self.llm.get_available_5hz_lm_models.return_value = ["acestep-5Hz-lm-1.7B"]
+        mock_gpu = MagicMock()
+        mock_gpu.recommended_lm_model = "acestep-5Hz-lm-1.7B"
+        mock_gpu.recommended_backend = "pt"
+        mock_gpu.offload_to_cpu_default = True
+        mock_config.return_value = mock_gpu
+        mock_find.return_value = "acestep-5Hz-lm-1.7B"
+        mock_resolve.return_value = "pt"
+        self.llm.initialize.return_value = ("ok", True)
+
+        gen = _simple_generate_wrapper(
+            self.dit, self.llm,
+            "test song", "", False, None,
+            0, 1, {}, {},
+        )
+
+        # First yield: LLM init progress
+        step1 = next(gen)
+        self.assertEqual(len(step1), 16)
+
+        # Second yield (and onwards): LLM init happens + rest of generation
+        step2 = next(gen)
+        self.assertEqual(len(step2), 16)
+
+        # The initialize() method should have been called
+        self.llm.initialize.assert_called_once()
+
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.generate_with_progress")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.get_global_gpu_config")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.find_best_lm_model_on_disk")
+    @patch("acestep.ui.gradio.events.wiring.simple_ui_wiring.resolve_lm_backend")
+    def test_generate_wrapper_llm_init_failure_falls_back(self, mock_resolve, mock_find, mock_config, mock_gen):
+        """When LLM auto-init fails, generation should continue without think."""
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _simple_generate_wrapper,
+        )
+
+        self.llm.llm_initialized = False
+        self.llm.get_available_5hz_lm_models.return_value = []
+        mock_gpu = MagicMock()
+        mock_gpu.recommended_lm_model = None
+        mock_gpu.recommended_backend = "pt"
+        mock_gpu.offload_to_cpu_default = True
+        mock_config.return_value = mock_gpu
+        mock_find.return_value = None
+        mock_resolve.return_value = "pt"
+
+        gen = _simple_generate_wrapper(
+            self.dit, self.llm,
+            "test song", "", False, None,
+            0, 1, {}, {},
+        )
+
+        step1 = next(gen)
+        self.assertEqual(len(step1), 16)
+        step2 = next(gen)
+        self.assertEqual(len(step2), 16)
+
+
+class TestAboutOverlay(unittest.TestCase):
+    """About overlay HTML should render correctly."""
+
+    def test_about_overlay_contains_title(self):
+        html = _about_overlay_html()
+        self.assertIn("ACE-Step", html)
+        self.assertIn("V1.5", html)
+        self.assertIn("Playground", html)
+
+    def test_about_overlay_does_not_mutate_visibility_inline(self):
+        html = _about_overlay_html()
+        self.assertNotIn("onclick", html)
+        self.assertNotIn("style.display", html)
+
+
+class TestSimpleMenu(unittest.TestCase):
+    """Hamburger menu controls should use styled SVG classes and plain labels."""
+
+    def test_menu_buttons_have_svg_classes_without_emoji_labels(self):
+        with gr.Blocks():
+            components = build_simple_ui()
+
+        expected = {
+            "simple_about_btn": ("About", "simple-menu-about"),
+            "simple_help_btn": ("Help", "simple-menu-help"),
+            "simple_advanced_btn": ("Advanced Mode", "simple-menu-advanced"),
+        }
+        for key, (label, icon_class) in expected.items():
+            button = components[key]
+            self.assertEqual(button.value, label)
+            self.assertIn(icon_class, button.elem_classes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
@@ -200,6 +200,19 @@ def _init_llm_for_simple_ui(
         return str(e)
 
 
+def _initialize_simple_ui_models(
+    llm_handler: Any = None,
+    dit_handler: Any = None,
+) -> dict:
+    """Initialize Simple UI models and update the Create button readiness."""
+    status = _init_llm_for_simple_ui(llm_handler, dit_handler)
+    is_ready = bool(dit_handler and getattr(dit_handler, "model", None) is not None)
+    if is_ready:
+        return gr.update(interactive=True, value="  Create Music")
+    logger.warning(f"Simple UI remains disabled because model initialization failed: {status}")
+    return gr.update(interactive=False, value="Models unavailable")
+
+
 def _start_generation() -> tuple:
     """Non-generator setup: navigate to step 4 (Creating...)."""
     return (

--- a/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
@@ -354,7 +354,7 @@ def _simple_generate_wrapper(
         params["latent_shift"], params["latent_rescale"],
         params["repaint_mode"], params["repaint_strength"],
         params["retake_variance"], params["retake_seed"],
-        _ignore_progress,
+        progress=_ignore_progress,
     )
 
     # Forward intermediate yields so Gradio 6 streams audio updates live
@@ -495,11 +495,22 @@ def _save_audio_js() -> str:
     """Return JS for downloading audio."""
     return """(audio) => {
         if (!audio) return;
-        let path = typeof audio === 'string' ? audio : (audio.path || audio.name || '');
-        if (!path) return;
+        let target = '';
+        let filename = 'audio';
+        if (typeof audio === 'object') {
+            target = audio.url || audio.data || audio.path || audio.name || '';
+            filename = audio.orig_name || audio.name || audio.path || filename;
+        } else {
+            target = audio;
+            filename = audio;
+        }
+        if (!target) return;
+        if (target.startsWith('/tmp/') || target.startsWith('/home/')) {
+            target = '/gradio_api/file=' + encodeURI(target);
+        }
         let a = document.createElement('a');
-        a.href = path;
-        a.download = path.split('/').pop() || 'audio';
+        a.href = target;
+        a.download = filename.split(/[\\/]/).pop().split('?')[0] || 'audio';
         a.style.display = 'none';
         document.body.appendChild(a);
         a.click();

--- a/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
@@ -91,6 +91,12 @@ def _instrumental_lyrics_update(instrumental: bool) -> dict:
     return gr.update(interactive=not instrumental)
 
 
+def _completion_message() -> str:
+    """Return a translated completion message with an English fallback."""
+    message = t("messages.generation_complete")
+    return "Generation complete" if message == "messages.generation_complete" else message
+
+
 def _navigate_to(target: int, current_step: int) -> tuple:
     """Navigate to a step — returns visibility updates for each column.
 
@@ -478,10 +484,7 @@ def _simple_generate_wrapper(
     meta_1 = _build_metadata_html(0, params["audio_format"])
     meta_2 = _build_metadata_html(0, params["audio_format"])
 
-    gen_status = _build_status_html(
-        t("messages.generation_complete"),
-        True,
-    )
+    gen_status = _build_status_html(_completion_message(), True)
 
     yield (
         gr.update(value=audio_1),  # 0

--- a/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
@@ -1,0 +1,756 @@
+"""Step-flow event wiring for the simplified UI."""
+
+import gc
+import os
+import random
+from typing import Any
+
+import gradio as gr
+import torch
+from loguru import logger
+
+from acestep.gpu_config import (
+    find_best_lm_model_on_disk,
+    get_global_gpu_config,
+    resolve_lm_backend,
+)
+from acestep.inference import create_sample
+from acestep.ui.gradio.interfaces.simple_ui import _step_indicator_html
+from acestep.ui.gradio.events.results.batch_management_helpers import (
+    _apply_param_defaults,
+    _build_saved_params,
+)
+from acestep.ui.gradio.events.results.batch_queue import (
+    store_batch_in_queue,
+)
+from acestep.ui.gradio.events.results.generation_progress import (
+    generate_with_progress,
+)
+from acestep.ui.gradio.events.generation.validation import clamp_duration_to_gpu_limit
+from acestep.ui.gradio.i18n import t
+
+_RANDOM_STYLES = [
+    "A happy pop song with piano and drums",
+    "A chill lo-fi beat with smooth guitar",
+    "An energetic rock anthem with electric guitar",
+    "A jazzy piano ballad with saxophone",
+    "A peaceful ambient track with soft pads",
+    "An upbeat funk song with bass and horns",
+    "A soulful R&B track with smooth vocals",
+    "An acoustic folk song with gentle strumming",
+    "A cinematic orchestral piece with strings",
+    "A driving electronic dance track with synths",
+    "A dreamy synthwave track with retro vibes",
+    "A melancholic piano piece with strings",
+    "An uplifting orchestral film score",
+    "A groovy disco track with funky bass",
+]
+
+
+def _format_duration(seconds: float) -> str:
+    """Format seconds to human-readable duration string."""
+    if seconds <= 0:
+        return ""
+    secs = int(seconds)
+    if secs < 60:
+        return f"{secs}s"
+    return f"{secs // 60}m {secs % 60}s"
+
+
+def _build_metadata_html(duration: float, fmt: str) -> str:
+    """Build an HTML metadata string for a result card."""
+    dur = _format_duration(duration)
+    parts = [p for p in [dur, fmt.upper()] if p]
+    return f'<span class="simple-meta-text">{" · ".join(parts)}</span>' if parts else ""
+
+
+def _build_status_html(message: str, is_success: bool) -> str:
+    cls = "success" if is_success else "info"
+    return (
+        f'<div class="simple-gen-status {cls}">'
+        f"  {message}"
+        f"</div>"
+    )
+
+
+def _result_card_updates(audio_1: str | None, audio_2: str | None) -> tuple:
+    """Return visibility updates for result cards with available audio."""
+    return (
+        gr.update(visible=audio_1 is not None),
+        gr.update(visible=audio_2 is not None),
+    )
+
+
+def _resolve_simple_lyrics(lyrics: str, instrumental: bool) -> str:
+    """Return the generator lyrics value for the selected vocal mode."""
+    return "[Instrumental]" if instrumental else (lyrics or "")
+
+
+def _instrumental_lyrics_update(instrumental: bool) -> dict:
+    """Disable manual lyrics while instrumental generation is selected."""
+    return gr.update(interactive=not instrumental)
+
+
+def _navigate_to(target: int, current_step: int) -> tuple:
+    """Navigate to a step — returns visibility updates for each column.
+
+    Args:
+        target: Step number to navigate to (1-5).
+        current_step: Previous step number (unused, for state tracking).
+
+    Returns:
+        Tuple of (step_number, indicator_html, col1_vis, col2_vis, col3_vis, col4_vis, col5_vis).
+    """
+    _ = current_step
+    step_vis = [gr.update(visible=(i + 1 == target)) for i in range(5)]
+    indicator = _step_indicator_html(target)
+    return (target, gr.update(value=indicator), *step_vis)
+
+
+def _go_random() -> tuple[str, str, str | None]:
+    """Generate a random style. Returns style, lyrics, audio (unchanged)."""
+    return random.choice(_RANDOM_STYLES)
+
+
+def _init_llm_for_simple_ui(
+    llm_handler: Any = None,
+    dit_handler: Any = None,
+) -> str:
+    """Initialize DiT service and LLM in the background.
+
+    Called when the Simple UI becomes active so models are ready
+    by the time the user reaches the Create Music button.
+
+    Args:
+        llm_handler: LLM handler to initialize (optional).
+        dit_handler: DiT handler to initialize (optional).
+
+    Returns:
+        Status message (empty string on success).
+    """
+    current_file = os.path.abspath(__file__)
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
+    )))
+    gpu_config = get_global_gpu_config()
+
+    # ── Initialize DiT service ──
+    if dit_handler:
+        try:
+            available = dit_handler.get_available_acestep_v15_models()
+            config_path = (
+                "acestep-v15-xl-turbo"
+                if "acestep-v15-xl-turbo" in available
+                else ("acestep-v15-turbo" if "acestep-v15-turbo" in available
+                      else (available[0] if available else "acestep-v15-turbo"))
+            )
+            dit_offload = gpu_config.offload_dit_to_cpu_default
+            status, success = dit_handler.initialize_service(
+                project_root=project_root,
+                config_path=config_path,
+                device="auto",
+                use_flash_attention=False,
+                compile_model=False,
+                offload_to_cpu=gpu_config.offload_to_cpu_default,
+                offload_dit_to_cpu=dit_offload,
+                quantization=None,
+                use_mlx_dit=True,
+                vae_checkpoint=None,
+            )
+            if success:
+                logger.info(f"Simple UI: DiT initialized ({config_path})")
+            else:
+                logger.warning(f"Simple UI DiT init failed: {status}")
+                return status
+        except Exception as e:
+            logger.warning(f"Simple UI DiT auto-init error: {e}")
+            return str(e)
+
+    # ── Initialize LLM ──
+    if not llm_handler or llm_handler.llm_initialized:
+        return ""
+    try:
+        all_models = llm_handler.get_available_5hz_lm_models()
+        lm_model = find_best_lm_model_on_disk(
+            gpu_config.recommended_lm_model, all_models
+        )
+        backend = resolve_lm_backend(
+            gpu_config.recommended_backend, gpu_config
+        )
+        checkpoint_dir = os.path.join(project_root, "checkpoints")
+        if lm_model:
+            status, success = llm_handler.initialize(
+                checkpoint_dir=checkpoint_dir,
+                lm_model_path=lm_model,
+                backend=backend,
+                device="auto",
+                offload_to_cpu=gpu_config.offload_to_cpu_default,
+            )
+            if success:
+                logger.info(f"Simple UI: LLM initialized ({lm_model}, {backend})")
+                return ""
+            logger.warning(f"Simple UI LLM init failed: {status}")
+            return status
+        logger.warning("Simple UI: no LM model found for auto-init")
+        return "No LM model available"
+    except Exception as e:
+        logger.warning(f"Simple UI LLM auto-init error: {e}")
+        return str(e)
+
+
+def _start_generation() -> tuple:
+    """Non-generator setup: navigate to step 4 (Creating...)."""
+    return (
+        gr.skip(),  # 0: audio_1
+        gr.skip(),  # 1: audio_2
+        gr.update(value=_step_indicator_html(4)),  # 2: step indicator
+        gr.update(visible=False),  # 3: step 3 hidden
+        gr.update(visible=True),  # 4: step 4 visible
+        gr.update(visible=False),  # 5: step 5 hidden
+        gr.update(value='<div class="simple-progress-status">Preparing...</div>'),  # 6: progress text
+        gr.skip(),  # 7: gen info
+        gr.skip(),  # 8: metadata 1
+        gr.skip(),  # 9: metadata 2
+        gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
+        gr.update(visible=False),  # 14: result card 1
+        gr.update(visible=False),  # 15: result card 2
+    )
+
+
+def _simple_generate_wrapper(
+    dit_handler: Any,
+    llm_handler: Any,
+    song_style: str,
+    lyrics: str,
+    instrumental: bool,
+    src_audio: str | None,
+    current_batch_index: int,
+    total_batches: int,
+    batch_queue: dict,
+    generation_params_state: dict,
+    progress: gr.Progress = gr.Progress(track_tqdm=True),
+):
+    """Generate music and stream progress through steps 4 and 5."""
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # Fallback: if background init didn't finish, initialize DiT + LLM now
+    _init_llm_for_simple_ui(llm_handler, dit_handler)
+
+    task_type = "cover" if src_audio else "text2music"
+    captions = song_style or ""
+    final_lyrics = _resolve_simple_lyrics(lyrics, instrumental)
+    audio_duration_val = -1
+
+    if song_style and not final_lyrics and llm_handler and llm_handler.llm_initialized:
+        yield (
+            gr.skip(),  # 0: audio_1
+            gr.skip(),  # 1: audio_2
+            gr.skip(),  # 2: step indicator
+            gr.skip(),  # 3: step 3 (no change)
+            gr.skip(),  # 4: step 4 (no change)
+            gr.skip(),  # 5: step 5 (no change)
+            gr.update(value='<div class="simple-progress-status">Generating lyrics...</div>'),  # 6
+            gr.skip(), gr.skip(), gr.skip(),  # 7-9: gen_info, metadata_1, metadata_2
+            gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
+            gr.skip(), gr.skip(),  # 14-15: result cards
+        )
+        result = create_sample(
+            llm_handler=llm_handler,
+            query=song_style,
+            instrumental=instrumental or ("instrumental" in song_style.lower()),
+            vocal_language="unknown",
+            temperature=0.85,
+            top_k=0,
+            top_p=0.9,
+            use_constrained_decoding=True,
+            constrained_decoding_debug=False,
+        )
+        if result.success:
+            captions = result.caption or song_style
+            final_lyrics = result.lyrics or ""
+            clamped = clamp_duration_to_gpu_limit(result.duration, llm_handler)
+            audio_duration_val = clamped if clamped and clamped > 0 else -1
+        else:
+            logger.warning(f"Sample creation failed: {result.status_message}")
+
+    yield (
+        gr.skip(),  # 0: audio_1
+        gr.skip(),  # 1: audio_2
+        gr.skip(),  # 2: step indicator
+        gr.skip(),  # 3: step 3
+        gr.skip(),  # 4: step 4
+        gr.skip(),  # 5: step 5
+        gr.update(value='<div class="simple-progress-status">Creating your music...</div>'),  # 6
+        gr.skip(), gr.skip(), gr.skip(),  # 7-9: gen_info, metadata_1, metadata_2
+        gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
+        gr.skip(), gr.skip(),  # 14-15: result cards
+    )
+
+    params: dict[str, Any] = {}
+    _apply_param_defaults(params)
+    params.update({
+        "captions": captions,
+        "lyrics": final_lyrics,
+        "src_audio": src_audio,
+        "task_type": task_type,
+        "audio_format": "flac",
+        "mp3_bitrate": "128k",
+        "mp3_sample_rate": 48000,
+        "think_checkbox": True,
+        "auto_score": False,
+        "auto_lrc": False,
+        "audio_duration": audio_duration_val,
+        "batch_size_input": 2,
+    })
+    if src_audio:
+        params["audio_cover_strength"] = 1.0
+
+    # If LLM is not initialized, disable all LM-dependent features
+    if not llm_handler or not llm_handler.llm_initialized:
+        params["think_checkbox"] = False
+        params["use_cot_metas"] = False
+        params["use_cot_caption"] = False
+        params["use_cot_language"] = False
+
+    logger.info(
+        f"Simple UI → generate_with_progress: "
+        f"captions={params['captions'][:80]!r}, "
+        f"lyrics={params['lyrics'][:80]!r}, "
+        f"lm_negative_prompt={params['lm_negative_prompt']!r}, "
+        f"think={params['think_checkbox']}, "
+        f"task_type={params['task_type']}"
+    )
+
+    gen = generate_with_progress(
+        dit_handler, llm_handler,
+        params["captions"], params["lyrics"], params["bpm"],
+        params["key_scale"], params["time_signature"], params["vocal_language"],
+        params["inference_steps"], params["guidance_scale"],
+        params["random_seed_checkbox"], params["seed"],
+        params["reference_audio"], params["audio_duration"],
+        params["batch_size_input"], params["src_audio"],
+        params["text2music_audio_code_string"],
+        params["repainting_start"], params["repainting_end"],
+        params["instruction_display_gen"],
+        params["audio_cover_strength"], params["cover_noise_strength"],
+        params["task_type"],
+        params["no_fsq"], params["use_adg"],
+        params["cfg_interval_start"], params["cfg_interval_end"],
+        params["shift"], params["infer_method"], params["sampler_mode"],
+        params["velocity_norm_threshold"], params["velocity_ema_factor"],
+        params["dcw_enabled"], params["dcw_mode"],
+        params["dcw_scaler"], params["dcw_high_scaler"], params["dcw_wavelet"],
+        params["custom_timesteps"],
+        params["audio_format"], params["mp3_bitrate"], params["mp3_sample_rate"],
+        params["lm_temperature"],
+        params["think_checkbox"], params["lm_cfg_scale"],
+        params["lm_top_k"], params["lm_top_p"], params["lm_negative_prompt"],
+        params["use_cot_metas"], params["use_cot_caption"], params["use_cot_language"],
+        False,  # is_format_caption
+        params["constrained_decoding_debug"],
+        params["allow_lm_batch"], params["auto_score"], params["auto_lrc"],
+        params["score_scale"], params["lm_batch_chunk_size"],
+        params["enable_normalization"], params["normalization_db"],
+        params["fade_in_duration"], params["fade_out_duration"],
+        params["latent_shift"], params["latent_rescale"],
+        params["repaint_mode"], params["repaint_strength"],
+        params["retake_variance"], params["retake_seed"],
+        progress,
+    )
+
+    # Forward intermediate yields so Gradio 6 streams audio updates live
+    final_result = None
+    for partial in gen:
+        final_result = partial
+        yield (
+            partial[0] if len(partial) > 0 else gr.skip(),   # 0: audio_1
+            partial[1] if len(partial) > 1 else gr.skip(),   # 1: audio_2
+            gr.skip(),                                         # 2: step indicator
+            gr.skip(),                                         # 3: step 3
+            gr.skip(),                                         # 4: step 4
+            gr.skip(),                                         # 5: step 5
+            gr.update(value='<div class="simple-progress-status">'
+                     f'{partial[10] if len(partial) > 10 else "Creating..."}'
+                     '</div>'),                                # 6: progress
+            gr.skip(),                                         # 7: gen info
+            gr.skip(),                                         # 8: metadata 1
+            gr.skip(),                                         # 9: metadata 2
+            gr.skip(), gr.skip(), gr.skip(), gr.skip(),        # 10-13: batch state
+            gr.skip(), gr.skip(),                              # 14-15: result cards
+        )
+
+    if final_result is None:
+        yield (
+            gr.update(value=None),  # 0: audio_1
+            gr.update(value=None),  # 1: audio_2
+            gr.update(value=_step_indicator_html(5)),  # 2
+            gr.update(visible=False),  # 3: step 3 hide
+            gr.update(visible=False),  # 4: step 4 hide
+            gr.update(visible=True),  # 5: step 5 show
+            gr.skip(),  # 6: progress
+            gr.update(value=_build_status_html("Generation failed. Please try again.", False)),  # 7
+            gr.skip(), gr.skip(),  # 8-9: metadata_1, metadata_2
+            current_batch_index, total_batches, batch_queue, generation_params_state,  # 10-13
+            gr.update(visible=False), gr.update(visible=False),  # 14-15
+        )
+        return
+
+    all_audio_paths = final_result[8] if len(final_result) > 8 else None
+    generation_info_text = final_result[9] if len(final_result) > 9 else ""
+    gen_status_message = final_result[10] if len(final_result) > 10 else ""
+    if all_audio_paths is None:
+        err_msg = gen_status_message or generation_info_text or "Generation produced no output"
+        logger.warning(f"Simple UI: generation result had no audio paths. Status: {gen_status_message}")
+        yield (
+            gr.update(value=None),  # 0: audio_1
+            gr.update(value=None),  # 1: audio_2
+            gr.update(value=_step_indicator_html(5)),  # 2
+            gr.update(visible=False),  # 3: step 3 hide
+            gr.update(visible=False),  # 4: step 4 hide
+            gr.update(visible=True),  # 5: step 5 show
+            gr.skip(),  # 6: progress
+            gr.update(value=_build_status_html(str(err_msg), False)),  # 7
+            gr.skip(), gr.skip(),  # 8-9: metadata_1, metadata_2
+            current_batch_index, total_batches, batch_queue, generation_params_state,  # 10-13
+            gr.update(visible=False), gr.update(visible=False),  # 14-15
+        )
+        return
+
+    saved_params = _build_saved_params(
+        params["captions"], params["lyrics"], params["bpm"],
+        params["key_scale"], params["time_signature"], params["vocal_language"],
+        params["inference_steps"], params["guidance_scale"],
+        params["random_seed_checkbox"], params["seed"],
+        params["reference_audio"], params["audio_duration"],
+        params["batch_size_input"], params["src_audio"],
+        params["text2music_audio_code_string"],
+        params["repainting_start"], params["repainting_end"],
+        params["instruction_display_gen"],
+        params["audio_cover_strength"], params["cover_noise_strength"],
+        params["task_type"],
+        params["no_fsq"], params["use_adg"],
+        params["cfg_interval_start"], params["cfg_interval_end"],
+        params["shift"], params["infer_method"], params["sampler_mode"],
+        params["velocity_norm_threshold"], params["velocity_ema_factor"],
+        params["dcw_enabled"], params["dcw_mode"],
+        params["dcw_scaler"], params["dcw_high_scaler"], params["dcw_wavelet"],
+        params["audio_format"], params["mp3_bitrate"], params["mp3_sample_rate"],
+        params["lm_temperature"],
+        params["think_checkbox"], params["lm_cfg_scale"],
+        params["lm_top_k"], params["lm_top_p"], params["lm_negative_prompt"],
+        params["use_cot_metas"], params["use_cot_caption"], params["use_cot_language"],
+        params["constrained_decoding_debug"], params["allow_lm_batch"],
+        params["auto_score"], params["auto_lrc"],
+        params["score_scale"], params["lm_batch_chunk_size"],
+        params["track_name"], params["complete_track_classes"],
+        params["enable_normalization"], params["normalization_db"],
+        params["fade_in_duration"], params["fade_out_duration"],
+        params["latent_shift"], params["latent_rescale"],
+        repaint_mode=params["repaint_mode"],
+        repaint_strength=params["repaint_strength"],
+        retake_variance=params["retake_variance"],
+        retake_seed=params["retake_seed"],
+    )
+
+    batch_queue = store_batch_in_queue(
+        batch_queue, current_batch_index,
+        all_audio_paths, generation_info_text,
+        final_result[11] if len(final_result) > 11 else "",
+        scores=[""] * 8,
+        codes=[""] * 8,
+        allow_lm_batch=False,
+        batch_size=2,
+        generation_params=saved_params,
+        status="completed",
+    )
+
+    total_batches = max(total_batches, current_batch_index + 1)
+
+    # all_audio_paths alternates [audio, json, audio, json, ...]
+    # Use every-other index to skip JSON sidecar paths
+    audio_paths_list = all_audio_paths if isinstance(all_audio_paths, list) else []
+    audio_1 = audio_paths_list[0] if len(audio_paths_list) >= 1 else None
+    audio_2 = audio_paths_list[2] if len(audio_paths_list) >= 3 else None
+    result_card_updates = _result_card_updates(audio_1, audio_2)
+
+    meta_1 = _build_metadata_html(0, params["audio_format"])
+    meta_2 = _build_metadata_html(0, params["audio_format"])
+
+    gen_status = _build_status_html(
+        t("messages.generation_complete"),
+        True,
+    )
+
+    yield (
+        gr.update(value=audio_1),  # 0
+        gr.update(value=audio_2),  # 1
+        gr.update(value=_step_indicator_html(5)),  # 2
+        gr.update(visible=False),  # 3: step 3 hide
+        gr.update(visible=False),  # 4: step 4 hide
+        gr.update(visible=True),  # 5: step 5 show
+        gr.skip(),  # 6: progress
+        gr.update(value=gen_status),  # 7
+        gr.update(value=meta_1),  # 8
+        gr.update(value=meta_2),  # 9
+        current_batch_index,  # 10
+        total_batches,  # 11
+        batch_queue,  # 12
+        saved_params,  # 13
+        *result_card_updates,  # 14-15
+    )
+
+
+def _save_audio_js() -> str:
+    """Return JS for downloading audio."""
+    return """(audio) => {
+        if (!audio) return;
+        let path = typeof audio === 'string' ? audio : (audio.path || audio.name || '');
+        if (!path) return;
+        let a = document.createElement('a');
+        a.href = path;
+        a.download = path.split('/').pop() || 'audio';
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }"""
+
+
+def register_simple_ui_handlers(
+    demo: Any,
+    dit_handler: Any,
+    llm_handler: Any,
+    simple_section: dict[str, Any],
+    results_section: dict[str, Any],
+    advanced_column: Any = None,
+    simple_mode_state: Any = None,
+) -> None:
+    """Register all event handlers for the stepped simple UI.
+
+    Args:
+        demo: Root Gradio demo.
+        dit_handler: DiT handler.
+        llm_handler: LLM handler.
+        simple_section: Simple UI component map.
+        results_section: Results section component map.
+        advanced_column: Advanced column component (for mode switch).
+        simple_mode_state: Mode state component (for mode switch).
+    """
+    gs = simple_section
+
+    # ── Navigation outputs ──
+    _nav_outputs = [
+        gs["simple_state_current_step"],
+        gs["simple_step_indicator"],
+        gs["simple_step_1"],
+        gs["simple_step_2"],
+        gs["simple_step_3"],
+        gs["simple_step_4"],
+        gs["simple_step_5"],
+    ]
+
+    # ── Step 1 → Step 2 ──
+    gs["simple_step1_continue_btn"].click(
+        fn=lambda state: _navigate_to(2, state),
+        inputs=[gs["simple_state_current_step"]],
+        outputs=_nav_outputs,
+    )
+
+    # ── Step 2 Back ──
+    gs["simple_step2_back_btn"].click(
+        fn=lambda state: _navigate_to(1, state),
+        inputs=[gs["simple_state_current_step"]],
+        outputs=_nav_outputs,
+    )
+
+    # ── Step 2 → Step 3 ──
+    gs["simple_step2_continue_btn"].click(
+        fn=lambda state: _navigate_to(3, state),
+        inputs=[gs["simple_state_current_step"]],
+        outputs=_nav_outputs,
+    )
+    gs["simple_instrumental"].change(
+        fn=_instrumental_lyrics_update,
+        inputs=[gs["simple_instrumental"]],
+        outputs=[gs["simple_lyrics"]],
+    )
+
+    # ── Step 3 Back ──
+    gs["simple_step3_back_btn"].click(
+        fn=lambda state: _navigate_to(2, state),
+        inputs=[gs["simple_state_current_step"]],
+        outputs=_nav_outputs,
+    )
+
+    # ── Hamburger toggle ──
+    gs["simple_hamburger_btn"].click(
+        fn=lambda state: (
+            gr.update(visible=not state),
+            not state,
+        ),
+        inputs=[gs["simple_hamburger_state"]],
+        outputs=[gs["simple_hamburger_menu"], gs["simple_hamburger_state"]],
+    )
+
+    # ── About overlay ──
+    gs["simple_about_btn"].click(
+        fn=lambda: (
+            gr.update(visible=False),   # close menu
+            False,                       # menu state = closed
+            gr.update(visible=True),     # show overlay
+        ),
+        inputs=[],
+        outputs=[gs["simple_hamburger_menu"], gs["simple_hamburger_state"], gs["simple_about_overlay"]],
+    )
+    gs["simple_about_close_btn"].click(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[gs["simple_about_overlay"]],
+    )
+
+    # ── Help (trigger hidden help button via JS) ──
+    gs["simple_help_btn"].click(
+        fn=lambda: (
+            gr.update(visible=False),   # close menu
+            False,
+        ),
+        inputs=[],
+        outputs=[gs["simple_hamburger_menu"], gs["simple_hamburger_state"]],
+        js="""() => {
+            var btn = document.querySelector('.help-inline-btn');
+            if (btn) btn.click();
+        }""",
+    )
+
+    # ── Advanced Mode (from hamburger menu) ──
+    if advanced_column is not None and simple_mode_state is not None:
+        gs["simple_advanced_btn"].click(
+            fn=lambda: (
+                gr.update(visible=False),   # close menu
+                False,                       # menu state = closed
+                gr.update(visible=False),    # hide simple column
+                gr.update(visible=True),     # show advanced column
+                "Advanced",                  # state = Advanced
+            ),
+            inputs=[],
+            outputs=[
+                gs["simple_hamburger_menu"], gs["simple_hamburger_state"],
+                gs["simple_column"], advanced_column, simple_mode_state,
+            ],
+        )
+
+    # ── Random Style ──
+    gs["simple_random_btn"].click(
+        fn=_go_random,
+        inputs=[],
+        outputs=[gs["simple_song_style"]],
+    )
+
+    # ── Generate (Create Music) ──
+    _gen_outputs = [
+        gs["simple_generated_audio_1"],          # 0
+        gs["simple_generated_audio_2"],          # 1
+        gs["simple_step_indicator"],             # 2
+        gs["simple_step_3"],                     # 3 — hide remix screen
+        gs["simple_step_4"],                     # 4
+        gs["simple_step_5"],                     # 5
+        gs["simple_progress_text"],              # 6
+        gs["simple_gen_info"],                   # 7
+        gs.get("simple_metadata_1", gr.skip()),  # 8
+        gs.get("simple_metadata_2", gr.skip()),  # 9
+        results_section["current_batch_index"],   # 10
+        results_section["total_batches"],         # 11
+        results_section["batch_queue"],           # 12
+        results_section["generation_params_state"], # 13
+        gs["simple_result_col_1"],                 # 14
+        gs["simple_result_col_2"],                 # 15
+    ]
+
+    _gen_shared_inputs = [
+        gs["simple_song_style"],
+        gs["simple_lyrics"],
+        gs["simple_instrumental"],
+        gs["simple_src_audio"],
+        results_section["current_batch_index"],
+        results_section["total_batches"],
+        results_section["batch_queue"],
+        results_section["generation_params_state"],
+    ]
+
+    # Generator must be a bare generator function (not wrapped in lambda)
+    # so Gradio 6 can detect 'generator': True via introspection.
+    def _gen_wrapper(style, lyrics, instrumental, src, bi, tb, bq, gps):
+        yield from _simple_generate_wrapper(
+            dit_handler, llm_handler, style, lyrics, instrumental, src, bi, tb, bq, gps,
+        )
+
+    gs["simple_create_btn"].click(
+        fn=_start_generation,
+        inputs=[],
+        outputs=_gen_outputs,
+    ).then(
+        fn=_gen_wrapper,
+        inputs=_gen_shared_inputs,
+        outputs=_gen_outputs,
+    )
+
+    # ── Save Buttons ──
+    _save_js = _save_audio_js()
+    gs["simple_save_btn_1"].click(
+        fn=None,
+        inputs=[gs["simple_generated_audio_1"]],
+        js=_save_js,
+    )
+    gs["simple_save_btn_2"].click(
+        fn=None,
+        inputs=[gs["simple_generated_audio_2"]],
+        js=_save_js,
+    )
+
+    # ── Retry (Try Different Style) ──
+    gs["simple_retry_btn"].click(
+        fn=lambda style, lyrics, audio, state: _navigate_to(1, state),
+        inputs=[
+            gs["simple_song_style"], gs["simple_lyrics"],
+            gs["simple_src_audio"], gs["simple_state_current_step"],
+        ],
+        outputs=_nav_outputs,
+    )
+
+    # ── New Song (reset all) ──
+    _new_song_outputs = _nav_outputs + [
+        gs["simple_song_style"],
+        gs["simple_lyrics"],
+        gs["simple_instrumental"],
+        gs["simple_src_audio"],
+        gs["simple_generated_audio_1"],
+        gs["simple_generated_audio_2"],
+        gs["simple_metadata_1"],
+        gs["simple_metadata_2"],
+        gs["simple_gen_info"],
+    ]
+
+    gs["simple_new_btn"].click(
+        fn=lambda: (
+            1,
+            gr.update(value=_step_indicator_html(1)),
+            gr.update(visible=True),        # step 1 show
+            gr.update(visible=False),       # step 2 hide
+            gr.update(visible=False),       # step 3 hide
+            gr.update(visible=False),       # step 4 hide
+            gr.update(visible=False),       # step 5 hide
+            gr.update(value=""),
+            gr.update(value=""),
+            gr.update(value=False),
+            gr.update(value=None),
+            gr.update(value=None),
+            gr.update(value=None),
+            gr.update(value=""),
+            gr.update(value=""),
+            gr.update(value=""),
+        ),
+        inputs=[],
+        outputs=_new_song_outputs,
+    )

--- a/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
+++ b/acestep/ui/gradio/events/wiring/simple_ui_wiring.py
@@ -73,14 +73,6 @@ def _build_status_html(message: str, is_success: bool) -> str:
     )
 
 
-def _result_card_updates(audio_1: str | None, audio_2: str | None) -> tuple:
-    """Return visibility updates for result cards with available audio."""
-    return (
-        gr.update(visible=audio_1 is not None),
-        gr.update(visible=audio_2 is not None),
-    )
-
-
 def _resolve_simple_lyrics(lyrics: str, instrumental: bool) -> str:
     """Return the generator lyrics value for the selected vocal mode."""
     return "[Instrumental]" if instrumental else (lyrics or "")
@@ -95,6 +87,10 @@ def _completion_message() -> str:
     """Return a translated completion message with an English fallback."""
     message = t("messages.generation_complete")
     return "Generation complete" if message == "messages.generation_complete" else message
+
+
+def _ignore_progress(*args: Any, **kwargs: Any) -> None:
+    """Suppress native Gradio progress when the Simple UI renders its own status."""
 
 
 def _navigate_to(target: int, current_step: int) -> tuple:
@@ -218,8 +214,6 @@ def _start_generation() -> tuple:
         gr.skip(),  # 8: metadata 1
         gr.skip(),  # 9: metadata 2
         gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
-        gr.update(visible=False),  # 14: result card 1
-        gr.update(visible=False),  # 15: result card 2
     )
 
 
@@ -234,7 +228,6 @@ def _simple_generate_wrapper(
     total_batches: int,
     batch_queue: dict,
     generation_params_state: dict,
-    progress: gr.Progress = gr.Progress(track_tqdm=True),
 ):
     """Generate music and stream progress through steps 4 and 5."""
     gc.collect()
@@ -260,7 +253,6 @@ def _simple_generate_wrapper(
             gr.update(value='<div class="simple-progress-status">Generating lyrics...</div>'),  # 6
             gr.skip(), gr.skip(), gr.skip(),  # 7-9: gen_info, metadata_1, metadata_2
             gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
-            gr.skip(), gr.skip(),  # 14-15: result cards
         )
         result = create_sample(
             llm_handler=llm_handler,
@@ -291,7 +283,6 @@ def _simple_generate_wrapper(
         gr.update(value='<div class="simple-progress-status">Creating your music...</div>'),  # 6
         gr.skip(), gr.skip(), gr.skip(),  # 7-9: gen_info, metadata_1, metadata_2
         gr.skip(), gr.skip(), gr.skip(), gr.skip(),  # 10-13: batch state
-        gr.skip(), gr.skip(),  # 14-15: result cards
     )
 
     params: dict[str, Any] = {}
@@ -363,7 +354,7 @@ def _simple_generate_wrapper(
         params["latent_shift"], params["latent_rescale"],
         params["repaint_mode"], params["repaint_strength"],
         params["retake_variance"], params["retake_seed"],
-        progress,
+        _ignore_progress,
     )
 
     # Forward intermediate yields so Gradio 6 streams audio updates live
@@ -384,7 +375,6 @@ def _simple_generate_wrapper(
             gr.skip(),                                         # 8: metadata 1
             gr.skip(),                                         # 9: metadata 2
             gr.skip(), gr.skip(), gr.skip(), gr.skip(),        # 10-13: batch state
-            gr.skip(), gr.skip(),                              # 14-15: result cards
         )
 
     if final_result is None:
@@ -399,7 +389,6 @@ def _simple_generate_wrapper(
             gr.update(value=_build_status_html("Generation failed. Please try again.", False)),  # 7
             gr.skip(), gr.skip(),  # 8-9: metadata_1, metadata_2
             current_batch_index, total_batches, batch_queue, generation_params_state,  # 10-13
-            gr.update(visible=False), gr.update(visible=False),  # 14-15
         )
         return
 
@@ -420,7 +409,6 @@ def _simple_generate_wrapper(
             gr.update(value=_build_status_html(str(err_msg), False)),  # 7
             gr.skip(), gr.skip(),  # 8-9: metadata_1, metadata_2
             current_batch_index, total_batches, batch_queue, generation_params_state,  # 10-13
-            gr.update(visible=False), gr.update(visible=False),  # 14-15
         )
         return
 
@@ -479,7 +467,6 @@ def _simple_generate_wrapper(
     audio_paths_list = all_audio_paths if isinstance(all_audio_paths, list) else []
     audio_1 = audio_paths_list[0] if len(audio_paths_list) >= 1 else None
     audio_2 = audio_paths_list[2] if len(audio_paths_list) >= 3 else None
-    result_card_updates = _result_card_updates(audio_1, audio_2)
 
     meta_1 = _build_metadata_html(0, params["audio_format"])
     meta_2 = _build_metadata_html(0, params["audio_format"])
@@ -501,7 +488,6 @@ def _simple_generate_wrapper(
         total_batches,  # 11
         batch_queue,  # 12
         saved_params,  # 13
-        *result_card_updates,  # 14-15
     )
 
 
@@ -667,8 +653,6 @@ def register_simple_ui_handlers(
         results_section["total_batches"],         # 11
         results_section["batch_queue"],           # 12
         results_section["generation_params_state"], # 13
-        gs["simple_result_col_1"],                 # 14
-        gs["simple_result_col_2"],                 # 15
     ]
 
     _gen_shared_inputs = [
@@ -693,10 +677,12 @@ def register_simple_ui_handlers(
         fn=_start_generation,
         inputs=[],
         outputs=_gen_outputs,
+        show_progress="hidden",
     ).then(
         fn=_gen_wrapper,
         inputs=_gen_shared_inputs,
         outputs=_gen_outputs,
+        show_progress="hidden",
     )
 
     # ── Save Buttons ──

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -555,6 +555,21 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             justify-content: space-between !important;
             gap: 0.75rem !important;
         }
+        .simple-remix-nav {
+            flex: 0 0 auto !important;
+            width: 100% !important;
+            margin-top: 0.75rem !important;
+        }
+        .simple-remix-nav .simple-back-btn,
+        .simple-remix-nav #simple-create-btn {
+            flex: 1 1 0 !important;
+            width: 100% !important;
+            min-width: 0 !important;
+            height: 48px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.95rem !important;
+            border-radius: 10px !important;
+        }
 
         /* ── Buttons ── */
         .simple-random-btn {
@@ -637,6 +652,11 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         }
 
         /* ── Upload Area (Step 3) ── */
+        .simple-upload-label-wrap {
+            flex: 0 0 auto !important;
+            width: 100% !important;
+            min-height: 0 !important;
+        }
         .simple-upload-label {
             font-size: 0.9rem;
             font-weight: 600;
@@ -651,8 +671,11 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             transition: all 0.2s ease !important;
             text-align: center !important;
             min-height: 0 !important;
+            height: 190px !important;
+            max-height: 190px !important;
         }
         .simple-upload-area > div:first-child {
+            height: 100% !important;
             min-height: 0 !important;
             padding: 0.25rem 0 !important;
         }
@@ -680,13 +703,14 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         /* ── Create Button (Step 3) ── */
         #simple-create-btn {
             width: 100% !important;
-            padding: 1rem 2rem !important;
-            font-size: 1.15rem !important;
+            height: 48px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.95rem !important;
             font-weight: 700 !important;
             letter-spacing: 0.01em;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
-            border: none !important;
-            border-radius: 14px !important;
+            border: 2px solid transparent !important;
+            border-radius: 10px !important;
             color: #ffffff !important;
             box-shadow: 0 4px 14px rgba(102, 126, 234, 0.35) !important;
             transition: transform 0.12s ease, box-shadow 0.12s ease !important;

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -239,13 +239,19 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
            ═══════════════════════════════════════════ */
 
         /* ── Container ── */
+        body:has(#simple-ui-column),
+        .gradio-container:has(#simple-ui-column) {
+            background: #f1f0f5 !important;
+        }
         #simple-ui-column {
             display: block !important;
             position: relative;
-            max-width: 680px;
+            width: min(880px, calc(100vw - 2rem));
+            max-width: 880px;
             margin: 0 auto;
             padding: 0 1rem 2rem;
             background: #faf8f6;
+            box-shadow: 0 18px 50px rgba(31, 35, 48, 0.12);
             min-height: 0;
             height: auto;
             overflow: hidden;
@@ -996,6 +1002,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         /* ── Responsive ── */
         @media (max-width: 640px) {
             #simple-ui-column {
+                width: calc(100vw - 1rem);
                 padding: 0 0.5rem 2rem;
             }
             .simple-header {

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -244,7 +244,8 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             margin: 0 auto;
             padding: 0 1rem 2rem;
             background: #faf8f6;
-            min-height: 80vh;
+            min-height: 0;
+            height: auto;
             overflow: hidden;
         }
         #simple-ui-column > div:empty {
@@ -784,7 +785,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
             flex: 0 0 auto !important;
             width: 100% !important;
-            align-items: flex-start !important;
+            align-items: stretch !important;
             gap: 0.75rem !important;
             margin-bottom: 0.5rem !important;
         }
@@ -800,6 +801,10 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
 
         .simple-best-badge {
             display: inline-flex;
+            position: absolute;
+            top: 0.75rem;
+            left: 0.75rem;
+            z-index: 2;
             align-items: center;
             gap: 4px;
             background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
@@ -810,7 +815,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             letter-spacing: 0.05em;
             padding: 3px 10px;
             border-radius: 20px;
-            margin-bottom: 2px;
+            margin: 0;
         }
 
         .simple-audio {

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -1106,12 +1106,12 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         simple_section = build_simple_ui()
         
         # Mode state shared between Simple and Advanced toggle buttons
-        simple_mode_state = gr.State(value="Advanced")
+        simple_mode_state = gr.State(value="Simple")
 
         # ═══════════════════════════════════════════
         # Advanced UI Column (visible when "Advanced" selected)
         # ═══════════════════════════════════════════
-        with gr.Column(visible=True) as advanced_column:
+        with gr.Column(visible=False) as advanced_column:
             # Compact mode toggle at the top of the Advanced column
             with gr.Row(elem_classes="advanced-mode-row"):
                 gr.HTML(
@@ -1170,6 +1170,13 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             fn=lambda: _init_llm_for_simple_ui(llm_handler, dit_handler),
             inputs=[],
             outputs=[],
+        )
+
+        demo.load(
+            fn=lambda: _init_llm_for_simple_ui(llm_handler, dit_handler),
+            inputs=[],
+            outputs=[],
+            show_progress="hidden",
         )
 
         # Connect event handlers

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -198,7 +198,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         /* Prevent tooltip CSS from hiding content inside .no-tooltip components */
         .no-tooltip span[data-testid="block-info"] + div,
         .no-tooltip span[data-testid="block-info"] + span {
-            display: block !important;
+            display: block;
             position: static !important;
             background: none !important;
             padding: 0 !important;
@@ -240,6 +240,8 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
 
         /* ── Container ── */
         #simple-ui-column {
+            display: block !important;
+            position: relative;
             max-width: 680px;
             margin: 0 auto;
             padding: 0 1rem 2rem;
@@ -466,6 +468,11 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
 
         /* ── Step Indicator ── */
         .simple-step-indicator {
+            display: block !important;
+            flex: none !important;
+            height: 70px !important;
+            min-height: 70px !important;
+            max-height: 70px !important;
             margin: 0 0 1.5rem;
             overflow: visible !important;
             contain: none !important;
@@ -825,10 +832,6 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
 
         .simple-best-badge {
             display: inline-flex;
-            position: absolute;
-            top: 0.75rem;
-            left: 0.75rem;
-            z-index: 2;
             align-items: center;
             gap: 4px;
             background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
@@ -839,7 +842,11 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             letter-spacing: 0.05em;
             padding: 3px 10px;
             border-radius: 20px;
-            margin: 0;
+            margin: 0 0 2px;
+        }
+        .simple-best-badge-placeholder {
+            visibility: hidden;
+            pointer-events: none;
         }
 
         .simple-audio {

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -741,6 +741,15 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             transform: translateY(0) !important;
             box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3) !important;
         }
+        #simple-create-btn:disabled,
+        #simple-create-btn[aria-disabled="true"] {
+            background: #a8a8b3 !important;
+            border-color: #a8a8b3 !important;
+            box-shadow: none !important;
+            color: #f4f4f6 !important;
+            cursor: not-allowed !important;
+            transform: none !important;
+        }
 
         /* ── Creating Step (Step 4) ── */
         .simple-creating-icon {
@@ -1186,7 +1195,7 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
 
         # Wire compact mode switch (Advanced → Simple)
         from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
-            _init_llm_for_simple_ui,
+            _initialize_simple_ui_models,
         )
 
         advanced_mode_switch.click(
@@ -1198,15 +1207,16 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             inputs=[],
             outputs=[simple_section["simple_column"], advanced_column, simple_mode_state],
         ).then(
-            fn=lambda: _init_llm_for_simple_ui(llm_handler, dit_handler),
+            fn=lambda: _initialize_simple_ui_models(llm_handler, dit_handler),
             inputs=[],
-            outputs=[],
+            outputs=[simple_section["simple_create_btn"]],
+            show_progress="hidden",
         )
 
         demo.load(
-            fn=lambda: _init_llm_for_simple_ui(llm_handler, dit_handler),
+            fn=lambda: _initialize_simple_ui_models(llm_handler, dit_handler),
             inputs=[],
-            outputs=[],
+            outputs=[simple_section["simple_create_btn"]],
             show_progress="hidden",
         )
 

--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -28,6 +28,7 @@ from acestep.ui.gradio.interfaces.generation import (
     create_advanced_settings_section,
     create_generation_tab_section,
 )
+from acestep.ui.gradio.interfaces.simple_ui import build_simple_ui
 from acestep.ui.gradio.interfaces.audio_player_preferences import (
     get_audio_player_preferences_head,
 )
@@ -37,7 +38,11 @@ from acestep.ui.gradio.interfaces.user_preferences import (
 )
 from acestep.ui.gradio.interfaces.result import create_results_section
 from acestep.ui.gradio.interfaces.training import create_training_section
-from acestep.ui.gradio.events import setup_event_handlers, setup_training_event_handlers
+from acestep.ui.gradio.events import (
+    setup_event_handlers,
+    setup_simple_ui_handlers,
+    setup_training_event_handlers,
+)
 from acestep.ui.gradio.help_content import create_help_button, HELP_MODAL_CSS
 
 
@@ -229,6 +234,778 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
             transition-delay: 0s;
         }
 
+        /* ═══════════════════════════════════════════
+           ✦ Simple UI — 5-Step Creative Studio ✦
+           ═══════════════════════════════════════════ */
+
+        /* ── Container ── */
+        #simple-ui-column {
+            max-width: 680px;
+            margin: 0 auto;
+            padding: 0 1rem 2rem;
+            background: #faf8f6;
+            min-height: 80vh;
+            overflow: hidden;
+        }
+        #simple-ui-column > div:empty {
+            display: none !important;
+        }
+        #simple-ui-column .gr-form {
+            min-height: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
+            border: none !important;
+        }
+
+        /* ── Header ── */
+        .simple-header {
+            position: relative;
+            padding: 1.25rem 1.5rem 1rem;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border-radius: 0 0 24px 24px;
+            margin: 0 -1rem 1.25rem;
+        }
+        .simple-header-content {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            justify-content: center;
+        }
+        .simple-header-icon {
+            flex-shrink: 0;
+            display: flex;
+        }
+        .simple-header-icon svg {
+            filter: drop-shadow(0 2px 4px rgba(0,0,0,0.15));
+        }
+        .simple-header-text {
+            text-align: left;
+        }
+        .simple-header-text h2 {
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin: 0;
+            color: #ffffff;
+            letter-spacing: -0.01em;
+            line-height: 1.3;
+        }
+        .simple-header-text p {
+            font-size: 0.8rem;
+            color: rgba(255,255,255,0.7);
+            margin: 0.1rem 0 0;
+            line-height: 1.3;
+        }
+
+        /* ── Hamburger button ── */
+        .simple-hamburger-btn {
+            position: absolute !important;
+            top: 0.75rem !important;
+            right: 0.75rem !important;
+            z-index: 10 !important;
+            background: rgba(255,255,255,0.15) !important;
+            border: none !important;
+            border-radius: 8px !important;
+            color: white !important;
+            font-size: 0 !important;
+            padding: 0.25rem 0.5rem !important;
+            line-height: 1 !important;
+            min-width: 0 !important;
+            width: auto !important;
+            cursor: pointer !important;
+            transition: background 0.15s ease !important;
+        }
+        .simple-hamburger-btn::before {
+            content: "";
+            display: block;
+            width: 22px;
+            height: 22px;
+            background: currentColor;
+            -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 6h16M4 12h16M4 18h16' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E") center/contain no-repeat;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 6h16M4 12h16M4 18h16' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E") center/contain no-repeat;
+        }
+        .simple-hamburger-btn:hover {
+            background: rgba(255,255,255,0.25) !important;
+        }
+
+        /* ── Hamburger dropdown menu ── */
+        .simple-hamburger-menu {
+            position: absolute !important;
+            top: 3rem !important;
+            right: 0.75rem !important;
+            z-index: 20 !important;
+            background: #ffffff !important;
+            border: 1px solid #e2dff0 !important;
+            border-radius: 12px !important;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.12) !important;
+            padding: 0.35rem !important;
+            min-width: 180px !important;
+            overflow: visible !important;
+        }
+        .simple-hamburger-menu > div,
+        .simple-hamburger-menu > div > div {
+            background: #ffffff !important;
+            border-color: transparent !important;
+        }
+        .simple-menu-item {
+            width: 100% !important;
+            justify-content: flex-start !important;
+            border: none !important;
+            border-radius: 8px !important;
+            padding: 0.5rem 0.85rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 500 !important;
+            color: #1a1a2e !important;
+            background: transparent !important;
+            transition: background 0.1s ease !important;
+            text-align: left !important;
+            gap: 0.65rem !important;
+        }
+        .simple-menu-item::before {
+            content: "";
+            display: inline-block;
+            flex: 0 0 18px;
+            width: 18px;
+            height: 18px;
+            background-color: #667eea;
+            -webkit-mask-position: center;
+            -webkit-mask-repeat: no-repeat;
+            -webkit-mask-size: contain;
+            mask-position: center;
+            mask-repeat: no-repeat;
+            mask-size: contain;
+        }
+        .simple-menu-about::before {
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9' fill='none' stroke='black' stroke-width='2'/%3E%3Cpath d='M12 11v6M12 7h.01' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E");
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9' fill='none' stroke='black' stroke-width='2'/%3E%3Cpath d='M12 11v6M12 7h.01' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E");
+        }
+        .simple-menu-help::before {
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9' fill='none' stroke='black' stroke-width='2'/%3E%3Cpath d='M9.8 9a2.4 2.4 0 1 1 3.4 2.2c-.8.4-1.2.9-1.2 1.8M12 17h.01' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9' fill='none' stroke='black' stroke-width='2'/%3E%3Cpath d='M9.8 9a2.4 2.4 0 1 1 3.4 2.2c-.8.4-1.2.9-1.2 1.8M12 17h.01' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+        }
+        .simple-menu-advanced::before {
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 7h10M18 7h2M4 17h2M10 17h10M14 4v6M7 14v6' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 7h10M18 7h2M4 17h2M10 17h10M14 4v6M7 14v6' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+        }
+        .simple-menu-item:hover {
+            background: #f4f2ff !important;
+        }
+
+        /* ── About Overlay ── */
+        .simple-about-backdrop {
+            position: fixed !important;
+            top: 0 !important;
+            left: 0 !important;
+            width: 100vw !important;
+            height: 100vh !important;
+            z-index: 9999 !important;
+            background: rgba(0,0,0,0.45) !important;
+            display: flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            backdrop-filter: blur(4px) !important;
+        }
+        .simple-about-modal {
+            background: #ffffff !important;
+            border-radius: 20px !important;
+            padding: 2.5rem 2rem !important;
+            max-width: 440px !important;
+            width: 90% !important;
+            text-align: center !important;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.2) !important;
+            position: relative !important;
+        }
+        .simple-about-close {
+            position: absolute !important;
+            top: 0.75rem !important;
+            right: 1rem !important;
+            background: none !important;
+            border: none !important;
+            font-size: 1.5rem !important;
+            color: #999 !important;
+            cursor: pointer !important;
+            padding: 0.25rem !important;
+            line-height: 1 !important;
+        }
+        .simple-about-close:hover {
+            color: #333 !important;
+        }
+        .simple-about-icon {
+            font-size: 2.5rem;
+            margin-bottom: 0.5rem;
+        }
+        .simple-about-modal h2 {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: #1a1a2e;
+            margin: 0 0 0.3rem;
+        }
+        .simple-about-subtitle {
+            font-size: 0.85rem;
+            color: #667eea;
+            font-weight: 600;
+            margin: 0 0 0.75rem;
+        }
+        .simple-about-desc {
+            font-size: 0.85rem;
+            color: #666;
+            line-height: 1.5;
+            margin: 0;
+        }
+
+        /* ── Hidden help button container ── */
+        .simple-help-container {
+            position: fixed !important;
+            top: -9999px !important;
+            left: -9999px !important;
+            opacity: 0 !important;
+            pointer-events: none !important;
+            height: 0 !important;
+            overflow: hidden !important;
+        }
+
+        /* ── Step Indicator ── */
+        .simple-step-indicator {
+            margin: 0 0 1.5rem;
+            overflow: visible !important;
+            contain: none !important;
+        }
+
+        /* ── Step Columns ── */
+        .simple-step {
+            /* Gradio 6 can hide a Column's children while leaving its layout shell
+               mounted. A transparent layout wrapper prevents that shell from
+               rendering as an empty bordered row. Inline display:none still wins
+               when Gradio hides the Column itself. */
+            display: contents;
+        }
+        /* Gradio can place its hidden marker on either the component or its host.
+           Collapse the single step boundary without overriding child display rules. */
+        .simple-step.hide,
+        .simple-step.hidden,
+        .simple-step[hidden],
+        .simple-step[style*="display: none"],
+        .hide:has(> .simple-step),
+        .hidden:has(> .simple-step),
+        [hidden]:has(> .simple-step) {
+            display: none !important;
+            height: 0 !important;
+            min-height: 0 !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            border: 0 !important;
+            gap: 0 !important;
+        }
+
+        /* Collapse any Gradio wrapper that contains ONLY hidden content */
+        #simple-ui-column > div:empty {
+            display: none !important;
+            height: 0 !important;
+            min-height: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
+        }
+        @keyframes simpleFadeIn {
+            from { opacity: 0; transform: translateY(8px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        /* ── Text Inputs ── */
+        .simple-input label {
+            font-size: 0.95rem !important;
+            font-weight: 600 !important;
+            color: #1a1a2e !important;
+            margin-bottom: 0.3rem !important;
+        }
+        .simple-input textarea {
+            border-radius: 12px !important;
+            border: 2px solid #e2dff0 !important;
+            padding: 12px 16px !important;
+            font-size: 0.95rem !important;
+            line-height: 1.5 !important;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+            background: #ffffff !important;
+            color: #1a1a2e !important;
+            resize: vertical !important;
+        }
+        .simple-input textarea:focus {
+            border-color: #667eea !important;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15) !important;
+            outline: none !important;
+        }
+        .simple-input textarea::placeholder {
+            color: #b0aec0 !important;
+        }
+        .simple-lyrics textarea {
+            min-height: 160px !important;
+        }
+        .simple-instrumental {
+            width: fit-content !important;
+            margin: -0.25rem 0 0.25rem auto !important;
+            padding: 0.25rem 0.5rem !important;
+        }
+        .simple-instrumental label {
+            font-size: 0.85rem !important;
+        }
+
+        /* ── Navigation Row ── */
+        .simple-nav-row {
+            margin-top: 1.25rem !important;
+            display: flex !important;
+            justify-content: space-between !important;
+            gap: 0.75rem !important;
+        }
+
+        /* ── Buttons ── */
+        .simple-random-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 10px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 500 !important;
+            color: #1a1a2e !important;
+            background: #ffffff !important;
+            transition: all 0.15s ease !important;
+        }
+        .simple-random-btn::before {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY3ZWVhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMyIgeT0iMyIgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiByeD0iMiIvPjxjaXJjbGUgY3g9IjgiIGN5PSI4IiByPSIxLjUiLz48Y2lyY2xlIGN4PSIxNiIgY3k9IjgiIHI9IjEuNSIvPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEuNSIvPjxjaXJjbGUgY3g9IjgiIGN5PSIxNiIgcj0iMS41Ii8+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMS41Ii8+PC9zdmc+") no-repeat center;
+            background-size: contain;
+        }
+        .simple-random-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        .simple-back-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 10px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 500 !important;
+            color: #1a1a2e !important;
+            background: #ffffff !important;
+            transition: all 0.15s ease !important;
+        }
+        .simple-back-btn::before {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY3ZWVhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PGxpbmUgeDE9IjE5IiB5MT0iMTIiIHgyPSI1IiB5Mj0iMTIiLz48cG9seWxpbmUgcG9pbnRzPSIxMiAxOSA1IDEyIDEyIDUiLz48L3N2Zz4=") no-repeat center;
+            background-size: contain;
+        }
+        .simple-back-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        .simple-continue-btn {
+            border-radius: 10px !important;
+            padding: 0.5rem 1.75rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 600 !important;
+            background: linear-gradient(135deg, #667eea, #764ba2) !important;
+            border: none !important;
+            color: #ffffff !important;
+            transition: all 0.15s ease !important;
+            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.25) !important;
+        }
+        .simple-continue-btn:hover {
+            transform: translateY(-1px) !important;
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.35) !important;
+        }
+        .simple-continue-btn:active {
+            transform: translateY(0) !important;
+        }
+        .simple-continue-btn::after {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            margin-left: 6px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxsaW5lIHgxPSI1IiB5MT0iMTIiIHgyPSIxOSIgeTI9IjEyIi8+PHBvbHlsaW5lIHBvaW50cz0iMTIgNSAxOSAxMiAxMiAxOSIvPjwvc3ZnPg==") no-repeat center;
+            background-size: contain;
+        }
+
+        /* ── Upload Area (Step 3) ── */
+        .simple-upload-label {
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #1a1a2e;
+            margin-bottom: 0.35rem !important;
+        }
+        .simple-upload-area {
+            border: 2px dashed #d0cce8 !important;
+            border-radius: 12px !important;
+            padding: 0.5rem !important;
+            background: #faf9ff !important;
+            transition: all 0.2s ease !important;
+            text-align: center !important;
+            min-height: 0 !important;
+        }
+        .simple-upload-area > div:first-child {
+            min-height: 0 !important;
+            padding: 0.25rem 0 !important;
+        }
+        .simple-upload-area:hover {
+            border-color: #667eea !important;
+            background: #f4f2ff !important;
+        }
+        /* Suppress empty child wrappers inside the upload area */
+        .simple-upload-area > div:empty,
+        .simple-upload-area .gr-box:empty {
+            display: none !important;
+        }
+        /* Hide waveform display before any audio is loaded */
+        .simple-upload-area audio,
+        .simple-upload-area canvas,
+        .simple-upload-area .waveform-container {
+            display: none !important;
+        }
+        /* Hide the record/mic source button — upload only */
+        .simple-upload-area button[aria-label*="mic"],
+        .simple-upload-area button[aria-label*="record"] {
+            display: none !important;
+        }
+
+        /* ── Create Button (Step 3) ── */
+        #simple-create-btn {
+            width: 100% !important;
+            padding: 1rem 2rem !important;
+            font-size: 1.15rem !important;
+            font-weight: 700 !important;
+            letter-spacing: 0.01em;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            border: none !important;
+            border-radius: 14px !important;
+            color: #ffffff !important;
+            box-shadow: 0 4px 14px rgba(102, 126, 234, 0.35) !important;
+            transition: transform 0.12s ease, box-shadow 0.12s ease !important;
+            cursor: pointer !important;
+        }
+        #simple-create-btn::before {
+            content: "";
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            margin-right: 8px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiIHN0cm9rZT0ibm9uZSI+PHBvbHlnb24gcG9pbnRzPSI1IDMgMTkgMTIgNSAyMSA1IDMiLz48L3N2Zz4=") no-repeat center;
+            background-size: contain;
+        }
+        #simple-create-btn:hover {
+            transform: translateY(-2px) !important;
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.45) !important;
+        }
+        #simple-create-btn:active {
+            transform: translateY(0) !important;
+            box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3) !important;
+        }
+
+        /* ── Creating Step (Step 4) ── */
+        .simple-creating-icon {
+            text-align: center;
+            padding: 2rem 0 1rem;
+            animation: simplePulse 1.5s ease-in-out infinite;
+        }
+        @keyframes simplePulse {
+            0%, 100% { opacity: 0.6; transform: scale(1); }
+            50% { opacity: 1; transform: scale(1.1); }
+        }
+        .simple-creating-title {
+            text-align: center;
+            font-size: 1.2rem;
+            font-weight: 600;
+            color: #1a1a2e;
+            margin: 0 0 1.5rem;
+        }
+        .simple-progress-track {
+            width: 100%;
+            height: 8px;
+            background: #e8e6f0;
+            border-radius: 4px;
+            overflow: hidden;
+            margin-bottom: 1rem;
+        }
+        .simple-progress-bar {
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, #667eea, #764ba2, #667eea);
+            background-size: 200% 100%;
+            border-radius: 4px;
+            animation: simpleProgressSlide 1.5s ease-in-out infinite;
+        }
+        @keyframes simpleProgressSlide {
+            0% { background-position: 200% 0; }
+            100% { background-position: -200% 0; }
+        }
+        .simple-progress-status {
+            text-align: center;
+            font-size: 0.9rem;
+            color: #8e8ea0;
+            padding: 0.5rem 0;
+            min-height: 2rem;
+        }
+
+        /* ── Results Step (Step 5) ── */
+        .simple-divider-wrap {
+            flex: 0 0 auto !important;
+            min-height: 0 !important;
+            width: 100% !important;
+        }
+        .simple-divider {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            justify-content: center;
+            margin: 0 0 0.75rem;
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #667eea;
+        }
+        .simple-divider::before,
+        .simple-divider::after {
+            content: "";
+            flex: 1;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, #d0cce8, transparent);
+        }
+
+        .simple-results-row {
+            display: grid !important;
+            grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+            flex: 0 0 auto !important;
+            width: 100% !important;
+            align-items: flex-start !important;
+            gap: 0.75rem !important;
+            margin-bottom: 0.5rem !important;
+        }
+        .simple-result-col {
+            position: relative;
+            width: 100% !important;
+            min-width: 0 !important;
+            flex-grow: 0 !important;
+            min-height: 0 !important;
+            gap: 0.25rem !important;
+            padding: 0.5rem !important;
+        }
+
+        .simple-best-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+            color: white;
+            font-size: 0.7rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 3px 10px;
+            border-radius: 20px;
+            margin-bottom: 2px;
+        }
+
+        .simple-audio {
+            border-radius: 8px !important;
+            overflow: hidden !important;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.06) !important;
+            min-height: 0 !important;
+            margin: 0 !important;
+        }
+        .simple-audio audio {
+            height: 36px !important;
+        }
+
+        .simple-meta-row {
+            display: flex !important;
+            align-items: center !important;
+            justify-content: space-between !important;
+            padding: 0.15rem 0 !important;
+            gap: 0.5rem !important;
+        }
+        .simple-metadata {
+            font-size: 0.8rem;
+            color: #8e8ea0;
+        }
+        .simple-meta-text {
+            white-space: nowrap;
+        }
+
+        .simple-save-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 8px !important;
+            padding: 0.35rem 0.75rem !important;
+            font-size: 0.8rem !important;
+            background: #ffffff !important;
+            transition: all 0.15s ease !important;
+            min-width: 40px !important;
+        }
+        .simple-save-btn::before {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY3ZWVhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTIxIDE1djRhMiAyIDAgMCAxLTIgMkg1YTIgMiAwIDAgMS0yLTJ2LTQiLz48cG9seWxpbmUgcG9pbnRzPSI3IDEwIDEyIDE1IDE3IDEwIi8+PGxpbmUgeDE9IjEyIiB5MT0iMTUiIHgyPSIxMiIgeTI9IjMiLz48L3N2Zz4=") no-repeat center;
+            background-size: contain;
+        }
+        .simple-save-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        .simple-gen-info {
+            flex: 0 0 auto !important;
+            width: 100% !important;
+            margin: 0.35rem 0 0.5rem;
+        }
+        .simple-gen-status {
+            text-align: center;
+            padding: 0.4rem 0.75rem;
+            border-radius: 10px;
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+        .simple-gen-status.success {
+            background: rgba(16, 185, 129, 0.08);
+            color: #047857;
+        }
+        .simple-gen-status.info {
+            background: rgba(102, 126, 234, 0.08);
+            color: #5b4fc4;
+        }
+
+        /* ── Footer Buttons (Step 5) ── */
+        .simple-footer-row {
+            display: flex !important;
+            flex: 0 0 auto !important;
+            width: 100% !important;
+            gap: 0.75rem !important;
+            justify-content: center !important;
+            margin-top: 0.25rem !important;
+        }
+        .simple-retry-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 10px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 500 !important;
+            background: #ffffff !important;
+            transition: all 0.15s ease !important;
+        }
+        .simple-retry-btn::before {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY3ZWVhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlsaW5lIHBvaW50cz0iMjMgNCAyMyAxMCAxNyAxMCIvPjxwb2x5bGluZSBwb2ludHM9IjEgMjAgMSAxNCA3IDE0Ii8+PHBhdGggZD0iTTMuNTEgOWE5IDkgMCAwIDEgMTQuODUtMy4zNkwyMyAxME0xIDE0bDQuNjQgNC4zNkE5IDkgMCAwIDAgMjAuNDkgMTUiLz48L3N2Zz4=") no-repeat center;
+            background-size: contain;
+        }
+        .simple-retry-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        .simple-new-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 10px !important;
+            padding: 0.5rem 1.25rem !important;
+            font-size: 0.85rem !important;
+            font-weight: 500 !important;
+            background: #ffffff !important;
+            transition: all 0.15s ease !important;
+        }
+        .simple-new-btn::before {
+            content: "";
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
+            vertical-align: middle;
+            background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY3ZWVhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTkgMThWNWwxMi0ydjEzIi8+PGNpcmNsZSBjeD0iNiIgY3k9IjE4IiByPSIzIi8+PGNpcmNsZSBjeD0iMTgiIGN5PSIxNiIgcj0iMyIvPjwvc3ZnPg==") no-repeat center;
+            background-size: contain;
+        }
+        .simple-new-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        /* ── Collapse hidden containers properly ── */
+        .simple-hamburger-menu {
+            transition: none !important;
+        }
+        .simple-hamburger-menu ~ div:empty {
+            display: none !important;
+        }
+
+        /* ── Responsive ── */
+        @media (max-width: 640px) {
+            #simple-ui-column {
+                padding: 0 0.5rem 2rem;
+            }
+            .simple-header {
+                margin: 0 -0.5rem 1rem;
+                padding: 1rem 0.75rem;
+            }
+            .simple-header-text h2 {
+                font-size: 1rem;
+            }
+            .simple-header-text p {
+                font-size: 0.75rem;
+            }
+            .simple-header-icon svg {
+                width: 24px;
+                height: 24px;
+            }
+            .simple-results-row {
+                grid-template-columns: minmax(0, 1fr) !important;
+            }
+            .simple-nav-row {
+                flex-direction: row !important;
+                gap: 0.5rem !important;
+            }
+        }
+
+        /* ── Advanced Mode Toggle Row ── */
+        .advanced-mode-row {
+            align-items: center !important;
+            justify-content: space-between !important;
+            margin-bottom: 0.5rem !important;
+            padding: 0.25rem 0 !important;
+        }
+        .advanced-mode-label {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--body-text-color, #1a1a2e);
+        }
+        .advanced-mode-switch-btn {
+            border: 2px solid #e2dff0 !important;
+            border-radius: 8px !important;
+            font-size: 0.8rem !important;
+            font-weight: 500 !important;
+            color: #667eea !important;
+            background: #ffffff !important;
+            padding: 0.25rem 0.75rem !important;
+            transition: all 0.15s ease !important;
+            white-space: nowrap !important;
+        }
+        .advanced-mode-switch-btn:hover {
+            border-color: #667eea !important;
+            background: #f8f7ff !important;
+        }
+
+        /* ── End Simple UI ── */
+
         /* High-res info icon using SVG, appended to the label text */
         .has-info-container span[data-testid="block-info"]::after,
         .checkbox-container:has(+ div) .label-text::after {
@@ -311,67 +1088,104 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         """ + HELP_MODAL_CSS,
     ) as demo:
         
-        gr.HTML(f"""
-        <div class="main-header">
-            <h1>{t("app.title")}</h1>
-            <p>{t("app.subtitle")}</p>
-        </div>
-        """)
-        create_help_button("getting_started")
+        # Hidden help button — triggered programmatically from the hamburger menu
+        with gr.Column(visible=True, elem_classes="simple-help-container"):
+            create_help_button("getting_started")
         
         # Dataset Explorer Section (hidden)
         dataset_section = create_dataset_section(dataset_handler)
         
         # ═══════════════════════════════════════════
-        # Top-level: Settings (contains Service Config + Advanced Settings)
+        # Simple UI Column (visible when "Simple" selected)
         # ═══════════════════════════════════════════
-        settings_section = create_advanced_settings_section(
-            dit_handler, llm_handler, init_params=init_params, language=language
-        )
+        simple_section = build_simple_ui()
         
+        # Mode state shared between Simple and Advanced toggle buttons
+        simple_mode_state = gr.State(value="Advanced")
+
         # ═══════════════════════════════════════════
-        # Tabs: Generation | Training
+        # Advanced UI Column (visible when "Advanced" selected)
         # ═══════════════════════════════════════════
-        with gr.Tabs():
-            # --- Generation Tab ---
-            with gr.Tab(t("generation.tab_title")):
-                gen_section = create_generation_tab_section(
-                    dit_handler, llm_handler, init_params=init_params, language=language
+        with gr.Column(visible=True) as advanced_column:
+            # Compact mode toggle at the top of the Advanced column
+            with gr.Row(elem_classes="advanced-mode-row"):
+                gr.HTML(
+                    '<span class="advanced-mode-label">' + t("app.title") + '</span>'
                 )
-                
-                # Results Section (inside the Generation tab, wrapped for visibility control)
-                with gr.Column(visible=True) as results_wrapper:
-                    results_section = create_results_section(dit_handler)
-                # Store the wrapper in gen_section so event handlers can toggle it
-                gen_section["results_wrapper"] = results_wrapper
-            
-            # --- Training Tab ---
-            with gr.Tab(t("training.tab_title"), visible=not service_mode):
-                training_section = create_training_section(
-                    dit_handler, llm_handler, init_params=init_params
+                advanced_mode_switch = gr.Button(
+                    "☰ Simple",
+                    size="sm",
+                    elem_classes=["advanced-mode-switch-btn"],
                 )
-        
+            settings_section = create_advanced_settings_section(
+                dit_handler, llm_handler, init_params=init_params, language=language
+            )
+
+            # Generation results section (shared between both modes)
+            results_section = create_results_section(dit_handler)
+
+            # Tabs: Generation | Training
+            with gr.Tabs():
+                # --- Generation Tab ---
+                with gr.Tab(t("generation.tab_title")):
+                    gen_section = create_generation_tab_section(
+                        dit_handler, llm_handler, init_params=init_params, language=language
+                    )
+                    # Results Section (inside the Generation tab, wrapped for visibility control)
+                    with gr.Column(visible=True) as results_wrapper:
+                        gen_section["results_wrapper"] = results_wrapper
+
+                # --- Training Tab ---
+                with gr.Tab(t("training.tab_title"), visible=not service_mode):
+                    training_section = create_training_section(
+                        dit_handler, llm_handler, init_params=init_params
+                    )
+
         # ═══════════════════════════════════════════
         # Merge all generation-related component dicts for event wiring
         # ═══════════════════════════════════════════
-        # The event handlers expect a single "generation_section" dict with all
-        # components from settings (service config + advanced) and generation tab.
         generation_section = {}
         generation_section.update(settings_section)
         generation_section.update(gen_section)
-        
+
+        # Wire compact mode switch (Advanced → Simple)
+        from acestep.ui.gradio.events.wiring.simple_ui_wiring import (
+            _init_llm_for_simple_ui,
+        )
+
+        advanced_mode_switch.click(
+            fn=lambda: (
+                gr.update(visible=True),        # simple column shown
+                gr.update(visible=False),       # advanced column hidden
+                "Simple",                        # state = Simple
+            ),
+            inputs=[],
+            outputs=[simple_section["simple_column"], advanced_column, simple_mode_state],
+        ).then(
+            fn=lambda: _init_llm_for_simple_ui(llm_handler, dit_handler),
+            inputs=[],
+            outputs=[],
+        )
+
         # Connect event handlers
         setup_event_handlers(
             demo, dit_handler, llm_handler, dataset_handler,
             dataset_section, generation_section, results_section
         )
-        
+
+        # Connect simple UI event handlers
+        setup_simple_ui_handlers(
+            demo, dit_handler, llm_handler,
+            simple_section, results_section,
+            advanced_column=advanced_column,
+            simple_mode_state=simple_mode_state,
+        )
+
         # Connect training event handlers
         setup_training_event_handlers(demo, dit_handler, llm_handler, training_section)
 
         # Restore user preferences from browser localStorage on page load.
-        # In service mode, skip restore so localStorage cannot override
-        # server-configured init_params or locked controls.
         wire_preference_restore(demo, generation_section, service_mode=service_mode)
 
+    demo.queue()
     return demo

--- a/acestep/ui/gradio/interfaces/simple_ui.py
+++ b/acestep/ui/gradio/interfaces/simple_ui.py
@@ -174,9 +174,10 @@ def _build_step_remix() -> tuple[gr.Column, dict[str, Any]]:
                 elem_classes=["simple-back-btn"],
             )
             simple_create_btn = gr.Button(
-                "  Create Music",
+                "Loading models…",
                 variant="primary",
                 size="sm",
+                interactive=False,
                 elem_id="simple-create-btn",
                 elem_classes=["simple-create-btn"],
             )

--- a/acestep/ui/gradio/interfaces/simple_ui.py
+++ b/acestep/ui/gradio/interfaces/simple_ui.py
@@ -157,7 +157,8 @@ def _build_step_remix() -> tuple[gr.Column, dict[str, Any]]:
     """Build Step 3: Remix / Create."""
     with gr.Column(visible=False, elem_id="simple-step-3", elem_classes="simple-step") as col:
         gr.HTML(
-            '<div class="simple-upload-label">Upload a song to remix? (optional)</div>'
+            '<div class="simple-upload-label">Upload a song to remix? (optional)</div>',
+            elem_classes=["simple-upload-label-wrap"],
         )
         simple_src_audio = gr.Audio(
             label="Click to upload, or drag a file here",
@@ -165,7 +166,7 @@ def _build_step_remix() -> tuple[gr.Column, dict[str, Any]]:
             sources=["upload"],
             elem_classes=["simple-upload-area"],
         )
-        with gr.Row(elem_classes="simple-nav-row"):
+        with gr.Row(elem_classes=["simple-nav-row", "simple-remix-nav"]):
             simple_step3_back_btn = gr.Button(
                 "  Back",
                 variant="secondary",
@@ -175,7 +176,7 @@ def _build_step_remix() -> tuple[gr.Column, dict[str, Any]]:
             simple_create_btn = gr.Button(
                 "  Create Music",
                 variant="primary",
-                size="lg",
+                size="sm",
                 elem_id="simple-create-btn",
                 elem_classes=["simple-create-btn"],
             )

--- a/acestep/ui/gradio/interfaces/simple_ui.py
+++ b/acestep/ui/gradio/interfaces/simple_ui.py
@@ -1,0 +1,384 @@
+"""5-step simplified UI component builder with SVG icons and hamburger menu."""
+
+from typing import Any
+
+import gradio as gr
+
+_STEP_LABELS = ["Describe Song", "Lyrics", "Remix", "Creating", "Done"]
+
+
+def _step_indicator_html(current: int) -> str:
+    """Generate inline SVG step indicator with connected dots and labels."""
+    total = len(_STEP_LABELS)
+    spacing = 120
+    padding = 40
+    width = padding * 2 + (total - 1) * spacing
+    height = 70
+
+    circles = []
+    lines = []
+    for i in range(total):
+        cx = padding + i * spacing
+        if i < current - 1:
+            circles.append(
+                f'<circle cx="{cx}" cy="28" r="9" fill="#667eea" stroke="none"/>'
+                f'<path d="M{cx - 4} 28l{3} {3}l{6} -{6}" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
+            )
+        elif i == current - 1:
+            circles.append(
+                f'<circle cx="{cx}" cy="28" r="11" fill="#667eea" stroke="white" stroke-width="3" filter="url(#glow)"/>'
+            )
+        else:
+            circles.append(
+                f'<circle cx="{cx}" cy="28" r="9" fill="none" stroke="#d0d0d0" stroke-width="2"/>'
+            )
+        color = "#667eea" if i <= current - 1 else "#999"
+        weight = "600" if i == current - 1 else "400"
+        circles.append(
+            f'<text x="{cx}" y="56" text-anchor="middle" font-size="11" font-weight="{weight}" fill="{color}">{_STEP_LABELS[i]}</text>'
+        )
+
+    for i in range(total - 1):
+        x1 = padding + i * spacing + 9
+        x2 = padding + (i + 1) * spacing - 9
+        stroke = "#667eea" if i < current - 1 else "#e0e0e0"
+        lines.append(f'<line x1="{x1}" y1="28" x2="{x2}" y2="28" stroke="{stroke}" stroke-width="2"/>')
+
+    glow = (
+        '<defs><filter id="glow" x="-50%" y="-50%" width="200%" height="200%">'
+        '<feGaussianBlur stdDeviation="3" result="blur"/>'
+        '<feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>'
+        '</filter></defs>'
+    )
+
+    return f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}" style="display:block;margin:0 auto;max-width:100%">{glow}{"".join(lines)}{"".join(circles)}</svg>'
+
+
+def _build_header() -> str:
+    """Return compact header HTML with hamburger icon."""
+    return f'''
+    <div class="simple-header">
+        <div class="simple-header-content">
+            <div class="simple-header-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="30" height="30">
+                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                </svg>
+            </div>
+            <div class="simple-header-text">
+                <h2>Quick Music Generator</h2>
+                <p>Turn your ideas into music in seconds</p>
+            </div>
+        </div>
+    </div>
+    '''
+
+
+def _about_overlay_html() -> str:
+    """Return the About modal content."""
+    return f'''
+    <div class="simple-about-icon">🎛️</div>
+    <h2>ACE-Step V1.5 Playground 💡</h2>
+    <p class="simple-about-subtitle">Pushing the Boundaries of Open-Source Music Generation</p>
+    <p class="simple-about-desc">
+        Generate high-quality music from text descriptions, remix existing tracks,
+        and explore the future of AI-powered music creation.
+    </p>
+    '''
+
+
+def _build_step_describe() -> tuple[gr.Column, dict[str, Any]]:
+    """Build Step 1: Describe your song."""
+    with gr.Column(visible=True, elem_id="simple-step-1", elem_classes="simple-step") as col:
+        simple_song_style = gr.Textbox(
+            label="What kind of music would you like to create?",
+            placeholder="e.g. A happy pop song with piano and drums",
+            lines=3,
+            elem_classes=["simple-input"],
+        )
+        with gr.Row(elem_classes="simple-nav-row"):
+            simple_random_btn = gr.Button(
+                " Surprise Me",
+                variant="secondary",
+                size="sm",
+                elem_classes=["simple-random-btn"],
+            )
+            simple_step1_continue_btn = gr.Button(
+                "Continue  ",
+                variant="primary",
+                size="sm",
+                elem_classes=["simple-continue-btn"],
+            )
+    return col, {
+        "simple_step_1": col,
+        "simple_song_style": simple_song_style,
+        "simple_random_btn": simple_random_btn,
+        "simple_step1_continue_btn": simple_step1_continue_btn,
+    }
+
+
+def _build_step_lyrics() -> tuple[gr.Column, dict[str, Any]]:
+    """Build Step 2: Lyrics."""
+    with gr.Column(visible=False, elem_id="simple-step-2", elem_classes="simple-step") as col:
+        simple_lyrics = gr.Textbox(
+            label="Add your own lyrics (optional)",
+            placeholder="Enter your lyrics here, or leave blank for AI-generated lyrics",
+            lines=8,
+            elem_classes=["simple-input", "simple-lyrics"],
+        )
+        simple_instrumental = gr.Checkbox(
+            label="Instrumental only",
+            info="Create music without vocals or lyrics",
+            value=False,
+            elem_classes=["simple-instrumental"],
+        )
+        with gr.Row(elem_classes="simple-nav-row"):
+            simple_step2_back_btn = gr.Button(
+                "  Back",
+                variant="secondary",
+                size="sm",
+                elem_classes=["simple-back-btn"],
+            )
+            simple_step2_continue_btn = gr.Button(
+                "Continue  ",
+                variant="primary",
+                size="sm",
+                elem_classes=["simple-continue-btn"],
+            )
+    return col, {
+        "simple_step_2": col,
+        "simple_lyrics": simple_lyrics,
+        "simple_instrumental": simple_instrumental,
+        "simple_step2_back_btn": simple_step2_back_btn,
+        "simple_step2_continue_btn": simple_step2_continue_btn,
+    }
+
+
+def _build_step_remix() -> tuple[gr.Column, dict[str, Any]]:
+    """Build Step 3: Remix / Create."""
+    with gr.Column(visible=False, elem_id="simple-step-3", elem_classes="simple-step") as col:
+        gr.HTML(
+            '<div class="simple-upload-label">Upload a song to remix? (optional)</div>'
+        )
+        simple_src_audio = gr.Audio(
+            label="Click to upload, or drag a file here",
+            type="filepath",
+            sources=["upload"],
+            elem_classes=["simple-upload-area"],
+        )
+        with gr.Row(elem_classes="simple-nav-row"):
+            simple_step3_back_btn = gr.Button(
+                "  Back",
+                variant="secondary",
+                size="sm",
+                elem_classes=["simple-back-btn"],
+            )
+            simple_create_btn = gr.Button(
+                "  Create Music",
+                variant="primary",
+                size="lg",
+                elem_id="simple-create-btn",
+                elem_classes=["simple-create-btn"],
+            )
+    return col, {
+        "simple_step_3": col,
+        "simple_src_audio": simple_src_audio,
+        "simple_step3_back_btn": simple_step3_back_btn,
+        "simple_create_btn": simple_create_btn,
+    }
+
+
+def _build_step_creating() -> tuple[gr.Column, dict[str, Any]]:
+    """Build Step 4: Creating..."""
+    with gr.Column(visible=False, elem_id="simple-step-4", elem_classes="simple-step") as col:
+        gr.HTML(
+            '<div class="simple-creating-icon">'
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#667eea" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="48" height="48">'
+            '<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>'
+            '</svg></div>'
+        )
+        gr.HTML('<div class="simple-creating-title">Creating your music...</div>')
+        gr.HTML(
+            '<div class="simple-progress-track">'
+            '<div class="simple-progress-bar" id="simple-progress-bar"></div>'
+            '</div>'
+        )
+        simple_progress_text = gr.HTML(
+            value='<div class="simple-progress-status">Preparing...</div>',
+            elem_classes=["simple-progress-status"],
+        )
+    return col, {
+        "simple_step_4": col,
+        "simple_progress_text": simple_progress_text,
+    }
+
+
+def _build_step_results() -> tuple[gr.Column, dict[str, Any]]:
+    """Build Step 5: Results."""
+    with gr.Column(visible=False, elem_id="simple-step-5", elem_classes="simple-step") as col:
+        gr.HTML(
+            '<div class="simple-divider">'
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#667eea" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18">'
+            '<path d="M12 3l1.91 5.87L20 9.73l-4.88 4.12 1.38 6.15L12 16.5l-4.5 3.5 1.38-6.15L4 9.73l6.09-.86L12 3z"/>'
+            '</svg>'
+            '<span>Your Music</span>'
+            '</div>',
+            elem_classes=["simple-divider-wrap"],
+        )
+        with gr.Row(elem_classes="simple-results-row"):
+            with gr.Column(scale=1, elem_classes="simple-result-col") as simple_result_col_1:
+                gr.HTML(
+                    '<div class="simple-best-badge">'
+                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="none" width="12" height="12">'
+                    '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>'
+                    '</svg> Best Pick'
+                    '</div>'
+                )
+                simple_generated_audio_1 = gr.Audio(
+                    label="",
+                    type="filepath",
+                    interactive=False,
+                    editable=False,
+                    show_label=False,
+                    container=False,
+                    buttons=[],
+                    elem_classes=["simple-audio"],
+                )
+                with gr.Row(elem_classes="simple-meta-row"):
+                    simple_metadata_1 = gr.HTML(
+                        value="",
+                        elem_classes=["simple-metadata"],
+                    )
+                    simple_save_btn_1 = gr.Button(
+                        "",
+                        size="sm",
+                        elem_classes=["simple-save-btn"],
+                    )
+            with gr.Column(scale=1, elem_classes="simple-result-col") as simple_result_col_2:
+                simple_generated_audio_2 = gr.Audio(
+                    label="",
+                    type="filepath",
+                    interactive=False,
+                    editable=False,
+                    show_label=False,
+                    container=False,
+                    buttons=[],
+                    elem_classes=["simple-audio"],
+                )
+                with gr.Row(elem_classes="simple-meta-row"):
+                    simple_metadata_2 = gr.HTML(
+                        value="",
+                        elem_classes=["simple-metadata"],
+                    )
+                    simple_save_btn_2 = gr.Button(
+                        "",
+                        size="sm",
+                        elem_classes=["simple-save-btn"],
+                    )
+        simple_gen_info = gr.HTML(
+            value="",
+            elem_classes=["simple-gen-info"],
+        )
+        with gr.Row(elem_classes="simple-footer-row"):
+            simple_retry_btn = gr.Button(
+                " Try Different Style",
+                variant="secondary",
+                size="sm",
+                elem_classes=["simple-retry-btn"],
+            )
+            simple_new_btn = gr.Button(
+                " Create New Song",
+                variant="secondary",
+                size="sm",
+                elem_classes=["simple-new-btn"],
+            )
+    return col, {
+        "simple_step_5": col,
+        "simple_generated_audio_1": simple_generated_audio_1,
+        "simple_generated_audio_2": simple_generated_audio_2,
+        "simple_result_col_1": simple_result_col_1,
+        "simple_result_col_2": simple_result_col_2,
+        "simple_metadata_1": simple_metadata_1,
+        "simple_metadata_2": simple_metadata_2,
+        "simple_save_btn_1": simple_save_btn_1,
+        "simple_save_btn_2": simple_save_btn_2,
+        "simple_gen_info": simple_gen_info,
+        "simple_retry_btn": simple_retry_btn,
+        "simple_new_btn": simple_new_btn,
+    }
+
+
+def build_simple_ui() -> dict[str, Any]:
+    """Build the complete stepped-flow simplified UI.
+
+    Returns:
+        A merged component map for all simple-UI controls.
+    """
+    with gr.Column(visible=False, elem_id="simple-ui-column") as simple_column:
+        gr.HTML(_build_header())
+
+        # ── Hamburger toggle button ──
+        simple_hamburger_btn = gr.Button(
+            "Menu",
+            elem_classes=["simple-hamburger-btn"],
+        )
+
+        # ── Dropdown menu (hidden by default) ──
+        with gr.Group(visible=False, elem_classes="simple-hamburger-menu") as simple_hamburger_menu:
+            simple_about_btn = gr.Button(
+                "About",
+                elem_classes=["simple-menu-item", "simple-menu-about"],
+            )
+            simple_help_btn = gr.Button(
+                "Help",
+                elem_classes=["simple-menu-item", "simple-menu-help"],
+            )
+            simple_advanced_btn = gr.Button(
+                "Advanced Mode",
+                elem_classes=["simple-menu-item", "simple-menu-advanced"],
+            )
+
+        # ── About overlay (hidden by default) ──
+        with gr.Group(
+            visible=False,
+            elem_classes=["simple-about-overlay", "simple-about-backdrop"],
+        ) as simple_about_overlay:
+            with gr.Column(elem_classes=["simple-about-modal"]):
+                simple_about_close_btn = gr.Button(
+                    "×", elem_classes=["simple-about-close"], size="sm"
+                )
+                gr.HTML(value=_about_overlay_html())
+
+        simple_step_indicator = gr.HTML(
+            value=_step_indicator_html(1),
+            elem_classes=["simple-step-indicator"],
+        )
+        _, step1 = _build_step_describe()
+        _, step2 = _build_step_lyrics()
+        _, step3 = _build_step_remix()
+        _, step4 = _build_step_creating()
+        _, step5 = _build_step_results()
+        simple_state_current_step = gr.State(value=1)
+        simple_state_song_style = gr.State(value="")
+        simple_state_lyrics = gr.State(value="")
+        simple_state_audio = gr.State(value=None)
+        simple_hamburger_state = gr.State(value=False)
+
+    result: dict[str, Any] = {
+        "simple_column": simple_column,
+        "simple_hamburger_btn": simple_hamburger_btn,
+        "simple_hamburger_menu": simple_hamburger_menu,
+        "simple_hamburger_state": simple_hamburger_state,
+        "simple_about_btn": simple_about_btn,
+        "simple_help_btn": simple_help_btn,
+        "simple_advanced_btn": simple_advanced_btn,
+        "simple_about_overlay": simple_about_overlay,
+        "simple_about_close_btn": simple_about_close_btn,
+        "simple_step_indicator": simple_step_indicator,
+        "simple_state_current_step": simple_state_current_step,
+        "simple_state_song_style": simple_state_song_style,
+        "simple_state_lyrics": simple_state_lyrics,
+        "simple_state_audio": simple_state_audio,
+    }
+    for d in (step1, step2, step3, step4, step5):
+        result.update(d)
+    return result

--- a/acestep/ui/gradio/interfaces/simple_ui.py
+++ b/acestep/ui/gradio/interfaces/simple_ui.py
@@ -255,6 +255,10 @@ def _build_step_results() -> tuple[gr.Column, dict[str, Any]]:
                         elem_classes=["simple-save-btn"],
                     )
             with gr.Column(scale=1, elem_classes="simple-result-col") as simple_result_col_2:
+                gr.HTML(
+                    '<div class="simple-best-badge simple-best-badge-placeholder">'
+                    'Best Pick</div>'
+                )
                 simple_generated_audio_2 = gr.Audio(
                     label="",
                     type="filepath",

--- a/acestep/ui/gradio/interfaces/simple_ui.py
+++ b/acestep/ui/gradio/interfaces/simple_ui.py
@@ -313,7 +313,7 @@ def build_simple_ui() -> dict[str, Any]:
     Returns:
         A merged component map for all simple-UI controls.
     """
-    with gr.Column(visible=False, elem_id="simple-ui-column") as simple_column:
+    with gr.Column(visible=True, elem_id="simple-ui-column") as simple_column:
         gr.HTML(_build_header())
 
         # ── Hamburger toggle button ──


### PR DESCRIPTION
## Summary

- Add a streamlined five-step Simple UI for describing, remixing, generating, and downloading music.
- Make Simple UI the default generation flow while retaining access to advanced controls.
- Gate generation on model readiness and improve the responsive desktop layout.

This gives less-technical users a focused path through music creation without removing the existing advanced workflow.

## Scope

The PR is limited to Simple UI components, event wiring, styling, and focused generation progress integration.

Out of scope:

- Tauri desktop shell and Flatpak packaging
- Model inference algorithms
- Hardware detection or platform-specific execution paths
- Training workflows

## Risk and compatibility

- The primary risk is Gradio component wiring across the five UI steps.
- Existing advanced generation controls remain available through the Simple UI menu.
- CPU, CUDA, ROCm, MPS, XPU, and MLX execution paths are unchanged.
- Public Python interfaces outside the Gradio UI are unchanged.

The initial Simple UI implementation predates the current 200-line module policy. The large CSS, component construction, generation orchestration, and event registration sections should be decomposed by responsibility in focused follow-up work. Splitting them in this behavior PR would substantially increase the review surface and regression risk.

## Regression checks

- `.venv/bin/python -m unittest acestep.ui.gradio.events.wiring.simple_ui_test` — 38 tests passed
- `.venv/bin/python -m unittest acestep.ui.gradio.events.results.generation_progress_repaint_cache_test` — 3 tests passed
- `git diff --check upstream/main...HEAD` — passed

Covered scenarios include navigation, remix behavior, instrumental lyrics handling, model readiness, generation progress, result downloads, responsive layout contracts, and failure fallback.

## Reviewer notes

- Review the PR diff only; the Tauri/Flatpak work is intentionally isolated on a different branch.
- The test suite emits expected mocked generation-error logging while still passing.
- Recommended follow-up decomposition: extract Simple UI CSS, step builders, initialization, generation orchestration, and event registration into focused modules.
