### PR TITLE
fix(repaint): preserve auto chunk mask sentinel

### DIFF
--- a/acestep/core/generation/handler/conditioning_masks.py
+++ b/acestep/core/generation/handler/conditioning_masks.py
@@ -35,6 +35,8 @@ class ConditioningMaskMixin:
 
         Returns:
             Tuple of (chunk_masks, spans, is_covers, src_latents, repaint_mask).
+            ``chunk_masks`` is floating point: explicit masks contain 0/1,
+            while auto-mode masks contain the 2.0 model-decided sentinel.
             ``repaint_mask`` is a boolean ``[B, T]`` tensor (True = generate,
             False = preserve source) when any item uses repainting, else ``None``.
         """
@@ -70,7 +72,7 @@ class ConditioningMaskMixin:
             is_cover = (task_type == "cover") or has_code_hint
             is_covers.append(is_cover)
 
-        chunk_masks_tensor = torch.stack(chunk_masks)
+        chunk_masks_tensor = torch.stack(chunk_masks).to(torch.float32)
         if chunk_mask_modes:
             for i, mode in enumerate(chunk_mask_modes):
                 if mode == "auto":

--- a/acestep/core/generation/handler/conditioning_masks_test.py
+++ b/acestep/core/generation/handler/conditioning_masks_test.py
@@ -32,6 +32,7 @@ def _build(
     target_latents: Optional[torch.Tensor] = None,
     repainting_start: Optional[List[float]] = None,
     repainting_end: Optional[List[float]] = None,
+    chunk_mask_modes: Optional[List[str]] = None,
     task_type: str = "",
 ):
     """Call _build_chunk_masks_and_src_latents with sensible defaults."""
@@ -55,8 +56,42 @@ def _build(
         repainting_start=repainting_start,
         repainting_end=repainting_end,
         silence_latent_tiled=silence_latent_tiled,
+        chunk_mask_modes=chunk_mask_modes,
         task_type=task_type,
     )
+
+
+class ConditioningMaskModeTests(unittest.TestCase):
+    """Verify model-facing values for explicit and automatic chunk masks."""
+
+    def test_auto_chunk_mask_uses_model_decided_sentinel(self):
+        """Auto mode should send the documented 2.0 sentinel to the model."""
+        host = _make_host()
+        chunk_masks, _spans, _is_covers, _src_latents, repaint_mask = _build(
+            host,
+            repainting_start=[1.0],
+            repainting_end=[2.0],
+            chunk_mask_modes=["auto"],
+        )
+
+        self.assertTrue(torch.is_floating_point(chunk_masks))
+        torch.testing.assert_close(chunk_masks, torch.full_like(chunk_masks, 2.0))
+        self.assertEqual(repaint_mask.dtype, torch.bool)
+
+    def test_explicit_chunk_mask_keeps_repainting_range(self):
+        """Explicit mode should preserve the interval-derived 0/1 mask."""
+        host = _make_host()
+        chunk_masks, *_ = _build(
+            host,
+            repainting_start=[1.0],
+            repainting_end=[2.0],
+            chunk_mask_modes=["explicit"],
+        )
+
+        self.assertTrue(torch.is_floating_point(chunk_masks))
+        self.assertTrue(torch.all(chunk_masks[0, :25] == 0.0))
+        self.assertTrue(torch.all(chunk_masks[0, 25:50] == 1.0))
+        self.assertTrue(torch.all(chunk_masks[0, 50:] == 0.0))
 
 
 class ConditioningMaskLegoBehaviorTests(unittest.TestCase):

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -250,6 +250,7 @@ These parameters control 5Hz LM sampling, used for metadata auto-completion and 
 | `instruction` | string | auto | Edit instruction (auto-generated based on task_type if not provided) |
 | `repainting_start` | float | `0.0` | Repainting start time (seconds) |
 | `repainting_end` | float | null | Repainting end time (seconds), -1 for end of audio |
+| `chunk_mask_mode` | string | `"auto"` | Chunk-mask conditioning: `"explicit"` uses the repaint time range as a 0/1 mask; `"auto"` lets the model decide chunk boundaries. |
 | `audio_cover_strength` | float | `1.0` | Cover strength (0.0-1.0). Lower values (0.2) for style transfer. |
 
 #### Method B: File Upload (multipart/form-data)
@@ -361,7 +362,10 @@ curl -X POST http://localhost:8001/release_task \
 curl -X POST http://localhost:8001/release_task \
   -F "prompt=remix this song" \
   -F "src_audio=@/path/to/local/song.mp3" \
-  -F "task_type=repaint"
+  -F "task_type=repaint" \
+  -F "repainting_start=10" \
+  -F "repainting_end=20" \
+  -F "chunk_mask_mode=explicit"
 ```
 
 ---

--- a/docs/en/INFERENCE.md
+++ b/docs/en/INFERENCE.md
@@ -193,6 +193,7 @@ class GenerationParams:
     
     repainting_start: float = 0.0
     repainting_end: float = -1
+    chunk_mask_mode: str = "auto"
     audio_cover_strength: float = 1.0
     
     # 5Hz Language Model Parameters
@@ -388,6 +389,7 @@ class FormatSampleResult:
 | `audio_codes` | `str` | `""` | Pre-extracted 5Hz audio semantic codes as a string. Advanced use only. |
 | `repainting_start` | `float` | `0.0` | Repainting start time in seconds (for repaint/lego tasks). |
 | `repainting_end` | `float` | `-1` | Repainting end time in seconds. Use `-1` for end of audio. |
+| `chunk_mask_mode` | `str` | `"auto"` | Chunk-mask conditioning mode. Use `"explicit"` to send the 0/1 mask derived from `repainting_start`/`repainting_end`; `"auto"` lets the model decide chunk boundaries. |
 | `audio_cover_strength` | `float` | `1.0` | Strength of audio cover/codes influence (0.0-1.0). Set smaller (0.2) for style transfer tasks. |
 
 ### 5Hz Language Model Parameters
@@ -515,9 +517,14 @@ params = GenerationParams(
     src_audio="original.mp3",
     repainting_start=10.0,  # seconds
     repainting_end=20.0,    # seconds
+    chunk_mask_mode="explicit",
     caption="smooth transition with piano solo",
 )
 ```
+
+`chunk_mask_mode="explicit"` forwards the selected time range as a 0/1 mask to model
+conditioning. The default `"auto"` sends a 2.0 sentinel so the model decides the chunk
+boundaries.
 
 **Required**:
 - `src_audio`: Path to source audio file

--- a/docs/zh/API.md
+++ b/docs/zh/API.md
@@ -247,6 +247,7 @@ API 支持大多数参数的 **snake_case** 和 **camelCase** 命名。例如：
 | `instruction` | string | auto | 编辑指令（如未提供则根据 task_type 自动生成）|
 | `repainting_start` | float | `0.0` | 重绘开始时间（秒）|
 | `repainting_end` | float | null | 重绘结束时间（秒），-1 表示音频末尾 |
+| `chunk_mask_mode` | string | `"auto"` | 分块掩码条件模式：`"explicit"` 使用重绘时间范围生成 0/1 掩码；`"auto"` 让模型自行决定分块边界。|
 | `audio_cover_strength` | float | `1.0` | 翻唱强度（0.0-1.0）。风格迁移使用较小值（0.2）|
 
 #### 方法 B：文件上传（multipart/form-data）
@@ -358,7 +359,10 @@ curl -X POST http://localhost:8001/release_task \
 curl -X POST http://localhost:8001/release_task \
   -F "prompt=重新混音这首歌" \
   -F "src_audio=@/path/to/local/song.mp3" \
-  -F "task_type=repaint"
+  -F "task_type=repaint" \
+  -F "repainting_start=10" \
+  -F "repainting_end=20" \
+  -F "chunk_mask_mode=explicit"
 ```
 
 ---

--- a/docs/zh/INFERENCE.md
+++ b/docs/zh/INFERENCE.md
@@ -193,6 +193,7 @@ class GenerationParams:
     
     repainting_start: float = 0.0
     repainting_end: float = -1
+    chunk_mask_mode: str = "auto"
     audio_cover_strength: float = 1.0
     
     # 5Hz 语言模型参数
@@ -378,6 +379,7 @@ class FormatSampleResult:
 | `audio_codes` | `str` | `""` | 预提取的 5Hz 音频语义代码字符串。仅供高级使用。|
 | `repainting_start` | `float` | `0.0` | 重绘开始时间（秒）（用于 repaint/lego 任务）。|
 | `repainting_end` | `float` | `-1` | 重绘结束时间（秒）。使用 `-1` 表示音频末尾。|
+| `chunk_mask_mode` | `str` | `"auto"` | 分块掩码条件模式。使用 `"explicit"` 将根据 `repainting_start`/`repainting_end` 生成的 0/1 掩码传给模型；`"auto"` 让模型自行决定分块边界。|
 | `audio_cover_strength` | `float` | `1.0` | 音频 cover/代码影响强度（0.0-1.0）。风格迁移任务设置较小值（0.2）。|
 
 ### 5Hz 语言模型参数
@@ -505,9 +507,13 @@ params = GenerationParams(
     src_audio="original.mp3",
     repainting_start=10.0,  # 秒
     repainting_end=20.0,    # 秒
+    chunk_mask_mode="explicit",
     caption="带钢琴独奏的平滑过渡",
 )
 ```
+
+`chunk_mask_mode="explicit"` 会将所选时间范围作为 0/1 掩码传给模型条件。默认的
+`"auto"` 会发送 2.0 哨兵值，让模型自行决定分块边界。
 
 **必需**：
 - `src_audio`：源音频文件路径


### PR DESCRIPTION
## Summary

Fixes #1289.

`chunk_mask_mode="auto"` is documented and implemented as a `2.0` model-decided sentinel. The chunk mask was built as `torch.bool`, however, so assigning `2.0` coerced it to `True`; the model ultimately received `1.0` instead of `2.0`.

This PR converts only the model-facing stacked chunk mask to floating point before applying the sentinel. It also adds focused coverage for both modes and documents the parameter in the English and Chinese inference/API guides.

## Root cause

- Interval masks were created as boolean tensors.
- `chunk_masks_tensor[i] = 2.0` therefore stored `True`, not `2.0`.
- The later model-dtype conversion turned that value into `1.0`, making `auto` behavior differ from the contract introduced in #815.

## Scope

Changed:

- `conditioning_masks.py`: convert the model-facing chunk mask to `float32` before applying auto-mode values.
- `conditioning_masks_test.py`: verify `auto -> 2.0`, `explicit -> interval-derived 0/1`, and the independent `repaint_mask` remains boolean.
- English and Chinese `INFERENCE.md` / `API.md`: document both modes and show explicit-mask Repaint examples.

Out of scope:

- The public `chunk_mask_mode="auto"` default is unchanged.
- Gradio continues to use that default; this PR repairs its intended sentinel behavior rather than changing UI policy.
- Source-latent injection, latent boundary blending, waveform splicing, model code, and hardware-specific paths are unchanged.

## Risk and compatibility

The intentional behavior change is limited to `auto`: it now sends the documented `2.0` sentinel instead of the accidental `1.0`. Explicit masks carry the same 0/1 values as before, now in the floating type expected by model context concatenation. The independent repaint enforcement mask remains `torch.bool`.

Non-target CPU/CUDA/MPS/XPU/MLX branches are unchanged.

## Regression checks

Passed in the requested ACE-Step environment:

```bash
source /home/node59_tmpdata3/yxxia/miniconda3/bin/activate ace-step
python -m unittest \
  acestep.core.generation.handler.conditioning_masks_test \
  acestep.core.generation.handler.conditioning_batch_test \
  acestep.core.generation.handler.conditioning_embed_test
# Ran 20 tests: OK

python -m compileall -q \
  acestep/core/generation/handler/conditioning_masks.py \
  acestep/core/generation/handler/conditioning_masks_test.py

git diff --check
```

A broader handler discovery run executed 298 tests and reported 3 errors plus 1 skip in untouched, unrelated tests (`init_service_test`, `reference_audio_validation_test`, and `vae_decode_chunks_test`). The focused mask/batch/embed suite above is green.

No checkpoint was needed: the regression is deterministic tensor dtype/value handling and is covered without model loading.
