### PR TITLE
fix(ui): use explicit chunk mask for Repaint

### DIFF
--- a/acestep/ui/gradio/events/results/generation_progress.py
+++ b/acestep/ui/gradio/events/results/generation_progress.py
@@ -27,7 +27,10 @@ from acestep.ui.gradio.events.results.generation_info import (
     DEFAULT_RESULTS_DIR,
     _build_generation_info,
 )
-from acestep.ui.gradio.events.results.generation_task_type import resolve_no_fsq_task_type
+from acestep.ui.gradio.events.results.generation_task_type import (
+    resolve_chunk_mask_mode,
+    resolve_no_fsq_task_type,
+)
 from acestep.ui.gradio.events.results.audio_playback_updates import (
     build_audio_slot_update,
 )
@@ -164,6 +167,7 @@ def generate_with_progress(
         timesteps=parsed_timesteps,
         repainting_start=repainting_start,
         repainting_end=repainting_end,
+        chunk_mask_mode=resolve_chunk_mask_mode(task_type),
         audio_cover_strength=audio_cover_strength,
         cover_noise_strength=cover_noise_strength,
         thinking=think_checkbox,

--- a/acestep/ui/gradio/events/results/generation_task_type.py
+++ b/acestep/ui/gradio/events/results/generation_task_type.py
@@ -15,3 +15,18 @@ def resolve_no_fsq_task_type(task_type: str, no_fsq: bool) -> str:
     if task_type == "cover" and no_fsq:
         return "cover-nofsq"
     return task_type
+
+
+def resolve_chunk_mask_mode(task_type: str) -> str:
+    """Resolve model chunk-mask control for a Gradio task.
+
+    Args:
+        task_type: Resolved backend task type from the Gradio mode.
+
+    Returns:
+        ``explicit`` for Repaint so its selected interval reaches model
+        conditioning; otherwise ``auto`` to preserve existing behavior.
+    """
+    if task_type == "repaint":
+        return "explicit"
+    return "auto"

--- a/acestep/ui/gradio/events/results/generation_task_type_test.py
+++ b/acestep/ui/gradio/events/results/generation_task_type_test.py
@@ -2,7 +2,10 @@
 
 import unittest
 
-from acestep.ui.gradio.events.results.generation_task_type import resolve_no_fsq_task_type
+from acestep.ui.gradio.events.results.generation_task_type import (
+    resolve_chunk_mask_mode,
+    resolve_no_fsq_task_type,
+)
 
 
 class GenerationTaskTypeTests(unittest.TestCase):
@@ -20,6 +23,16 @@ class GenerationTaskTypeTests(unittest.TestCase):
         """Hidden checked state should not alter other generation modes."""
         self.assertEqual(resolve_no_fsq_task_type("repaint", True), "repaint")
         self.assertEqual(resolve_no_fsq_task_type("text2music", True), "text2music")
+
+    def test_repaint_uses_explicit_chunk_mask(self):
+        """Repaint should forward its selected interval to model conditioning."""
+        self.assertEqual(resolve_chunk_mask_mode("repaint"), "explicit")
+
+    def test_non_repaint_tasks_keep_auto_chunk_mask(self):
+        """The Repaint fix should not change masking for other UI tasks."""
+        for task_type in ("text2music", "cover", "cover-nofsq", "lego", "extract", "complete"):
+            with self.subTest(task_type=task_type):
+                self.assertEqual(resolve_chunk_mask_mode(task_type), "auto")
 
 
 if __name__ == "__main__":

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -250,6 +250,7 @@ These parameters control 5Hz LM sampling, used for metadata auto-completion and 
 | `instruction` | string | auto | Edit instruction (auto-generated based on task_type if not provided) |
 | `repainting_start` | float | `0.0` | Repainting start time (seconds) |
 | `repainting_end` | float | null | Repainting end time (seconds), -1 for end of audio |
+| `chunk_mask_mode` | string | `"auto"` | Chunk-mask control: `"explicit"` uses the repaint time range as a 0/1 mask; `"auto"` uses automatic chunk control. |
 | `audio_cover_strength` | float | `1.0` | Cover strength (0.0-1.0). Lower values (0.2) for style transfer. |
 
 #### Method B: File Upload (multipart/form-data)
@@ -361,7 +362,10 @@ curl -X POST http://localhost:8001/release_task \
 curl -X POST http://localhost:8001/release_task \
   -F "prompt=remix this song" \
   -F "src_audio=@/path/to/local/song.mp3" \
-  -F "task_type=repaint"
+  -F "task_type=repaint" \
+  -F "repainting_start=10" \
+  -F "repainting_end=20" \
+  -F "chunk_mask_mode=explicit"
 ```
 
 ---

--- a/docs/en/INFERENCE.md
+++ b/docs/en/INFERENCE.md
@@ -193,6 +193,7 @@ class GenerationParams:
     
     repainting_start: float = 0.0
     repainting_end: float = -1
+    chunk_mask_mode: str = "auto"
     audio_cover_strength: float = 1.0
     
     # 5Hz Language Model Parameters
@@ -388,6 +389,7 @@ class FormatSampleResult:
 | `audio_codes` | `str` | `""` | Pre-extracted 5Hz audio semantic codes as a string. Advanced use only. |
 | `repainting_start` | `float` | `0.0` | Repainting start time in seconds (for repaint/lego tasks). |
 | `repainting_end` | `float` | `-1` | Repainting end time in seconds. Use `-1` for end of audio. |
+| `chunk_mask_mode` | `str` | `"auto"` | Chunk-mask control mode. Use `"explicit"` to pass the 0/1 mask derived from `repainting_start`/`repainting_end`; `"auto"` uses automatic chunk control. |
 | `audio_cover_strength` | `float` | `1.0` | Strength of audio cover/codes influence (0.0-1.0). Set smaller (0.2) for style transfer tasks. |
 
 ### 5Hz Language Model Parameters
@@ -515,9 +517,13 @@ params = GenerationParams(
     src_audio="original.mp3",
     repainting_start=10.0,  # seconds
     repainting_end=20.0,    # seconds
+    chunk_mask_mode="explicit",
     caption="smooth transition with piano solo",
 )
 ```
+
+Use `chunk_mask_mode="explicit"` when the selected Repaint interval must be passed as
+the model chunk mask. Gradio Repaint selects this mode automatically.
 
 **Required**:
 - `src_audio`: Path to source audio file

--- a/docs/zh/API.md
+++ b/docs/zh/API.md
@@ -247,6 +247,7 @@ API 支持大多数参数的 **snake_case** 和 **camelCase** 命名。例如：
 | `instruction` | string | auto | 编辑指令（如未提供则根据 task_type 自动生成）|
 | `repainting_start` | float | `0.0` | 重绘开始时间（秒）|
 | `repainting_end` | float | null | 重绘结束时间（秒），-1 表示音频末尾 |
+| `chunk_mask_mode` | string | `"auto"` | 分块掩码控制：`"explicit"` 使用重绘时间范围生成 0/1 掩码；`"auto"` 使用自动分块控制。|
 | `audio_cover_strength` | float | `1.0` | 翻唱强度（0.0-1.0）。风格迁移使用较小值（0.2）|
 
 #### 方法 B：文件上传（multipart/form-data）
@@ -358,7 +359,10 @@ curl -X POST http://localhost:8001/release_task \
 curl -X POST http://localhost:8001/release_task \
   -F "prompt=重新混音这首歌" \
   -F "src_audio=@/path/to/local/song.mp3" \
-  -F "task_type=repaint"
+  -F "task_type=repaint" \
+  -F "repainting_start=10" \
+  -F "repainting_end=20" \
+  -F "chunk_mask_mode=explicit"
 ```
 
 ---

--- a/docs/zh/INFERENCE.md
+++ b/docs/zh/INFERENCE.md
@@ -193,6 +193,7 @@ class GenerationParams:
     
     repainting_start: float = 0.0
     repainting_end: float = -1
+    chunk_mask_mode: str = "auto"
     audio_cover_strength: float = 1.0
     
     # 5Hz 语言模型参数
@@ -378,6 +379,7 @@ class FormatSampleResult:
 | `audio_codes` | `str` | `""` | 预提取的 5Hz 音频语义代码字符串。仅供高级使用。|
 | `repainting_start` | `float` | `0.0` | 重绘开始时间（秒）（用于 repaint/lego 任务）。|
 | `repainting_end` | `float` | `-1` | 重绘结束时间（秒）。使用 `-1` 表示音频末尾。|
+| `chunk_mask_mode` | `str` | `"auto"` | 分块掩码控制模式。使用 `"explicit"` 将根据 `repainting_start`/`repainting_end` 生成的 0/1 掩码传给模型；`"auto"` 使用自动分块控制。|
 | `audio_cover_strength` | `float` | `1.0` | 音频 cover/代码影响强度（0.0-1.0）。风格迁移任务设置较小值（0.2）。|
 
 ### 5Hz 语言模型参数
@@ -505,9 +507,13 @@ params = GenerationParams(
     src_audio="original.mp3",
     repainting_start=10.0,  # 秒
     repainting_end=20.0,    # 秒
+    chunk_mask_mode="explicit",
     caption="带钢琴独奏的平滑过渡",
 )
 ```
+
+当所选 Repaint 区间必须作为模型分块掩码传入时，请使用
+`chunk_mask_mode="explicit"`。Gradio Repaint 会自动选择该模式。
 
 **必需**：
 - `src_audio`：源音频文件路径


### PR DESCRIPTION
## Summary

Fixes #1291.

Gradio Repaint collects an exact `repainting_start` / `repainting_end` interval, but its `GenerationParams` construction omitted `chunk_mask_mode` and therefore used the global `"auto"` default.

This PR makes the Gradio Repaint path pass `chunk_mask_mode="explicit"`, so the selected interval is used as the model-facing 0/1 chunk mask. All other Gradio tasks retain `"auto"`.

## Root cause

The UI mapped the selected generation mode to `task_type="repaint"`, but it did not map that task type to the matching chunk-mask control. `GenerationParams` silently fell back to its global default.

## Scope

Changed:

- Add a focused Gradio task-type resolver: `repaint -> explicit`, all other task types -> `auto`.
- Pass the resolved mode into `GenerationParams` in `generate_with_progress()`.
- Add success and non-target regression tests.
- Document `chunk_mask_mode` and use `explicit` in the English and Chinese Repaint inference/API examples.

Out of scope:

- The `GenerationParams` and HTTP API defaults remain `"auto"`.
- Core chunk-mask construction and `auto` sentinel handling are unchanged.
- Repaint source injection, boundary blending, waveform splicing, model code, and hardware-specific paths are unchanged.

## User impact

Selecting Repaint in Gradio now automatically uses the explicit mask derived from the chosen start/end interval. Python and HTTP API callers can continue choosing either mode directly.

## Regression checks

Checks run locally:

```bash
python -m unittest \
  acestep.ui.gradio.events.results.generation_task_type_test \
  acestep.core.generation.handler.conditioning_masks_test
# Ran 16 tests: OK

python -m unittest discover \
  -s acestep/ui/gradio/events/results \
  -p "*_test.py"
# Ran 98 tests: OK

python -m compileall -q \
  acestep/ui/gradio/events/results/generation_task_type.py \
  acestep/ui/gradio/events/results/generation_progress.py

git diff --check
```

No checkpoint was needed because this is deterministic UI parameter routing, covered by focused unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-aware chunk masking for generation, using explicit masking for Repaint tasks and automatic masking elsewhere.
  * Added the `chunk_mask_mode` parameter, supporting `auto` and `explicit` modes.

* **Documentation**
  * Updated English and Chinese API and inference guides with parameter details and revised Repaint examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
