### PR TITLE
fix(deps): align torchao constraint in requirements.txt with pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,12 @@ uvicorn[standard]>=0.27.0
 numba>=0.63.1
 vector-quantize-pytorch>=1.27.15
 torchcodec>=0.9.1; platform_machine != 'aarch64'
-torchao
+# Must match pyproject.toml. Unpinned, this resolves to torchao 0.18.x, which
+# imports torch.nn.functional.ScalingType -- a symbol that does not exist in the
+# torch 2.7.1+cu128 build pinned above for Windows. The model then fails to load
+# with "cannot import name 'ScalingType'". Keep these two declarations aligned.
+torchao>=0.16.0,<0.17.0; platform_machine != 'aarch64'
+torchao; platform_machine == 'aarch64'
 toml
 modelscope
 


### PR DESCRIPTION
## Align the `torchao` constraint in `requirements.txt` with `pyproject.toml`

`requirements.txt` declares `torchao` unpinned, while `pyproject.toml` declares:

```
torchao>=0.16.0,<0.17.0; platform_machine != 'aarch64'
torchao; platform_machine == 'aarch64'
```

A fresh `pip install -r requirements.txt` on Windows therefore resolves `torchao 0.18.0`, while the same file pins `torch==2.7.1+cu128` for `sys_platform == 'win32'`. `torchao 0.18.x` imports `ScalingType` from `torch.nn.functional`, which does not exist in torch 2.7.1, so model loading fails:

```
File ".../torchao/quantization/quantize_/workflows/float8/float8_tensor.py", line 12
    from torch.nn.functional import ScalingType, scaled_grouped_mm
ImportError: cannot import name 'ScalingType' from 'torch.nn.functional'

RuntimeError: Failed to load model with attention implementations ['sdpa', 'eager']:
cannot import name 'ScalingType' from 'torch.nn.functional'
```

Installing the range already declared in `pyproject.toml` (`torchao 0.16.0`) restores loading, with no other change.

### Reproduction

| | |
|---|---|
| base commit | `6d467e4b5081ccb0abf1ec1bf4fdf9051a2d34b0` |
| OS | Windows |
| Python | 3.12.10 |
| torch | `2.7.1+cu128` (as pinned for win32) |
| torchao resolved before | `0.18.0` → model load fails |
| torchao resolved after | `0.16.0` → model load succeeds |

Verified in a clean virtual environment created from scratch and installed only from `requirements.txt`:

- **before the change** — `torchao 0.18.0` resolved; DiT checkpoint load raised the `ScalingType` `ImportError` above.
- **after the change** — `torchao 0.16.0` resolved; `import torchao` and `import torchao.quantization` succeed, the released DiT checkpoint loads cleanly on CUDA, and generation runs to completion.

Two seeded generations in that clean environment produced decoded audio identical to the same seeded request in a separately built environment, so the change does not perturb generation behaviour.

### Note

`torchao 0.16.0` emits a compatibility advisory against torch 2.7.1 referencing pytorch/ao#2919. It is advisory only; `torchao.quantization` imports and the model loads and generates.

### Change

Only the two `torchao` environment markers, mirroring `pyproject.toml`, plus a comment recording why the two declarations must stay aligned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform-specific compatibility requirements for the `torchao` package.
  * Added support for newer compatible versions on non-ARM64 platforms.
  * Preserved existing ARM64 installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->