### PR TITLE
fix(api): run lazy model init on executor to keep event loop responsive

### DIFF
--- a/acestep/api/job_runtime_state.py
+++ b/acestep/api/job_runtime_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any, Optional
 
@@ -14,6 +15,10 @@ async def ensure_models_initialized(app_state: Any) -> None:
     If models were already loaded at startup (``ACESTEP_NO_INIT=false``), this
     returns immediately.  Otherwise it performs on-demand initialization using
     the kwargs stored on ``app_state._model_init_kwargs`` during lifespan setup.
+
+    Initialization runs on ``app_state.executor`` rather than inline: it is
+    slow, blocking work that would otherwise freeze the event loop and hang
+    every other in-flight request (e.g. ``/health``) until it finishes.
 
     Args:
         app_state: Application state object containing initialization flags.
@@ -58,7 +63,11 @@ async def ensure_models_initialized(app_state: Any) -> None:
             def __init__(self, state: Any) -> None:
                 self.state = state
 
-        do_model_initialization(app=_AppProxy(app_state), **init_kwargs)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            app_state.executor,
+            lambda: do_model_initialization(app=_AppProxy(app_state), **init_kwargs),
+        )
 
 
 async def cleanup_job_temp_files(app_state: Any, job_id: str) -> None:

--- a/acestep/api/job_runtime_state_test.py
+++ b/acestep/api/job_runtime_state_test.py
@@ -95,6 +95,7 @@ class JobRuntimeStateTests(unittest.IsolatedAsyncioTestCase):
         init_threads: list[threading.Thread] = []
 
         def _blocking_init(*_args: object, **_kwargs: object) -> None:
+            """Record the calling thread, then block until the event loop sets the event."""
             init_threads.append(threading.current_thread())
             if not loop_alive_during_init.wait(timeout=0.5):
                 raise RuntimeError(

--- a/acestep/api/job_runtime_state_test.py
+++ b/acestep/api/job_runtime_state_test.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -49,11 +51,14 @@ class JobRuntimeStateTests(unittest.IsolatedAsyncioTestCase):
 
         handler = MagicMock()
         handler.initialize_service.return_value = ("ok", True)
+        executor = ThreadPoolExecutor(max_workers=1)
+        self.addCleanup(executor.shutdown, wait=False)
 
         app_state = SimpleNamespace(
             _init_error=None,
             _initialized=False,
             _init_lock=asyncio.Lock(),
+            executor=executor,
             _model_init_kwargs=dict(
                 handler=handler,
                 llm_handler=MagicMock(),
@@ -75,6 +80,66 @@ class JobRuntimeStateTests(unittest.IsolatedAsyncioTestCase):
         with patch("acestep.api.startup_model_init.do_model_initialization") as mock_init:
             await ensure_models_initialized(app_state)
             mock_init.assert_called_once()
+
+    async def test_ensure_models_initialized_does_not_block_event_loop(self) -> None:
+        """Regression for the blocking-init bug: the fake init blocks on a
+        ``threading.Event`` that only this coroutine -- running on the event
+        loop -- can set. If init were executed inline on the loop, ``set()``
+        could never run before init finishes (the loop's single thread would
+        be stuck inside ``wait()``), so ``wait()`` would time out and init
+        would raise. Deterministic in both directions: no timing race.
+        """
+
+        loop_thread = threading.current_thread()
+        loop_alive_during_init = threading.Event()
+        init_threads: list[threading.Thread] = []
+
+        def _blocking_init(*_args: object, **_kwargs: object) -> None:
+            init_threads.append(threading.current_thread())
+            if not loop_alive_during_init.wait(timeout=0.5):
+                raise RuntimeError(
+                    "event loop never ran while model initialization was in "
+                    "flight -- do_model_initialization is not actually being "
+                    "offloaded to a thread"
+                )
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        self.addCleanup(executor.shutdown, wait=False)
+
+        app_state = SimpleNamespace(
+            _init_error=None,
+            _initialized=False,
+            _init_lock=asyncio.Lock(),
+            executor=executor,
+            _model_init_kwargs=dict(
+                handler=MagicMock(),
+                llm_handler=MagicMock(),
+                handler2=None,
+                handler3=None,
+                config_path2="",
+                config_path3="",
+                get_project_root=MagicMock(return_value="/repo"),
+                get_model_name=MagicMock(return_value="acestep-v15-turbo"),
+                ensure_model_downloaded=MagicMock(),
+                env_bool=lambda _name, default: default,
+            ),
+            gpu_config=SimpleNamespace(gpu_memory_gb=24.0, tier="high"),
+        )
+
+        with patch(
+            "acestep.api.startup_model_init.do_model_initialization", _blocking_init
+        ):
+            init_task = asyncio.create_task(ensure_models_initialized(app_state))
+            await asyncio.sleep(0)  # let the init task start
+            loop_alive_during_init.set()  # only reachable if the loop stayed free
+            await init_task
+
+        self.assertIsNot(
+            init_threads[0],
+            loop_thread,
+            "do_model_initialization ran on the event-loop thread instead of "
+            "a worker thread",
+        )
 
     async def test_cleanup_job_temp_files_removes_tracked_paths(self) -> None:
         """Cleanup helper should remove tracked files and clear job mapping."""


### PR DESCRIPTION
ensure_models_initialized() called do_model_initialization() synchronously inside an async def while holding the init lock, blocking the single-threaded event loop for the full duration of model loading (DiT load, LM tokenizer, vLLM torch.compile warm-up — 60-120+ s on 8GB-tier GPUs). Every other in-flight request, including GET /health and POST /query_result, hung until init finished, making the server indistinguishable from an unreachable one.

Offload the call to app.state.executor via loop.run_in_executor(), the same pattern job_execution_runtime.py already uses for generation. The _init_lock / double-check / _init_error semantics are unchanged: state flags are set inside do_model_initialization itself, and concurrent callers still wait on the async lock — but the event loop stays free.

Add a deterministic regression test: the fake init blocks in the worker thread on a threading.Event that only the event loop can set, so inline (blocking) execution deadlocks and times out while offloaded execution completes immediately; also asserts init ran off the loop thread.

Fixes #1281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness during model initialization by preventing blocking work from freezing the event loop.
  * Model setup now runs safely in the background, allowing other asynchronous tasks to continue without interruption.

* **Tests**
  * Added coverage confirming initialization runs outside the event-loop thread and remains non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->