### PR TITLE
fix(api): make api_server importable without gradio installed

### DIFF
--- a/acestep/api_server.py
+++ b/acestep/api_server.py
@@ -95,7 +95,9 @@ from acestep.inference import (
     create_sample,
     format_sample,
 )
-from acestep.ui.gradio.events.results_handlers import _build_generation_info
+# Import from the defining module (not the results_handlers facade) so the API
+# server stays importable without gradio installed.
+from acestep.ui.gradio.events.results.generation_info import _build_generation_info
 
 def _get_project_root() -> str:
     current_file = os.path.abspath(__file__)

--- a/acestep/ui/gradio/__init__.py
+++ b/acestep/ui/gradio/__init__.py
@@ -5,6 +5,8 @@ submodules that do not need gradio itself (e.g. the headless helpers used by
 ``acestep.api_server``) does not require the gradio package to be installed.
 """
 
+__all__ = ["create_gradio_interface"]
+
 
 def __getattr__(name):
     if name == "create_gradio_interface":
@@ -12,3 +14,7 @@ def __getattr__(name):
 
         return create_gradio_interface
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals()) + __all__)

--- a/acestep/ui/gradio/__init__.py
+++ b/acestep/ui/gradio/__init__.py
@@ -1,2 +1,14 @@
-"""Gradio package: web UI composition for ACE-Step controls and outputs."""
-from acestep.ui.gradio.interfaces import create_gradio_interface  # noqa: F401
+"""Gradio package: web UI composition for ACE-Step controls and outputs.
+
+``create_gradio_interface`` is exposed lazily (PEP 562) so that importing
+submodules that do not need gradio itself (e.g. the headless helpers used by
+``acestep.api_server``) does not require the gradio package to be installed.
+"""
+
+
+def __getattr__(name):
+    if name == "create_gradio_interface":
+        from acestep.ui.gradio.interfaces import create_gradio_interface
+
+        return create_gradio_interface
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/acestep/ui/gradio/events/__init__.py
+++ b/acestep/ui/gradio/events/__init__.py
@@ -97,7 +97,17 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
 
 
 def setup_training_event_handlers(demo, dit_handler, llm_handler, training_section):
-    """Setup event handlers for the training tab (dataset builder and LoRA training)"""
+    """Setup event handlers for the training tab (dataset builder and LoRA training).
+
+    Args:
+        demo (Any): Root Gradio demo/container used to register events.
+        dit_handler (Any): Inference service used by preprocess/training callbacks.
+        llm_handler (Any): LLM service used by dataset-builder callbacks.
+        training_section (dict[str, Any]): Training UI component map.
+
+    Returns:
+        None: Registers event handlers in-place on the supplied components.
+    """
     from .wiring import (
         TrainingWiringContext,
         register_training_dataset_builder_handlers,

--- a/acestep/ui/gradio/events/__init__.py
+++ b/acestep/ui/gradio/events/__init__.py
@@ -1,26 +1,13 @@
 """
 Gradio UI Event Handlers Module
 Main entry point for setting up all event handlers
+
+The ``.wiring`` handler modules import gradio at module level, so they are
+imported inside the setup functions (only called from the Gradio UI) rather
+than at package level. This keeps ``acestep.ui.gradio.events.*`` submodules
+importable in headless contexts (e.g. ``acestep.api_server``) without gradio
+installed.
 """
-# Import handler modules
-from .wiring import (
-    GenerationWiringContext,
-    TrainingWiringContext,
-    build_mode_ui_outputs,
-    register_generation_batch_navigation_handlers,
-    register_generation_metadata_file_handlers,
-    register_generation_metadata_handlers,
-    register_generation_mode_handlers,
-    register_generation_run_handlers,
-    register_results_aux_handlers,
-    register_results_restore_and_lrc_handlers,
-    register_results_save_button_handlers,
-    register_generation_service_handlers,
-    register_training_dataset_builder_handlers,
-    register_training_dataset_load_handler,
-    register_training_preprocess_handler,
-    register_training_run_handlers,
-)
 
 
 def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, dataset_section, generation_section, results_section):
@@ -53,6 +40,20 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
     Returns:
         None: Registers event handlers in-place on the supplied components.
     """
+    from .wiring import (
+        GenerationWiringContext,
+        build_mode_ui_outputs,
+        register_generation_batch_navigation_handlers,
+        register_generation_metadata_file_handlers,
+        register_generation_metadata_handlers,
+        register_generation_mode_handlers,
+        register_generation_run_handlers,
+        register_results_aux_handlers,
+        register_results_restore_and_lrc_handlers,
+        register_results_save_button_handlers,
+        register_generation_service_handlers,
+    )
+
     wiring_context = GenerationWiringContext(
         demo=demo,
         dit_handler=dit_handler,
@@ -97,6 +98,14 @@ def setup_event_handlers(demo, dit_handler, llm_handler, dataset_handler, datase
 
 def setup_training_event_handlers(demo, dit_handler, llm_handler, training_section):
     """Setup event handlers for the training tab (dataset builder and LoRA training)"""
+    from .wiring import (
+        TrainingWiringContext,
+        register_training_dataset_builder_handlers,
+        register_training_dataset_load_handler,
+        register_training_preprocess_handler,
+        register_training_run_handlers,
+    )
+
     training_context = TrainingWiringContext(
         demo=demo,
         dit_handler=dit_handler,


### PR DESCRIPTION
## Summary

`acestep.api_server` only needs one helper from the UI layer (`_build_generation_info`), but importing it via `acestep.ui.gradio.events.results_handlers` drags in the entire gradio UI package at import time — so the API server cannot start in environments where gradio is not installed (headless / API-only deployments that consume ACE-Step purely through REST).

Three changes keep the API path headless while leaving Gradio UI behavior unchanged when gradio is installed:

- **`acestep/ui/gradio/__init__.py`** — expose `create_gradio_interface` lazily (PEP 562 `__getattr__`) instead of importing the interfaces package eagerly
- **`acestep/ui/gradio/events/__init__.py`** — move the `.wiring` import (whose handler modules import gradio at module level) inside the two setup functions, which only run under the Gradio UI
- **`acestep/api_server.py`** — import `_build_generation_info` from its defining module (`events/results/generation_info.py`, already headless-safe with its own lazy gradio fallback) instead of the `results_handlers` facade

## Testing

- `import acestep.api_server` succeeds with gradio imports blocked (simulating an environment without gradio)
- `from acestep.ui.gradio import create_gradio_interface` and `from acestep.ui.gradio.events import setup_event_handlers, setup_training_event_handlers` still work with gradio installed
- `results_handlers_facade_test.py` and `i18n_thread_safety_test.py` pass

Related: #1275 declares `python-multipart` directly — headless installs need it since it currently only arrives via gradio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless and API usage when Gradio is not installed.
  * Prevented unnecessary UI-related loading during standard application imports.
  * Preserved existing generation result handling and event registration behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->