### PR TITLE
fix: use model-aware DCW defaults for non-Turbo inference

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -177,6 +177,20 @@ class GenerateMusicMixin:
             "error": msg,
         }
 
+    def _resolve_dcw_enabled(self, dcw_enabled: Optional[bool]) -> bool:
+        """Resolve an explicit or model-aware DCW setting.
+
+        Args:
+            dcw_enabled: Explicit caller choice, or ``None`` for the model
+                family default.
+
+        Returns:
+            The explicit choice, or the loaded configuration's Turbo setting.
+        """
+        if dcw_enabled is not None:
+            return bool(dcw_enabled)
+        return bool(self.is_turbo_model())
+
     def generate_music(
         self,
         captions: str,
@@ -209,7 +223,7 @@ class GenerateMusicMixin:
         sampler_mode: str = "euler",
         velocity_norm_threshold: float = 0.0,
         velocity_ema_factor: float = 0.0,
-        dcw_enabled: bool = True,
+        dcw_enabled: Optional[bool] = None,
         dcw_mode: str = "double",
         dcw_scaler: float = 0.05,
         dcw_high_scaler: float = 0.02,
@@ -245,8 +259,8 @@ class GenerateMusicMixin:
             guidance_scale: CFG guidance value.
             seed: Optional explicit seed from caller/UI.
             infer_method: Diffusion method name.
-            dcw_enabled: Enable Differential Correction in Wavelet domain
-                (CVPR 2026, arXiv:2604.16044) at each sampler step.  Off by default.
+            dcw_enabled: Enable Differential Correction in Wavelet domain.
+                ``None`` selects the default for the loaded model family.
             dcw_mode: DCW mode — ``"low"`` / ``"high"`` / ``"double"`` / ``"pix"``.
             dcw_scaler: Low-band (or single-band) correction strength; modulated
                 by ``t_curr`` inside the sampler, so the effective strength decays
@@ -292,6 +306,7 @@ class GenerateMusicMixin:
                 guidance_scale,
             )
             guidance_scale = 1.0
+        dcw_enabled = self._resolve_dcw_enabled(dcw_enabled)
 
         # When LoRA is active, verify all decoder parameters are on the
         # expected device and dtype.  CPU-offload round-trips can leave PEFT

--- a/acestep/core/generation/handler/generate_music_dcw_test.py
+++ b/acestep/core/generation/handler/generate_music_dcw_test.py
@@ -1,0 +1,60 @@
+"""Regression tests for model-aware DCW defaults in generation orchestration."""
+
+import unittest
+
+from acestep.core.generation.handler.generate_music_test import _Host
+from acestep.inference import GenerationParams
+
+
+class ModelAwareDcwDefaultTests(unittest.TestCase):
+    """Verify DCW resolves from the loaded model configuration."""
+
+    def test_generation_params_defers_dcw_default(self):
+        """The request object should preserve an unspecified DCW value."""
+        self.assertIsNone(GenerationParams().dcw_enabled)
+
+    def test_non_turbo_50_step_inference_disables_dcw_by_default(self):
+        """A non-Turbo 50-step request should not enable DCW implicitly."""
+        host = _Host(is_turbo=False)
+        host.generate_music(
+            captions="cap",
+            lyrics="lyr",
+            inference_steps=50,
+            use_random_seed=False,
+            seed=77,
+        )
+
+        forwarded = host.calls["_run_generate_music_service_with_progress"]
+        self.assertEqual(forwarded["inference_steps"], 50)
+        self.assertFalse(forwarded["dcw_enabled"])
+
+    def test_turbo_keeps_dcw_enabled_by_default(self):
+        """Turbo's established default should remain enabled."""
+        host = _Host(is_turbo=True)
+        host.generate_music(
+            captions="cap",
+            lyrics="lyr",
+            inference_steps=8,
+            use_random_seed=False,
+            seed=77,
+        )
+
+        self.assertTrue(host.calls["_run_generate_music_service_with_progress"]["dcw_enabled"])
+
+    def test_explicit_non_turbo_dcw_opt_in_is_preserved(self):
+        """An explicit non-Turbo DCW choice should override the default."""
+        host = _Host(is_turbo=False)
+        host.generate_music(
+            captions="cap",
+            lyrics="lyr",
+            inference_steps=50,
+            dcw_enabled=True,
+            use_random_seed=False,
+            seed=77,
+        )
+
+        self.assertTrue(host.calls["_run_generate_music_service_with_progress"]["dcw_enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/core/generation/handler/service_generate.py
+++ b/acestep/core/generation/handler/service_generate.py
@@ -51,7 +51,7 @@ class ServiceGenerateMixin:
         sampler_mode: str = "euler",
         velocity_norm_threshold: float = 0.0,
         velocity_ema_factor: float = 0.0,
-        dcw_enabled: bool = True,
+        dcw_enabled: Optional[bool] = None,
         dcw_mode: str = "double",
         dcw_scaler: float = 0.05,
         dcw_high_scaler: float = 0.02,
@@ -74,6 +74,8 @@ class ServiceGenerateMixin:
         conditioning; ``cfg_interval_*`` / ``sampler_mode`` /
         ``velocity_*`` / ``dcw_*`` are sampler tweaks; ``flow_edit_morph``
         layers the V_delta overlay on top of cover/cover-nofsq dispatch.
+        ``dcw_enabled=None`` defers to the loaded model family, while an
+        explicit boolean overrides that default.
 
         Returns:
             Dict[str, Any]: Service output payload containing generated latents,

--- a/acestep/core/generation/handler/service_generate_execute.py
+++ b/acestep/core/generation/handler/service_generate_execute.py
@@ -61,6 +61,14 @@ class ServiceGenerateExecuteMixin:
             return seed_list
         return random.randint(0, 2**32 - 1)
 
+    def _resolve_service_dcw_enabled(self, generate_kwargs: Dict[str, Any]) -> bool:
+        """Return an explicit or loaded-model DCW value for backend execution."""
+        dcw_enabled = generate_kwargs.get("dcw_enabled")
+        if dcw_enabled is not None:
+            return bool(dcw_enabled)
+        config = getattr(self, "config", None)
+        return bool(getattr(config, "is_turbo", False))
+
     def _build_service_generate_kwargs(
         self,
         payload: Dict[str, Any],
@@ -80,7 +88,7 @@ class ServiceGenerateExecuteMixin:
         sampler_mode: str = "euler",
         velocity_norm_threshold: float = 0.0,
         velocity_ema_factor: float = 0.0,
-        dcw_enabled: bool = True,
+        dcw_enabled: Optional[bool] = None,
         dcw_mode: str = "double",
         dcw_scaler: float = 0.05,
         dcw_high_scaler: float = 0.02,
@@ -148,6 +156,10 @@ class ServiceGenerateExecuteMixin:
         flow_edit_ctx: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor]:
         """Execute condition preparation and diffusion using MLX or PyTorch backend."""
+        generate_kwargs = {
+            **generate_kwargs,
+            "dcw_enabled": self._resolve_service_dcw_enabled(generate_kwargs),
+        }
         if flow_edit_ctx is not None and flow_edit_ctx.get("morph"):
             from .service_generate_flow_edit import dispatch_flow_edit_overlay
 
@@ -183,7 +195,8 @@ class ServiceGenerateExecuteMixin:
                 )
 
                 if self.use_mlx_dit and self.mlx_decoder is not None:
-                    if generate_kwargs.get("dcw_enabled") and generate_kwargs.get("dcw_wavelet", "haar") != "haar":
+                    dcw_enabled = generate_kwargs["dcw_enabled"]
+                    if dcw_enabled and generate_kwargs.get("dcw_wavelet", "haar") != "haar":
                         logger.info(
                             "[service_generate] DCW enabled on MLX path with "
                             "wavelet='{}'; non-Haar wavelets use the PyTorch "
@@ -238,7 +251,7 @@ class ServiceGenerateExecuteMixin:
                             sampler_mode=generate_kwargs.get("sampler_mode", "euler"),
                             velocity_norm_threshold=generate_kwargs.get("velocity_norm_threshold", 0.0),
                             velocity_ema_factor=generate_kwargs.get("velocity_ema_factor", 0.0),
-                            dcw_enabled=generate_kwargs.get("dcw_enabled", True),
+                            dcw_enabled=dcw_enabled,
                             dcw_mode=generate_kwargs.get("dcw_mode", "double"),
                             dcw_scaler=generate_kwargs.get("dcw_scaler", 0.05),
                             dcw_high_scaler=generate_kwargs.get("dcw_high_scaler", 0.02),

--- a/acestep/core/generation/handler/service_generate_execute_test.py
+++ b/acestep/core/generation/handler/service_generate_execute_test.py
@@ -1,7 +1,9 @@
 """Unit tests for service-generation execution helper mixin."""
 
 import unittest
-from unittest.mock import patch
+from contextlib import nullcontext
+import types
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -58,6 +60,7 @@ class ServiceGenerateExecuteMixinTests(unittest.TestCase):
         self.assertEqual(kwargs["infer_steps"], 16)
         self.assertEqual(kwargs["timesteps"].dtype, torch.float32)
         self.assertEqual(kwargs["timesteps"].device.type, "cpu")
+        self.assertIsNone(kwargs["dcw_enabled"])
 
     def test_attach_service_outputs_persists_required_fields(self):
         """Attached payload fields should be available to downstream handlers."""
@@ -90,6 +93,56 @@ class ServiceGenerateExecuteMixinTests(unittest.TestCase):
         with patch("acestep.core.generation.handler.service_generate_execute.random.randint", return_value=42):
             seed_param = host._resolve_service_seed_param(None)
         self.assertEqual(seed_param, 42)
+
+    def test_service_dcw_resolution_preserves_defaults_and_overrides(self):
+        """Service execution should defer defaulting until config is available."""
+        host = _Host()
+        host.config = types.SimpleNamespace(is_turbo=False)
+        self.assertFalse(host._resolve_service_dcw_enabled({}))
+        self.assertTrue(host._resolve_service_dcw_enabled({"dcw_enabled": True}))
+
+        host.config = types.SimpleNamespace(is_turbo=True)
+        self.assertTrue(host._resolve_service_dcw_enabled({}))
+        self.assertFalse(host._resolve_service_dcw_enabled({"dcw_enabled": False}))
+
+    def test_service_execution_resolves_dcw_for_pytorch_fallback(self):
+        """MLX fallback should use the same non-Turbo DCW value as PyTorch."""
+        host = _Host()
+        host.config = types.SimpleNamespace(is_turbo=False)
+        host.use_mlx_dit = True
+        host.mlx_decoder = object()
+        host.model = MagicMock()
+        condition = torch.zeros(1, 4, 4)
+        host.model.prepare_condition.return_value = (condition, condition, condition)
+        host.model.generate_audio.return_value = {"target_latents": condition}
+        host._load_model_context = lambda _name: nullcontext()
+        host._mlx_run_diffusion = MagicMock(side_effect=RuntimeError("MLX failed"))
+        payload = {
+            "text_hidden_states": condition,
+            "text_attention_mask": condition,
+            "lyric_hidden_states": condition,
+            "lyric_attention_mask": condition,
+            "refer_audio_acoustic_hidden_states_packed": condition,
+            "refer_audio_order_mask": torch.zeros(1, dtype=torch.long),
+            "src_latents": condition,
+            "chunk_mask": torch.ones(1, 4, dtype=torch.bool),
+            "is_covers": torch.tensor([False]),
+            "precomputed_lm_hints_25Hz": None,
+            "non_cover_text_hidden_states": None,
+            "non_cover_text_attention_masks": None,
+        }
+
+        host._execute_service_generate_diffusion(
+            payload=payload,
+            generate_kwargs={},
+            seed_param=1234,
+            infer_method="ode",
+            shift=1.0,
+            audio_cover_strength=1.0,
+        )
+
+        self.assertFalse(host._mlx_run_diffusion.call_args.kwargs["dcw_enabled"])
+        self.assertFalse(host.model.generate_audio.call_args.kwargs["dcw_enabled"])
 
 
 if __name__ == "__main__":

--- a/acestep/core/generation/handler/service_generate_test.py
+++ b/acestep/core/generation/handler/service_generate_test.py
@@ -139,6 +139,7 @@ class ServiceGenerateMixinTests(unittest.TestCase):
         self.assertEqual(build_kwargs["cover_noise_strength"], 0.2)
         self.assertTrue(build_kwargs["use_adg"])
         self.assertEqual(build_kwargs["timesteps"], custom_timesteps)
+        self.assertIsNone(build_kwargs["dcw_enabled"])
         self.assertFalse(host.calls["_attach_service_generate_outputs"]["return_intermediate"])
         execute_kwargs = host.calls["_execute_service_generate_diffusion"]
         self.assertEqual(execute_kwargs["infer_method"], "sde")

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -143,9 +143,9 @@ class GenerationParams:
     velocity_norm_threshold: float = 0.0  # Clamp velocity prediction norms (0 = disabled, try 2.0)
     velocity_ema_factor: float = 0.0  # Velocity EMA smoothing (0 = disabled, try 0.1)
     # DCW — Differential Correction in Wavelet domain (CVPR 2026, arXiv:2604.16044).
-    # On by default to mitigate SNR-t bias via per-band wavelet-domain correction
-    # at each sampler step.  Uses `pytorch_wavelets` + `PyWavelets` (managed deps).
-    dcw_enabled: bool = True
+    # Resolved after the loaded model configuration is available: enabled for
+    # Turbo and disabled for non-Turbo models unless explicitly overridden.
+    dcw_enabled: Optional[bool] = None
     # Defaults tuned by grid search on the pure-DiT path; "double" with
     # low_scaler=0.05 and high_scaler=0.02 was the top configuration.  In
     # LLM-think mode DCW's gain is small and these defaults still sit near

--- a/acestep/models/mlx/dit_generate_sampler_test.py
+++ b/acestep/models/mlx/dit_generate_sampler_test.py
@@ -88,6 +88,28 @@ class EulerSamplerTests(unittest.TestCase):
         self.assertIn("target_latents", result)
         self.assertFalse(np.any(np.isnan(result["target_latents"])))
 
+    def test_50_step_non_turbo_schedule_is_repeatable_without_dcw(self):
+        """The non-Turbo 50-step MLX path should remain deterministic with DCW off."""
+        kwargs = {
+            "encoder_hidden_states_np": np.zeros((1, 2, 4), dtype=np.float32),
+            "context_latents_np": np.zeros((1, 4, 4), dtype=np.float32),
+            "src_latents_shape": (1, 4, 4),
+            "seed": 1259,
+            "infer_steps": 50,
+            "shift": 1.0,
+            "dcw_enabled": False,
+            "disable_tqdm": True,
+        }
+        first_decoder = _make_fake_decoder()
+        second_decoder = _make_fake_decoder()
+
+        first = mlx_generate_diffusion(mlx_decoder=first_decoder, **kwargs)
+        second = mlx_generate_diffusion(mlx_decoder=second_decoder, **kwargs)
+
+        self.assertEqual(first_decoder.call_count, 50)
+        self.assertEqual(second_decoder.call_count, 50)
+        np.testing.assert_array_equal(first["target_latents"], second["target_latents"])
+
 
 class HeunSamplerTests(unittest.TestCase):
     """Verify Heun (second-order) sampler produces valid output."""

--- a/docs/en/DCW.md
+++ b/docs/en/DCW.md
@@ -78,7 +78,7 @@ are forwarded through the generation handler chain into the base model's
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `dcw_enabled` | `bool` | `True` | Master switch. Set to `False` for a clean A/B against the uncorrected sampler. |
+| `dcw_enabled` | `Optional[bool]` | `None` | Enabled by default for Turbo and disabled by default for non-Turbo after the model is loaded. |
 | `dcw_mode` | `str` | `"double"` | One of `"low"`, `"high"`, `"double"`, `"pix"`. |
 | `dcw_scaler` | `float` | `0.05` | Low-band correction strength (or the single scaler for `"high"` / `"pix"`). Usable range `0–0.1`. |
 | `dcw_high_scaler` | `float` | `0.02` | High-band correction strength (used only when `dcw_mode == "double"`). Usable range `0–0.1`. |
@@ -139,22 +139,22 @@ result = generate_music(
 
 Open the standard Gradio UI, expand **Advanced DiT** → **🧪 DCW – Differential
 Correction in Wavelet domain (experimental)**, and tune the four
-sliders/dropdowns inside. **Enable DCW** is on by default with
-`mode="double"` and `wavelet="haar"` — uncheck it to A/B against the
-uncorrected sampler.  The default strengths follow the current Think state:
+sliders/dropdowns inside. **Enable DCW** defaults on for Turbo and off for
+non-Turbo models; set it explicitly to A/B against the uncorrected sampler.
+The default strengths follow the current Think state:
 non-Think uses `scaler=0.05`, `high_scaler=0.02`, while Think uses
 `scaler=0.02`, `high_scaler=0.06`.
 
 ## Recommended starting values
 
-The defaults come from a grid search on the pure-DiT path (no LLM
+The opt-in parameter values come from a grid search on the pure-DiT path (no LLM
 think-CoT): `dcw_mode="double"`, `dcw_scaler=0.05`,
 `dcw_high_scaler=0.02`, `dcw_wavelet="haar"`.  In LLM-think mode the
 overall DCW gain is small and the optimum band drifts slightly, so Gradio
 switches to `dcw_scaler=0.02` and `dcw_high_scaler=0.06` when Think is
 enabled.  Direct Python callers can override these values on
-`GenerationParams`; the HTTP generation routes currently use the
-`GenerationParams` defaults and do not expose per-request `dcw_*` fields.
+`GenerationParams`; HTTP generation routes use the same model-aware default and
+do not expose per-request `dcw_*` fields.
 
 - `"low"` alone (`dcw_scaler=0.02`) is a safer, more conservative
   setting if `"double"` sounds too aggressive for a given track.


### PR DESCRIPTION
## Summary

Fix non-Turbo Base/SFT inference producing distorted or noisy output when DCW is unspecified.

This is the root-layer part of the fix for #1259 and #1288:

- preserve an unspecified `dcw_enabled` value as `None`;
- resolve it only after the loaded model configuration is available;
- default to enabled for Turbo and disabled for non-Turbo;
- preserve explicit `True` and `False` choices.

Fixes #1259.

## Scope

The change is intentionally limited to DCW default resolution and its propagation through the core generation entry points:

- `GenerationParams` defers its default;
- `generate_music` resolves from the loaded handler's model configuration;
- direct `service_generate` callers resolve at the service execution boundary;
- PyTorch, MLX, and MLX-to-PyTorch fallback use the same resolved boolean.

No scheduler, sampler math, checkpoint, kernel, device-selection, UI, CLI, REST API, seed, logging, or tracing behavior is changed.

## Compatibility

| Request/model | Effective DCW value |
| --- | --- |
| Explicit `True` | enabled |
| Explicit `False` | disabled |
| Unspecified Turbo | enabled |
| Unspecified Base/SFT | disabled |

This preserves Turbo compatibility while preventing experimental DCW correction from accumulating over the 32–50 step non-Turbo schedules.

## Regression checks

```
uv run python -m unittest \
  acestep.core.generation.handler.generate_music_test \
  acestep.core.generation.handler.generate_music_dcw_test \
  acestep.core.generation.handler.service_generate_test \
  acestep.core.generation.handler.service_generate_execute_test \
  acestep.models.mlx.dit_generate_sampler_test
```

- 39 focused tests pass.
- Coverage includes a deterministic 50-step MLX non-Turbo schedule, root-level Turbo/non-Turbo defaults, explicit override preservation, and MLX-to-PyTorch fallback propagation.
- `git diff --check` and a non-writing Python syntax parse pass.
- The prior Apple Silicon manual matrix remains successful for XL Turbo (8 steps), Base (8/32), XL Base (32), SFT (50), and XL SFT (50, including the earlier 284-second case).

## Coordination with #1282

#1282 provides useful CLI/REST API forwarding for explicit `dcw_*` controls. This PR deliberately owns the single model-aware default decision after `config.is_turbo` is available.

To avoid two independent default implementations, #1282 should retain explicit parameter plumbing but leave an omitted `dcw_enabled` as `None`, allowing this root-level resolver to determine the default. Its model-name heuristic should not become a second source of truth.

## Follow-up

The earlier deterministic diffusion tracing implementation has been removed from this PR in response to the scope and memory-copy review concern. It will be proposed separately with a dedicated design for bounded/low-copy tensor observation and its own review.