### PR TITLE
feat(text_tasks): add MiniMax to external LM provider registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ ACESTEP_INIT_LLM=auto
 # API key for authentication (optional)
 # ACESTEP_API_KEY=sk-your-secret-key
 
+# MiniMax external LM settings (optional)
+# Shared by the OpenAI Chat and Anthropic Messages provider options.
+# ACESTEP_MINIMAX_API_KEY=your-minimax-api-key
+# Global base URLs (default). Use the Mainland China hosts when required:
+#   OpenAI Chat:        https://api.minimaxi.com/v1/chat/completions
+#   Anthropic Messages: https://api.minimaxi.com/anthropic/v1/messages
+# ACESTEP_EXTERNAL_BASE_URL=https://api.minimax.io/v1/chat/completions
+
 # ==================== Gradio UI Settings ====================
 # Server port (default: 7860)
 # PORT=7860

--- a/acestep/text_tasks/external_ai_request_helpers.py
+++ b/acestep/text_tasks/external_ai_request_helpers.py
@@ -134,7 +134,7 @@ def build_request_for_protocol(
         "max_tokens": max_tokens or int(os.getenv("ACESTEP_OPENAI_MAX_TOKENS", "3072")),
         "temperature": 0.4,
     }
-    if require_json_output and provider in {"openai", "zai"}:
+    if require_json_output and provider in {"minimax", "openai", "zai"}:
         payload["response_format"] = {"type": "json_object"}
         payload["stop"] = ["```"]
     if disable_thinking and provider == "zai":

--- a/acestep/text_tasks/external_ai_request_helpers_test.py
+++ b/acestep/text_tasks/external_ai_request_helpers_test.py
@@ -127,6 +127,24 @@ class ExternalAIRequestHelpersTests(unittest.TestCase):
         self.assertEqual(payload["stop"], ["```"])
         self.assertNotIn("thinking", payload)
 
+    def test_build_request_for_protocol_requests_json_output_for_minimax_format(self) -> None:
+        """MiniMax format-mode requests should use OpenAI-compatible JSON output flags."""
+
+        payload, _headers = build_request_for_protocol(
+            protocol="openai_chat",
+            provider="minimax",
+            api_key="test-key",
+            model="MiniMax-M3",
+            messages=[{"role": "system", "content": "s"}, {"role": "user", "content": "u"}],
+            base_url="https://api.minimax.io/v1/chat/completions",
+            max_tokens=768,
+            require_json_output=True,
+        )
+
+        self.assertEqual(payload["response_format"], {"type": "json_object"})
+        self.assertEqual(payload["stop"], ["```"])
+        self.assertNotIn("thinking", payload)
+
     def test_build_request_for_protocol_disables_zai_thinking_and_requests_json(self) -> None:
         """Z.ai format calls should disable thinking and request JSON output."""
 

--- a/acestep/text_tasks/external_lm_providers.py
+++ b/acestep/text_tasks/external_lm_providers.py
@@ -53,6 +53,36 @@ _EXTERNAL_PROVIDER_PROFILES: dict[str, ExternalProviderProfile] = {
             ("OpenAI chat completions", "https://api.openai.com/v1/chat/completions"),
         ),
     ),
+    "minimax": ExternalProviderProfile(
+        provider_id="minimax",
+        label="MiniMax",
+        protocol="openai_chat",
+        default_model="MiniMax-M3",
+        default_base_url="https://api.minimax.io/v1/chat/completions",
+        api_key_env="ACESTEP_MINIMAX_API_KEY",
+        api_key_required=True,
+        secret_path_env="ACESTEP_MINIMAX_SECRET_PATH",
+        secret_file_name="minimax_api_key.enc",
+        base_url_presets=(
+            ("Global chat completions", "https://api.minimax.io/v1/chat/completions"),
+            ("Mainland China chat completions", "https://api.minimaxi.com/v1/chat/completions"),
+        ),
+    ),
+    "minimax_anthropic": ExternalProviderProfile(
+        provider_id="minimax_anthropic",
+        label="MiniMax (Anthropic API)",
+        protocol="anthropic_messages",
+        default_model="MiniMax-M3",
+        default_base_url="https://api.minimax.io/anthropic/v1/messages",
+        api_key_env="ACESTEP_MINIMAX_API_KEY",
+        api_key_required=True,
+        secret_path_env="ACESTEP_MINIMAX_SECRET_PATH",
+        secret_file_name="minimax_api_key.enc",
+        base_url_presets=(
+            ("Global Anthropic messages", "https://api.minimax.io/anthropic/v1/messages"),
+            ("Mainland China Anthropic messages", "https://api.minimaxi.com/anthropic/v1/messages"),
+        ),
+    ),
     "claude": ExternalProviderProfile(
         provider_id="claude",
         label="Anthropic Claude",
@@ -101,7 +131,7 @@ def get_external_provider_profile(provider: str | None) -> ExternalProviderProfi
 def get_external_provider_choices() -> list[tuple[str, str]]:
     """Return provider dropdown choices as ``(label, value)`` pairs."""
 
-    order = ("zai", "openai", "claude", "ollama")
+    order = ("zai", "openai", "minimax", "minimax_anthropic", "claude", "ollama")
     return [
         (_EXTERNAL_PROVIDER_PROFILES[provider_id].label, provider_id)
         for provider_id in order

--- a/acestep/text_tasks/external_lm_providers_test.py
+++ b/acestep/text_tasks/external_lm_providers_test.py
@@ -6,8 +6,10 @@ import unittest
 
 from acestep.text_tasks.external_lm_providers import (
     CUSTOM_BASE_URL_PRESET,
+    build_external_model_choice,
     get_external_base_url_preset_choices,
     get_external_base_url_preset_value,
+    get_external_provider_choices,
     get_external_provider_profile,
 )
 
@@ -15,11 +17,67 @@ from acestep.text_tasks.external_lm_providers import (
 class ExternalLmProvidersTests(unittest.TestCase):
     """Verify provider lookup and base-URL preset helpers stay explicit."""
 
+    def test_get_external_provider_profile_returns_minimax_defaults(self) -> None:
+        """MiniMax should expose OpenAI-compatible chat defaults."""
+
+        profile = get_external_provider_profile("minimax")
+
+        self.assertEqual(profile.protocol, "openai_chat")
+        self.assertEqual(profile.default_model, "MiniMax-M3")
+        self.assertEqual(
+            profile.default_base_url,
+            "https://api.minimax.io/v1/chat/completions",
+        )
+        self.assertEqual(profile.api_key_env, "ACESTEP_MINIMAX_API_KEY")
+
+    def test_get_external_provider_profile_returns_minimax_anthropic_defaults(self) -> None:
+        """MiniMax also exposes an Anthropic Messages provider option."""
+
+        profile = get_external_provider_profile("minimax_anthropic")
+
+        self.assertEqual(profile.protocol, "anthropic_messages")
+        self.assertEqual(profile.default_model, "MiniMax-M3")
+        self.assertEqual(
+            profile.default_base_url,
+            "https://api.minimax.io/anthropic/v1/messages",
+        )
+        self.assertEqual(profile.api_key_env, "ACESTEP_MINIMAX_API_KEY")
+
+    def test_minimax_base_url_presets_cover_global_and_china(self) -> None:
+        """MiniMax presets should offer both the global and Mainland China hosts."""
+
+        openai_presets = dict(get_external_base_url_preset_choices("minimax"))
+        anthropic_presets = dict(get_external_base_url_preset_choices("minimax_anthropic"))
+
+        self.assertIn("https://api.minimax.io/v1/chat/completions", openai_presets.values())
+        self.assertIn("https://api.minimaxi.com/v1/chat/completions", openai_presets.values())
+        self.assertIn(
+            "https://api.minimax.io/anthropic/v1/messages", anthropic_presets.values()
+        )
+        self.assertIn(
+            "https://api.minimaxi.com/anthropic/v1/messages", anthropic_presets.values()
+        )
+
     def test_get_external_provider_profile_rejects_unknown_provider(self) -> None:
         """Unknown providers should fail fast instead of silently defaulting."""
 
         with self.assertRaises(ValueError):
             get_external_provider_profile("mystery")
+
+    def test_get_external_provider_choices_includes_minimax(self) -> None:
+        """Provider choices should expose both MiniMax options to the picker."""
+
+        choices = get_external_provider_choices()
+
+        self.assertIn(("MiniMax", "minimax"), choices)
+        self.assertIn(("MiniMax (Anthropic API)", "minimax_anthropic"), choices)
+
+    def test_build_external_model_choice_defaults_minimax_model(self) -> None:
+        """Missing MiniMax model names should fall back to the provider default."""
+
+        choice = build_external_model_choice("minimax", "")
+
+        self.assertEqual(choice, "external:minimax:MiniMax-M3")
 
     def test_base_url_preset_helpers_use_shared_custom_token(self) -> None:
         """Custom base-URL selection should use the centralized custom token."""


### PR DESCRIPTION
Reason: The external LM provider registry did not include MiniMax, so users could not select it for captioning, lyrics, or planning tasks.

## What changed

Adds MiniMax to the external LM provider registry (`acestep/text_tasks/external_lm_providers.py`), following the existing provider-profile pattern:

- **MiniMax** (`minimax`) — OpenAI Chat protocol, default model `MiniMax-M3`, default endpoint `https://api.minimax.io/v1/chat/completions`.
- **MiniMax (Anthropic API)** (`minimax_anthropic`) — Anthropic Messages protocol, default model `MiniMax-M3`, default endpoint `https://api.minimax.io/anthropic/v1/messages`.

Both options are exposed in the provider picker via `get_external_provider_choices()` and share the `ACESTEP_MINIMAX_API_KEY` credential. Each profile ships base-URL presets for both the global (`api.minimax.io`) and Mainland China (`api.minimaxi.com`) hosts, so users can switch regions from the picker.

The OpenAI-compatible MiniMax option is added to the JSON-output allowlist in `build_request_for_protocol` so format-mode planning requests receive `response_format: {"type": "json_object"}`, matching the other OpenAI-compatible providers.

`.env.example` documents the new `ACESTEP_MINIMAX_API_KEY` variable and the regional base URLs.

## Tests

New unit tests cover the two provider profiles, the regional base-URL presets, picker exposure, the model-choice default, and the OpenAI-compatible JSON-output request path.

## Checks

- `ruff check` on the changed source and test files — passed.
- `python -m unittest acestep.text_tasks.external_lm_providers_test acestep.text_tasks.external_ai_request_helpers_test acestep.text_tasks.external_lm_runtime_store_test acestep.text_tasks.external_lm_model_discovery_test` — 29 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as an external language model provider, including OpenAI-compatible and Anthropic-compatible options.
  * Added support for selecting MiniMax models and regional API endpoints.
  * Added configuration guidance for MiniMax API authentication and custom base URLs.
* **Bug Fixes**
  * Enabled structured JSON responses when using MiniMax through compatible chat integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->