### PR TITLE
fix: make same-seed generations reproducible (LM sampling + reference-audio cropping)

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -331,6 +331,7 @@ class GenerateMusicMixin:
                 actual_batch_size=actual_batch_size,
                 task_type=task_type,
                 flow_edit_morph=flow_edit_morph,
+                seed=actual_seed_list[0] if actual_seed_list else None,
             )
             if audio_error is not None:
                 return audio_error

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -106,11 +106,12 @@ class GenerateMusicRequestMixin:
         actual_batch_size: int,
         task_type: str,
         flow_edit_morph: bool = False,
+        seed: Optional[int] = None,
     ) -> Tuple[Optional[List[List[torch.Tensor]]], Optional[torch.Tensor], Optional[Dict[str, Any]]]:
         """Prepare reference/source audio tensors and return early error payload when invalid."""
         if reference_audio is not None:
             logger.info("[generate_music] Processing reference audio...")
-            processed_ref_audio = self.process_reference_audio(reference_audio)
+            processed_ref_audio = self.process_reference_audio(reference_audio, seed=seed)
             if processed_ref_audio is None:
                 return None, None, {
                     "audios": [],

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -108,7 +108,11 @@ class GenerateMusicRequestMixin:
         flow_edit_morph: bool = False,
         seed: Optional[int] = None,
     ) -> Tuple[Optional[List[List[torch.Tensor]]], Optional[torch.Tensor], Optional[Dict[str, Any]]]:
-        """Prepare reference/source audio tensors and return early error payload when invalid."""
+        """Prepare reference/source audio tensors and return early error payload when invalid.
+
+        ``seed`` makes the reference-audio segment sampling deterministic so
+        same-seed generations condition on the same reference slices.
+        """
         if reference_audio is not None:
             logger.info("[generate_music] Processing reference audio...")
             processed_ref_audio = self.process_reference_audio(reference_audio, seed=seed)

--- a/acestep/core/generation/handler/io_audio.py
+++ b/acestep/core/generation/handler/io_audio.py
@@ -115,12 +115,14 @@ class IoAudioMixin:
             return None
 
     def process_reference_audio(
-        self, audio_file: Optional[str]
+        self, audio_file: Optional[str], seed: Optional[int] = None
     ) -> Optional[torch.Tensor]:
         """Load and normalize reference audio, then sample 3x10s segments.
 
         Args:
             audio_file: Path to reference audio file.
+            seed: Optional seed for the segment sampling, so same-seed
+                generations condition on the same reference slices.
 
         Returns:
             30-second stereo tensor from sampled front/middle/back segments,
@@ -128,6 +130,7 @@ class IoAudioMixin:
         """
         if audio_file is None:
             return None
+        rng = random.Random(seed) if seed is not None else random
 
         try:
             audio_np, sr = _read_audio_file(audio_file)
@@ -155,15 +158,15 @@ class IoAudioMixin:
             total_frames = audio.shape[-1]
             segment_size = total_frames // 3
 
-            front_start = random.randint(0, max(0, segment_size - segment_frames))
+            front_start = rng.randint(0, max(0, segment_size - segment_frames))
             front_audio = audio[:, front_start : front_start + segment_frames]
 
-            middle_start = segment_size + random.randint(
+            middle_start = segment_size + rng.randint(
                 0, max(0, segment_size - segment_frames)
             )
             middle_audio = audio[:, middle_start : middle_start + segment_frames]
 
-            back_start = 2 * segment_size + random.randint(
+            back_start = 2 * segment_size + rng.randint(
                 0, max(0, (total_frames - 2 * segment_size) - segment_frames)
             )
             back_audio = audio[:, back_start : back_start + segment_frames]

--- a/acestep/core/generation/handler/io_audio_seed_test.py
+++ b/acestep/core/generation/handler/io_audio_seed_test.py
@@ -1,0 +1,51 @@
+"""Unit tests for seeded reference-audio segment sampling."""
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from acestep.core.generation.handler.io_audio import IoAudioMixin
+from acestep.core.generation.handler.memory_utils import MemoryUtilsMixin
+
+
+class _Host(IoAudioMixin, MemoryUtilsMixin):
+    """Test host combining the audio IO and silence-check mixins."""
+
+
+def _fixture_audio():
+    """Return 90s of stereo 48kHz noise in soundfile [samples, channels] layout."""
+    rng = np.random.default_rng(0)
+    audio = rng.uniform(-0.5, 0.5, size=(90 * 48000, 2)).astype(np.float32)
+    return audio, 48000
+
+
+class ProcessReferenceAudioSeedTests(unittest.TestCase):
+    """Validate deterministic segment selection under a fixed seed."""
+
+    def test_same_seed_selects_same_segments(self):
+        """Two calls with the same seed must return identical tensors."""
+        host = _Host()
+        with patch(
+            "acestep.core.generation.handler.io_audio._read_audio_file",
+            return_value=_fixture_audio(),
+        ):
+            first = host.process_reference_audio("ref.wav", seed=1234)
+            second = host.process_reference_audio("ref.wav", seed=1234)
+        self.assertTrue(torch.equal(first, second))
+
+    def test_different_seeds_select_different_segments(self):
+        """Different seeds should sample different reference slices."""
+        host = _Host()
+        with patch(
+            "acestep.core.generation.handler.io_audio._read_audio_file",
+            return_value=_fixture_audio(),
+        ):
+            first = host.process_reference_audio("ref.wav", seed=1)
+            second = host.process_reference_audio("ref.wav", seed=2)
+        self.assertFalse(torch.equal(first, second))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -915,6 +915,11 @@ class LLMHandler:
             torch.manual_seed(seeds[0])
             if torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seeds[0])
+            if len(set(seeds)) > 1:
+                logger.info(
+                    "_run_vllm: per-item seeds are not supported by the vllm backend; "
+                    f"seeding the whole batch with the first seed ({seeds[0]})"
+                )
 
         # Determine effective temperature for sampler
         # Batch mode doesn't support phase temperatures, so use simple temperature
@@ -1332,8 +1337,10 @@ class LLMHandler:
             use_cot_language: Whether to generate language in CoT (default True).
             batch_size: Optional batch size for batch generation. If None or 1, returns single result.
                        If > 1, returns batch results (lists).
-            seeds: Optional list of seeds for batch generation (for reproducibility).
-                  Only used when batch_size > 1. TODO: not used yet
+            seeds: Optional list of per-item seeds for reproducible sampling.
+                  Applied to CoT and codes generation on all backends. The
+                  vllm backend cannot seed per item (all prompts share one
+                  sampling stream), so it seeds once per call with seeds[0].
 
         Returns:
             Dictionary containing:
@@ -4063,9 +4070,12 @@ class LLMHandler:
             logger.info(f"MLX batch: using sequential mode (batch_size={batch_size})")
             output_texts = []
             for i, formatted_prompt in enumerate(formatted_prompt_list):
-                # Set MLX seed for reproducibility
+                # Set MLX seed for reproducibility. Also seed torch: the
+                # hybrid fallback samples via torch.multinomial
+                # (_sample_tokens), which mx.random.seed does not cover.
                 if seeds and i < len(seeds):
                     mx.random.seed(seeds[i])
+                    torch.manual_seed(seeds[i])
 
                 output_text = self._run_mlx_single(
                     formatted_prompt=formatted_prompt,
@@ -4093,9 +4103,11 @@ class LLMHandler:
 
         # Single mode
         formatted_prompt = formatted_prompt_list[0]
-        # Set MLX seed for reproducibility (mirrors the sequential batch path)
+        # Set MLX seed for reproducibility (mirrors the sequential batch path).
+        # Also seed torch for the hybrid fallback's torch.multinomial sampling.
         if seeds:
             mx.random.seed(seeds[0])
+            torch.manual_seed(seeds[0])
         return self._run_mlx_single(
             formatted_prompt=formatted_prompt,
             temperature=temperature,

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -907,6 +907,15 @@ class LLMHandler:
         formatted_prompt_list, is_batch = self._normalize_batch_input(formatted_prompts)
         batch_size = len(formatted_prompt_list)
 
+        # Seed torch RNG for reproducibility. nano-vllm's sampler draws from the
+        # global torch generator; it samples all prompts in a single stream, so
+        # per-item seeding is not possible — seeding once with the first seed
+        # still makes same-seed runs reproducible.
+        if seeds:
+            torch.manual_seed(seeds[0])
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seeds[0])
+
         # Determine effective temperature for sampler
         # Batch mode doesn't support phase temperatures, so use simple temperature
         # Single mode supports phase temperatures
@@ -1220,6 +1229,14 @@ class LLMHandler:
         # Single mode: process the formatted prompt
         formatted_prompt = formatted_prompt_list[0]
 
+        # Set seed for reproducibility (mirrors the batch path above)
+        if seeds:
+            torch.manual_seed(seeds[0])
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seeds[0])
+            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                torch.mps.manual_seed(seeds[0])
+
         return self._run_pt_single(
             formatted_prompt=formatted_prompt,
             temperature=temperature,
@@ -1397,6 +1414,7 @@ class LLMHandler:
                     # Pass context for building unconditional prompt in CoT phase
                     "caption": caption,
                     "lyrics": lyrics,
+                    "seeds": seeds,
                 },
                 use_constrained_decoding=use_constrained_decoding,
                 constrained_decoding_debug=constrained_decoding_debug,
@@ -1619,6 +1637,7 @@ class LLMHandler:
                     "caption": caption,
                     "lyrics": lyrics,
                     "cot_text": cot_text,
+                    "seeds": seeds,
                 },
                 use_constrained_decoding=use_constrained_decoding,
                 constrained_decoding_debug=constrained_decoding_debug,
@@ -2379,6 +2398,7 @@ class LLMHandler:
                 - top_k (int), top_p (float), repetition_penalty (float)
                 - target_duration (float): Target duration in seconds for codes generation
                 - generation_phase (str): "cot" or "codes" for phase-aware CFG
+                - seeds (List[int]): Optional seeds for reproducible sampling
             use_constrained_decoding: Whether to use FSM-based constrained decoding
             constrained_decoding_debug: Whether to enable debug logging for constrained decoding
             stop_at_reasoning: If True, stop generation immediately after </think> tag (no audio codes)
@@ -2416,6 +2436,7 @@ class LLMHandler:
         caption = cfg.get("caption", "")
         lyrics = cfg.get("lyrics", "")
         cot_text = cfg.get("cot_text", "")
+        seeds = cfg.get("seeds")  # Optional list of seeds for reproducible sampling
 
         try:
             if self.llm_backend == "vllm":
@@ -2439,6 +2460,7 @@ class LLMHandler:
                     caption=caption,
                     lyrics=lyrics,
                     cot_text=cot_text,
+                    seeds=seeds,
                 )
                 self._clear_accelerator_cache()
                 return output_text, f"✅ Generated successfully (vllm) | length={len(output_text)}"
@@ -2465,6 +2487,7 @@ class LLMHandler:
                     caption=caption,
                     lyrics=lyrics,
                     cot_text=cot_text,
+                    seeds=seeds,
                 )
                 self._clear_accelerator_cache()
                 return output_text, f"✅ Generated successfully (mlx) | length={len(output_text)}"
@@ -2490,6 +2513,7 @@ class LLMHandler:
                 caption=caption,
                 lyrics=lyrics,
                 cot_text=cot_text,
+                seeds=seeds,
             )
             self._clear_accelerator_cache()
             return output_text, f"✅ Generated successfully (pt) | length={len(output_text)}"
@@ -4069,6 +4093,9 @@ class LLMHandler:
 
         # Single mode
         formatted_prompt = formatted_prompt_list[0]
+        # Set MLX seed for reproducibility (mirrors the sequential batch path)
+        if seeds:
+            mx.random.seed(seeds[0])
         return self._run_mlx_single(
             formatted_prompt=formatted_prompt,
             temperature=temperature,


### PR DESCRIPTION
## Problem

Two runs with the same seed and identical settings produce entirely different songs. The generation seed was only applied to the DiT diffusion stage; two other stochastic stages sampled unseeded randomness:

1. **5Hz LM planning/CoT sampling** — different CoT metadata and audio codes every run whenever `thinking` or CoT is enabled (the default).
2. **Reference-audio segment cropping** — `process_reference_audio()` samples three random 10s windows (front/middle/back) from the reference track with unseeded `random.randint`, so every run conditions on different slices of the reference audio.

## Root causes and fixes

### Commit 1: LM sampling

- **`_run_vllm` accepts `seeds` but never uses it.** nano-vllm's sampler draws from the global torch generator (`probs.div_(torch.empty_like(probs).exponential_(1))` in `nanovllm/layers/sampler.py`), which nothing seeds. Now seeds torch/CUDA RNG before `llm.generate`. nano-vllm samples all prompts in a single stream, so per-item seeding isn't possible — the batch is seeded once with `seeds[0]`, which still makes same-seed runs reproducible.
- **`_run_pt` and `_run_mlx` only seed in batch mode.** The single-mode paths (the `batch_size=1` default) skip seeding entirely. Now both single paths seed with `seeds[0]`, mirroring each backend's existing batch-path pattern.
- **`generate_from_formatted_prompt` had no seeds plumbing at all**, and both Phase 1 (CoT) and single-mode Phase 2 (codes) go through it — so those phases were unseeded on every backend. Seeds are now passed via the `cfg` dict and forwarded to all three backends.

### Commit 2: reference-audio cropping

The generation seed (`actual_seed_list[0]`) is threaded into `process_reference_audio()` via a local `random.Random` instance, so same-seed runs condition on the same reference slices. The global RNG is never touched.

## Verification

Tested end-to-end against a running API server (Linux, single RTX 5090, nano-vllm backend): two `/release_task` generations with the same seed — including a reference audio file and CoT metadata generation — now produce **bit-identical audio** (same SHA-256); a different seed produces different audio.

Behavior is unchanged when no seeds are provided (all new code is behind `if seeds:` / `seed is not None`).

Caveat: bit-exact reproducibility still assumes the usual determinism constraints (same hardware, same batch size); these changes make the sampling RNG deterministic, which is the dominant source of run-to-run variation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent seed handling across supported generation backends and audio-generation stages.
  * Repeated generations with the same seed now produce deterministic reference-audio segment selection.
  * Seeded behavior is supported for CoT, audio-code, and reference-audio processing.

* **Tests**
  * Added coverage verifying identical results for matching seeds and different results for different seeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->