### PR TITLE
Promote the complete/lego skip-LM workaround to a default (interim)

### DIFF
--- a/acestep/direct_conditioning_tasks_test.py
+++ b/acestep/direct_conditioning_tasks_test.py
@@ -37,12 +37,24 @@ class RecordingDitHandler:
     """
 
     def __init__(self):
+        """Initialize with no captured call; ``generate_kwargs`` stays None until called."""
         self.generate_kwargs = None
         self.lora_loaded = False
         self.use_lora = False
         self.lora_scale = 1.0
 
     def prepare_seeds(self, batch_size, seed, use_random_seed):
+        """Return a fixed seed list so the run is deterministic.
+
+        Args:
+            batch_size: Number of seeds the caller expects.
+            seed: Ignored; the real handler parses a comma-separated string here.
+            use_random_seed: Ignored; seeds are fixed regardless.
+
+        Returns:
+            ``(seeds, None)`` — a list of ``batch_size`` identical seeds, and the
+            padding info the real handler returns and ``generate_music`` discards.
+        """
         return [1234] * batch_size, None
 
     def generate_music(
@@ -54,6 +66,23 @@ class RecordingDitHandler:
         audio_code_string=None,
         **kwargs,
     ):
+        """Record the conditioning kwargs and stop the pipeline.
+
+        Args:
+            captions: Caption reaching the DiT — ``params.caption`` on a
+                direct-conditioning task, LM-generated otherwise.
+            lyrics: Lyrics reaching the DiT, same origin as ``captions``.
+            src_audio: Source audio path; the value under test.
+            task_type: Task the orchestrator resolved.
+            audio_code_string: LM-generated codes. Non-empty here means codes
+                pre-empted ``src_audio`` downstream.
+            **kwargs: Remaining DiT arguments, captured but not asserted on.
+
+        Returns:
+            A failure result (``success=False``), which makes ``generate_music``
+            return early — so no model runs and nothing is written to disk.
+            The captured kwargs are left on ``self.generate_kwargs``.
+        """
         self.generate_kwargs = {
             "captions": captions,
             "lyrics": lyrics,
@@ -103,10 +132,12 @@ class CompleteTaskSkipsLmTests(unittest.TestCase):
     """``complete`` must reach the DiT with source conditioning, not LM codes."""
 
     def test_lm_is_not_invoked(self):
+        """An initialized LM with every CoT flag on must still be skipped."""
         _, llm_handler, _ = _run("complete")
         llm_handler.generate_with_stop_condition.assert_not_called()
 
     def test_dit_receives_source_audio_and_params_conditioning(self):
+        """With no LM run, src_audio and params caption/lyrics must reach the DiT."""
         dit_handler, _, params = _run("complete")
         self.assertIsNotNone(dit_handler.generate_kwargs, "DiT handler was never called")
         self.assertEqual(params.src_audio, dit_handler.generate_kwargs["src_audio"])
@@ -123,10 +154,12 @@ class LegoTaskSkipsLmTests(unittest.TestCase):
     """``lego`` shares the path but is asserted independently on purpose."""
 
     def test_lm_is_not_invoked(self):
+        """Asserted separately from ``complete``: only that one is behaviour-verified."""
         _, llm_handler, _ = _run("lego")
         llm_handler.generate_with_stop_condition.assert_not_called()
 
     def test_dit_receives_source_audio_and_params_conditioning(self):
+        """With no LM run, src_audio and params caption/lyrics must reach the DiT."""
         dit_handler, _, params = _run("lego")
         self.assertIsNotNone(dit_handler.generate_kwargs, "DiT handler was never called")
         self.assertEqual(params.src_audio, dit_handler.generate_kwargs["src_audio"])
@@ -134,6 +167,7 @@ class LegoTaskSkipsLmTests(unittest.TestCase):
         self.assertEqual(params.lyrics, dit_handler.generate_kwargs["lyrics"])
 
     def test_no_audio_codes_pre_empt_source_audio(self):
+        """Empty codes are what keep the source-audio branch reachable downstream."""
         dit_handler, _, _ = _run("lego")
         self.assertFalse((dit_handler.generate_kwargs["audio_code_string"] or "").strip())
 
@@ -142,12 +176,14 @@ class DirectConditioningTaskSetTests(unittest.TestCase):
     """The LM gate and the params fallback must not be able to diverge."""
 
     def test_every_direct_conditioning_task_skips_the_lm(self):
+        """Membership in the set must imply the LM gate, for every task in it."""
         for task_type in sorted(DIRECT_CONDITIONING_TASKS):
             with self.subTest(task_type=task_type):
                 _, llm_handler, _ = _run(task_type)
                 llm_handler.generate_with_stop_condition.assert_not_called()
 
     def test_every_direct_conditioning_task_conditions_from_params(self):
+        """And must imply the params fallback — the half the LM gate would otherwise strand."""
         for task_type in sorted(DIRECT_CONDITIONING_TASKS):
             with self.subTest(task_type=task_type):
                 dit_handler, _, params = _run(task_type)

--- a/acestep/direct_conditioning_tasks_test.py
+++ b/acestep/direct_conditioning_tasks_test.py
@@ -1,0 +1,164 @@
+"""Regression tests for the direct-conditioning task gate in ``generate_music``.
+
+``complete`` and ``lego`` condition on source audio.  Running the LM for them
+made it emit audio codes from text alone, and those codes then pre-empted real
+``src_audio`` processing downstream (the "Audio codes provided, ignoring
+src_audio" branch in ``_prepare_reference_and_source_audio``).  Both halves of
+the fix are asserted here, because either one alone is silently wrong:
+
+1. the LM must not run — ``llm_handler.generate_with_stop_condition`` uncalled;
+2. conditioning must come from ``params`` instead — ``src_audio``, ``caption``
+   and ``lyrics`` must reach ``dit_handler.generate_music``.
+
+The two task types are asserted separately: they share a code path, but only
+``complete`` has been behaviour-verified upstream, so a future divergence in
+``lego`` should fail on its own line rather than hide behind a loop.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from acestep.inference import (
+    DIRECT_CONDITIONING_TASKS,
+    GenerationConfig,
+    GenerationParams,
+    generate_music,
+)
+
+
+class RecordingDitHandler:
+    """Minimal stand-in that captures the kwargs ``generate_music`` passes on.
+
+    ``generate_music`` filters its kwargs through
+    ``inspect.signature(dit_handler.generate_music)``, so the parameters under
+    test have to be named explicitly here rather than swallowed by ``**kwargs``.
+    Returning ``success=False`` stops the orchestrator right after the call, so
+    no model or file I/O is needed.
+    """
+
+    def __init__(self):
+        self.generate_kwargs = None
+        self.lora_loaded = False
+        self.use_lora = False
+        self.lora_scale = 1.0
+
+    def prepare_seeds(self, batch_size, seed, use_random_seed):
+        return [1234] * batch_size, None
+
+    def generate_music(
+        self,
+        captions=None,
+        lyrics=None,
+        src_audio=None,
+        task_type=None,
+        audio_code_string=None,
+        **kwargs,
+    ):
+        self.generate_kwargs = {
+            "captions": captions,
+            "lyrics": lyrics,
+            "src_audio": src_audio,
+            "task_type": task_type,
+            "audio_code_string": audio_code_string,
+            **kwargs,
+        }
+        return {
+            "success": False,
+            "status_message": "stub handler — stopped after capturing conditioning",
+            "error": "stub",
+            "audios": [],
+            "extra_outputs": {},
+        }
+
+
+def _make_llm_handler():
+    """LLM handler that looks fully initialized, so skipping is a real decision."""
+    llm_handler = MagicMock()
+    llm_handler.llm_initialized = True
+    llm_handler.generate_with_stop_condition.return_value = {
+        "success": False,
+        "error": "stub LM should not have been reached",
+    }
+    return llm_handler
+
+
+def _run(task_type, **param_overrides):
+    """Drive ``generate_music`` once with LM-enabling defaults left on."""
+    dit_handler = RecordingDitHandler()
+    llm_handler = _make_llm_handler()
+    params = GenerationParams(
+        task_type=task_type,
+        src_audio="/tmp/source.wav",
+        caption="warm analog drums and bass",
+        lyrics="[Instrumental]",
+        # thinking and the three CoT flags default to True; leaving them alone
+        # is the point — the gate must hold without the caller disabling them.
+        **param_overrides,
+    )
+    generate_music(dit_handler, llm_handler, params, GenerationConfig(batch_size=1))
+    return dit_handler, llm_handler, params
+
+
+class CompleteTaskSkipsLmTests(unittest.TestCase):
+    """``complete`` must reach the DiT with source conditioning, not LM codes."""
+
+    def test_lm_is_not_invoked(self):
+        _, llm_handler, _ = _run("complete")
+        llm_handler.generate_with_stop_condition.assert_not_called()
+
+    def test_dit_receives_source_audio_and_params_conditioning(self):
+        dit_handler, _, params = _run("complete")
+        self.assertIsNotNone(dit_handler.generate_kwargs, "DiT handler was never called")
+        self.assertEqual(params.src_audio, dit_handler.generate_kwargs["src_audio"])
+        self.assertEqual(params.caption, dit_handler.generate_kwargs["captions"])
+        self.assertEqual(params.lyrics, dit_handler.generate_kwargs["lyrics"])
+
+    def test_no_audio_codes_pre_empt_source_audio(self):
+        """Empty codes are what keep the source-audio branch reachable downstream."""
+        dit_handler, _, _ = _run("complete")
+        self.assertFalse((dit_handler.generate_kwargs["audio_code_string"] or "").strip())
+
+
+class LegoTaskSkipsLmTests(unittest.TestCase):
+    """``lego`` shares the path but is asserted independently on purpose."""
+
+    def test_lm_is_not_invoked(self):
+        _, llm_handler, _ = _run("lego")
+        llm_handler.generate_with_stop_condition.assert_not_called()
+
+    def test_dit_receives_source_audio_and_params_conditioning(self):
+        dit_handler, _, params = _run("lego")
+        self.assertIsNotNone(dit_handler.generate_kwargs, "DiT handler was never called")
+        self.assertEqual(params.src_audio, dit_handler.generate_kwargs["src_audio"])
+        self.assertEqual(params.caption, dit_handler.generate_kwargs["captions"])
+        self.assertEqual(params.lyrics, dit_handler.generate_kwargs["lyrics"])
+
+    def test_no_audio_codes_pre_empt_source_audio(self):
+        dit_handler, _, _ = _run("lego")
+        self.assertFalse((dit_handler.generate_kwargs["audio_code_string"] or "").strip())
+
+
+class DirectConditioningTaskSetTests(unittest.TestCase):
+    """The LM gate and the params fallback must not be able to diverge."""
+
+    def test_every_direct_conditioning_task_skips_the_lm(self):
+        for task_type in sorted(DIRECT_CONDITIONING_TASKS):
+            with self.subTest(task_type=task_type):
+                _, llm_handler, _ = _run(task_type)
+                llm_handler.generate_with_stop_condition.assert_not_called()
+
+    def test_every_direct_conditioning_task_conditions_from_params(self):
+        for task_type in sorted(DIRECT_CONDITIONING_TASKS):
+            with self.subTest(task_type=task_type):
+                dit_handler, _, params = _run(task_type)
+                self.assertEqual(params.caption, dit_handler.generate_kwargs["captions"])
+                self.assertEqual(params.lyrics, dit_handler.generate_kwargs["lyrics"])
+
+    def test_text2music_still_runs_the_lm(self):
+        """Control: proves the assertions above can actually observe an LM call."""
+        _, llm_handler, _ = _run("text2music")
+        llm_handler.generate_with_stop_condition.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -26,6 +26,17 @@ from acestep.constants import BPM_MIN, BPM_MAX, DURATION_MAX, TASK_TYPES, VALID_
 # HuggingFace Space environment detection
 IS_HUGGINGFACE_SPACE = os.environ.get("SPACE_ID") is not None
 
+# Task types conditioned directly on reference/source audio rather than on
+# LM-generated audio codes.  Two decisions must stay in lockstep for these:
+#   1. the LM is skipped entirely (its codes would pre-empt src_audio
+#      downstream in ``_prepare_reference_and_source_audio``), and
+#   2. caption/lyrics conditioning therefore has to come from ``params``,
+#      since no LM ran to produce them.
+# Keeping one set means a task added here can never be half-applied.
+DIRECT_CONDITIONING_TASKS = frozenset(
+    {"cover", "cover-nofsq", "repaint", "extract", "complete", "lego"}
+)
+
 def _get_spaces_gpu_decorator(duration=180):
     """
     Get the @spaces.GPU decorator if running in HuggingFace Space environment.
@@ -605,8 +616,8 @@ def generate_music(
             use_random_seed_for_dit = False
 
         # LM-based Chain-of-Thought reasoning
-        # Skip LM for cover/repaint/extract/complete/lego tasks - these tasks use
-        # reference/src audio directly and don't need LM to generate audio codes or metadata.
+        # Skip LM for the direct-conditioning tasks - these use reference/src audio
+        # directly and don't need LM to generate audio codes or metadata.
         # For extract tasks, LLM-generated captions can conflict with the extract instruction
         # and cause the DiT model to reconstruct input audio instead of extracting stems.
         # complete/lego were previously NOT skipped, so with thinking=True the LM
@@ -614,7 +625,7 @@ def generate_music(
         # stage). Those codes then pre-empted real src_audio processing downstream in
         # ``_prepare_reference_and_source_audio`` (the "Audio codes provided, ignoring
         # src_audio" branch), so the DiT never saw the source audio.
-        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract", "complete", "lego"}
+        skip_lm_tasks = DIRECT_CONDITIONING_TASKS
         # Flow-edit overlay on text2music must NOT trigger LM Phase 1.
         # Even if Think is on, the LM-generated codes would be routed
         # into ``conditioning_target`` which replaces target_wavs with
@@ -811,8 +822,8 @@ def generate_music(
             if params.use_cot_language:
                 dit_input_vocal_language = lm_generated_metadata.get("vocal_language", dit_input_vocal_language)
 
-        # Repaint/cover/extract/complete/lego: no LM run, so conditioning must come from params (caption + lyrics from GUI).
-        if params.task_type in ("repaint", "cover", "cover-nofsq", "extract", "complete", "lego"):
+        # Direct-conditioning tasks: no LM run, so conditioning must come from params (caption + lyrics from GUI).
+        if params.task_type in DIRECT_CONDITIONING_TASKS:
             dit_input_caption = params.caption or dit_input_caption
             dit_input_lyrics = params.lyrics if params.lyrics is not None else dit_input_lyrics
             logger.info(f"[generate_music] {params.task_type} task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")

--- a/acestep/inference.py
+++ b/acestep/inference.py
@@ -605,11 +605,16 @@ def generate_music(
             use_random_seed_for_dit = False
 
         # LM-based Chain-of-Thought reasoning
-        # Skip LM for cover/repaint/extract tasks - these tasks use reference/src audio directly
-        # and don't need LM to generate audio codes or metadata.
+        # Skip LM for cover/repaint/extract/complete/lego tasks - these tasks use
+        # reference/src audio directly and don't need LM to generate audio codes or metadata.
         # For extract tasks, LLM-generated captions can conflict with the extract instruction
         # and cause the DiT model to reconstruct input audio instead of extracting stems.
-        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract"}
+        # complete/lego were previously NOT skipped, so with thinking=True the LM
+        # generated audio codes from text alone (no src_audio conditioning at the LM
+        # stage). Those codes then pre-empted real src_audio processing downstream in
+        # ``_prepare_reference_and_source_audio`` (the "Audio codes provided, ignoring
+        # src_audio" branch), so the DiT never saw the source audio.
+        skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract", "complete", "lego"}
         # Flow-edit overlay on text2music must NOT trigger LM Phase 1.
         # Even if Think is on, the LM-generated codes would be routed
         # into ``conditioning_target`` which replaces target_wavs with
@@ -806,8 +811,8 @@ def generate_music(
             if params.use_cot_language:
                 dit_input_vocal_language = lm_generated_metadata.get("vocal_language", dit_input_vocal_language)
 
-        # Repaint/cover/extract: no LM run, so conditioning must come from params (caption + lyrics from GUI).
-        if params.task_type in ("repaint", "cover", "cover-nofsq", "extract"):
+        # Repaint/cover/extract/complete/lego: no LM run, so conditioning must come from params (caption + lyrics from GUI).
+        if params.task_type in ("repaint", "cover", "cover-nofsq", "extract", "complete", "lego"):
             dit_input_caption = params.caption or dit_input_caption
             dit_input_lyrics = params.lyrics if params.lyrics is not None else dit_input_lyrics
             logger.info(f"[generate_music] {params.task_type} task: using params.caption='{params.caption}', params.lyrics='{params.lyrics}'")


### PR DESCRIPTION
## What this changes

Adds `complete` and `lego` to `skip_lm_tasks`, and extends the params-based conditioning
fallback to the same two task types.

```diff
- skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract"}
+ skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract", "complete", "lego"}
```

```diff
- if params.task_type in ("repaint", "cover", "cover-nofsq", "extract"):
+ if params.task_type in ("repaint", "cover", "cover-nofsq", "extract", "complete", "lego"):
```

## This is a workaround promoted to a default, not a root-cause fix

I want to be explicit about this, because I got the framing wrong the first time and
corrected it publicly in #1286.

Running the LM for `complete`/`lego` is **intentional** — #963 documents that Think/CoT
apply to these tasks. The actual defect is upstream of the skip decision: `src_audio`
never reaches the LM before it generates audio codes, so the LM plans blind to the
source, and those codes then silently pre-empt real source-audio processing in
`_prepare_reference_and_source_audio()` (the *"Audio codes provided, ignoring src_audio"*
branch). @andreiostacie flagged the same mechanism for `lego` in #117 back in February.

The proper fix is to wire `convert_src_audio_to_codes()` / `understand_audio_from_codes()`
— both already exist — into the LM's context for these tasks. **This PR does not do
that.** It changes the default so the source-conditioned behaviour is what users get
until that plumbing lands.

### What this costs

Skipping the LM for these tasks gives up LM CoT caption/metadata enrichment — the same
trade-off #117 describes for `thinking=False`. For source-conditioned tasks I'd argue
that's the right default (following the source matters more than an LM-written caption),
but it is a real loss and should be a deliberate choice, not a silent one.

### Why a per-task gate rather than telling users to set `thinking=False`

`thinking=False` alone does not actually skip the LM:

```python
use_lm = (thinking or need_lm_for_cot) and ... and not skip_lm
need_lm_for_cot = use_cot_caption or use_cot_language or use_cot_metas
```

All three CoT flags default to `True`, so a caller must set **four** flags correctly to
avoid the LM. The Gradio UI's Think checkbox also defaults on. A per-task-type gate is
the only form of this that can't be half-applied.

## Precedent

#886 (*fix: skip LLM for extract tasks*, merged 2026-03-20) made exactly this change for
`extract`, for the same reason — LM-generated conditioning conflicting with a
source-conditioned task. This PR extends that precedent to the two remaining
source-conditioned task types.

## Verification

**Log path.** Before: `complete` logged *"Audio codes provided, ignoring src_audio"* and
never entered source processing. After: it logs the same path as `cover-nofsq`, which
already skipped the LM — `Skipping LM for task_type=...` followed by
`Processing source audio...`.

**Behaviour.** Log parity only shows the plumbing is connected, so I also measured whether
output actually follows the source.

<details>
<summary>Method and numbers</summary>

Method (source-agnostic, reproducible with any source you have a chord chart for): take a
source recording whose chord progression is known independently, run `complete` with
drums+bass as the added tracks, and measure the fraction of frames where the root of the
newly generated bass matches the chart root at the same time position. Two references are
needed to read the number: a **floor**, measured on the source alone with no generated
bass, which captures how much the metric picks up from the source's own low end; and a
**control**, the same run with the bass stem not rendered (−33.5 dB), which should land on
the floor if the metric is measuring the generated track rather than leakage.

| Condition | Root match |
|---|---|
| `complete`, source containing harmony | **56.9%** |
| Control — same run, bass not rendered | 31.5% |
| Floor — source bleed only, no generated bass | 32.5% |

The control landing on the floor is the part that matters: it means the 56.9% comes from
the generated track following the source, not from the measurement seeing the source
through the mix.

</details>

**Scope of verification.** Both task types are log-verified: with the patch applied,
`lego` logs `Skipping LM for task_type='lego' - using DiT directly` followed by
`[generate_music] Processing source audio...`, and never logs the
*"Audio codes provided, ignoring src_audio"* branch. Behaviour (output following the
source harmony) was measured for `complete` only; `lego` shares the identical code path
and #117 flagged the same mechanism for it, but was not separately behaviour-tested.

## Refs

Refs #1286, #117, #963, #886 — interim fix; the fuller fix (feeding src-derived codes
into the LM stage) remains open. Deliberately not `Closes`, since the underlying gap
described in #1286 is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music generation for direct-conditioning tasks, including cover, cover-nofsq, repaint, extract, complete, and lego.
  * Preserved provided captions and lyrics during these workflows.
  * Prevented unnecessary language-model processing from overriding source-audio conditioning.
  * Ensured source audio and requested parameters are consistently applied during generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->