### PR TITLE
fix(training): encode lyrics in the inference prompt format

### DIFF
--- a/acestep/constants.py
+++ b/acestep/constants.py
@@ -167,6 +167,14 @@ SFT_GEN_PROMPT = """# Instruction
 {}<|endoftext|>
 """
 
+# Template for the DiT lyric branch, formatted with (vocal_language, lyrics).
+# Shared by inference and training preprocessing so both encode lyrics into the
+# same token sequence. The leading header shifts every lyric token, and the
+# trailing terminator is what `_extract_lyric_segment` searches for to find the
+# end of the sung range, so a mismatch between the two paths misaligns lyrics
+# against the audio timeline.
+LYRIC_GEN_PROMPT = "# Languages\n{}\n\n# Lyric\n{}<|endoftext|>"
+
 
 # ==============================================================================
 # GPU Memory Configuration Constants

--- a/acestep/core/generation/handler/prompt_utils.py
+++ b/acestep/core/generation/handler/prompt_utils.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 from loguru import logger
 
-from acestep.constants import DEFAULT_DIT_INSTRUCTION, SFT_GEN_PROMPT
+from acestep.constants import DEFAULT_DIT_INSTRUCTION, LYRIC_GEN_PROMPT, SFT_GEN_PROMPT
 
 
 class PromptMixin:
@@ -26,7 +26,7 @@ class PromptMixin:
 
     def _format_lyrics(self, lyrics: str, language: str) -> str:
         """Format lyrics text with language header."""
-        return f"# Languages\n{language}\n\n# Lyric\n{lyrics}<|endoftext|>"
+        return LYRIC_GEN_PROMPT.format(language, lyrics)
 
     def _pad_sequences(
         self, sequences: List[torch.Tensor], max_length: int, pad_value: int = 0

--- a/acestep/training/dataset_builder_modules/preprocess.py
+++ b/acestep/training/dataset_builder_modules/preprocess.py
@@ -186,7 +186,7 @@ class PreprocessMixin:
                     lyrics = sample.lyrics if sample.lyrics else "[Instrumental]"
                     t0 = debug_start_verbose_for("dataset", f"encode_lyrics[{i}]")
                     lyric_hidden_states, lyric_attention_mask = encode_lyrics(
-                        text_encoder, text_tokenizer, lyrics, device, dtype
+                        text_encoder, text_tokenizer, lyrics, sample.language, device, dtype
                     )
                     debug_end_verbose_for("dataset", f"encode_lyrics[{i}]", t0)
                     debug_log_verbose_for(

--- a/acestep/training/dataset_builder_modules/preprocess_lyrics.py
+++ b/acestep/training/dataset_builder_modules/preprocess_lyrics.py
@@ -1,12 +1,46 @@
+"""Lyric encoding for dataset preprocessing.
+
+Encodes lyrics into the same token sequence the inference lyric branch builds,
+so an adapter trained on these tensors sees the prompt shape it is later
+generated with.
+"""
+
 import torch
 
+from acestep.constants import LYRIC_GEN_PROMPT
 
-def encode_lyrics(text_encoder, text_tokenizer, lyrics: str, device, dtype):
-    """Encode lyrics into hidden states."""
+# Matches the inference lyric branch (``_prepare_text_conditioning_inputs``).
+LYRIC_MAX_LENGTH = 2048
+
+
+def encode_lyrics(
+    text_encoder,
+    text_tokenizer,
+    lyrics: str,
+    vocal_language: str,
+    device,
+    dtype,
+):
+    """Encode lyrics into hidden states using the inference prompt format.
+
+    Args:
+        text_encoder: Text encoder providing the ``embed_tokens`` table.
+        text_tokenizer: Tokenizer shared with the caption branch.
+        lyrics: Raw lyric text, or ``"[Instrumental]"``.
+        vocal_language: Language code for the prompt header, e.g. ``"pa"``.
+            Required so a call site cannot silently omit the header and
+            reintroduce a train/inference offset.
+        device: Device to place the token tensors on.
+        dtype: Target dtype for the returned hidden states and mask.
+
+    Returns:
+        Tuple of ``(lyric_hidden_states, lyric_attention_mask)``.
+    """
+    lyric_prompt = LYRIC_GEN_PROMPT.format(vocal_language, lyrics)
     lyric_inputs = text_tokenizer(
-        lyrics,
-        padding="max_length",
-        max_length=512,
+        lyric_prompt,
+        padding="longest",
+        max_length=LYRIC_MAX_LENGTH,
         truncation=True,
         return_tensors="pt",
     )

--- a/acestep/training/dataset_builder_modules/preprocess_lyrics_test.py
+++ b/acestep/training/dataset_builder_modules/preprocess_lyrics_test.py
@@ -1,0 +1,135 @@
+"""Tests that training encodes lyrics into the inference prompt shape.
+
+Training previously tokenized bare lyrics while inference prepended
+``# Languages\\n{lang}\\n\\n# Lyric\\n`` and appended ``<|endoftext|>``. Every
+lyric token therefore sat at a different sequence position during training than
+at generation, and no terminator was ever learned.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+try:
+    import torch
+
+    from acestep.constants import LYRIC_GEN_PROMPT
+    from acestep.core.generation.handler.prompt_utils import PromptMixin
+    from acestep.training.dataset_builder_modules.preprocess_lyrics import (
+        LYRIC_MAX_LENGTH,
+        encode_lyrics,
+    )
+
+    _IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover
+    torch = None
+    LYRIC_GEN_PROMPT = None
+    LYRIC_MAX_LENGTH = None
+    PromptMixin = None
+    encode_lyrics = None
+    _IMPORT_ERROR = exc
+
+
+def _fake_tokenizer(captured):
+    """Build a tokenizer stub that records the text it was asked to encode."""
+
+    def tokenize(text, **kwargs):
+        captured["text"] = text
+        captured["kwargs"] = kwargs
+        return MagicMock(
+            input_ids=torch.tensor([[1, 2, 3]]),
+            attention_mask=torch.tensor([[1, 1, 1]]),
+        )
+
+    return tokenize
+
+
+def _fake_encoder():
+    """Build a text-encoder stub exposing a device and an embedding table."""
+    encoder = MagicMock()
+    encoder.parameters.return_value = iter([torch.zeros(1)])
+    encoder.embed_tokens.return_value = torch.zeros(1, 3, 8)
+    return encoder
+
+
+@unittest.skipIf(encode_lyrics is None, f"import unavailable: {_IMPORT_ERROR}")
+class LyricPromptParityTests(unittest.TestCase):
+    """Training and inference must build one identical lyric prompt."""
+
+    def test_training_prompt_matches_inference_prompt(self):
+        """encode_lyrics tokenizes exactly what _format_lyrics produces."""
+        captured = {}
+        encode_lyrics(
+            _fake_encoder(), _fake_tokenizer(captured), "Sohniye", "pa",
+            torch.device("cpu"), torch.float32,
+        )
+
+        expected = PromptMixin._format_lyrics(None, "Sohniye", "pa")
+        self.assertEqual(captured["text"], expected)
+
+    def test_training_prompt_carries_header_and_terminator(self):
+        """The encoded text has the language header and the lyric terminator."""
+        captured = {}
+        encode_lyrics(
+            _fake_encoder(), _fake_tokenizer(captured), "Sohniye", "pa",
+            torch.device("cpu"), torch.float32,
+        )
+
+        self.assertTrue(captured["text"].startswith("# Languages\npa\n\n# Lyric\n"))
+        self.assertTrue(captured["text"].endswith("<|endoftext|>"))
+
+    def test_training_truncation_matches_inference(self):
+        """Lyrics are truncated at the inference budget, not the old 512."""
+        captured = {}
+        encode_lyrics(
+            _fake_encoder(), _fake_tokenizer(captured), "la la", "hi",
+            torch.device("cpu"), torch.float32,
+        )
+
+        self.assertEqual(LYRIC_MAX_LENGTH, 2048)
+        self.assertEqual(captured["kwargs"]["max_length"], 2048)
+        self.assertTrue(captured["kwargs"]["truncation"])
+
+    def test_instrumental_lyrics_still_get_a_header(self):
+        """Instrumental samples are formatted the same way, not special-cased."""
+        captured = {}
+        encode_lyrics(
+            _fake_encoder(), _fake_tokenizer(captured), "[Instrumental]", "unknown",
+            torch.device("cpu"), torch.float32,
+        )
+
+        self.assertEqual(
+            captured["text"], "# Languages\nunknown\n\n# Lyric\n[Instrumental]<|endoftext|>"
+        )
+
+
+@unittest.skipIf(LYRIC_GEN_PROMPT is None, f"import unavailable: {_IMPORT_ERROR}")
+class LyricTemplateContractTests(unittest.TestCase):
+    """Pin the template's exact bytes.
+
+    ``_extract_lyric_segment`` derives the start of the sung range from the
+    header's token length and the end from ``<|endoftext|>``, so changing these
+    bytes silently misaligns lyric timestamping and scoring.
+    """
+
+    def test_format_lyrics_output_is_unchanged(self):
+        """Rendering matches the literal inference used before the refactor."""
+        self.assertEqual(
+            PromptMixin._format_lyrics(None, "line one", "pa"),
+            "# Languages\npa\n\n# Lyric\nline one<|endoftext|>",
+        )
+
+    def test_alignment_header_is_a_prefix_of_the_template(self):
+        """The offset header in lyric_alignment_common still matches."""
+        alignment_header = f"# Languages\n{'pa'}\n\n# Lyric\n"
+        self.assertTrue(LYRIC_GEN_PROMPT.format("pa", "x").startswith(alignment_header))
+
+    def test_braces_in_lyrics_survive_formatting(self):
+        """Lyrics are a format argument, so braces are not interpreted."""
+        self.assertEqual(
+            PromptMixin._format_lyrics(None, "oh {yeah} {0}", "pa"),
+            "# Languages\npa\n\n# Lyric\noh {yeah} {0}<|endoftext|>",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/training_v2/preprocess.py
+++ b/acestep/training_v2/preprocess.py
@@ -272,7 +272,7 @@ def _pass1_light(
                         text_enc, tokenizer, text_prompt, device, dtype
                     )
                     lyric_hs, lyric_mask = encode_lyrics(
-                        text_enc, tokenizer, lyrics, device, dtype
+                        text_enc, tokenizer, lyrics, sm.get("language", "unknown"), device, dtype
                     )
 
                 # 4. Save intermediate

--- a/acestep/training_v2/preprocess_discovery.py
+++ b/acestep/training_v2/preprocess_discovery.py
@@ -136,6 +136,7 @@ def load_sample_metadata(
                 "keyscale": "",
                 "timesignature": "",
                 "duration": 0,
+                "language": "unknown",
                 "is_instrumental": True,
             }
 


### PR DESCRIPTION
Inference builds the lyric branch as
`# Languages\n{lang}\n\n# Lyric\n{lyrics}<|endoftext|>` (`_format_lyrics`), but `encode_lyrics` tokenized bare lyrics. Two consequences for any adapter fine-tuned through this pipeline:

- Every lyric token sat ~10 positions earlier during training than at generation. `_extract_lyric_segment` derives the start of the sung range from the header's token length, so position inside the lyric sequence is how lyrics are tied to the audio timeline; a constant offset smears that mapping. The caption/metas branch is a separate encoder input and was already consistent, which is why symptoms show up in vocals and not in beats or key.
- No `<|endoftext|>` was ever inserted, so no lyric terminator was learned, though the alignment code searches for that token to find where singing ends.

The template moves to `acestep.constants.LYRIC_GEN_PROMPT`, beside the `SFT_GEN_PROMPT` that both paths already share, and `_format_lyrics` renders it. `encode_lyrics` takes a required `vocal_language` so a call site cannot silently omit the header again. `max_length` goes 512 -> 2048 to match inference and stop silently truncating long lyrics.

`padding` moves "max_length" -> "longest" to match inference. This is semantically neutral: `pack_sequences` left-packs valid tokens by mask and takes the length from `mask.sum()`, so padding width never reached the model. It avoids quadrupling the cached tensors that raising max_length would otherwise cause.

Non-target paths unchanged: `_format_lyrics` output is byte-identical to the previous literal (pinned by test), so inference, lyric timestamping and lyric scoring are unaffected. No hardware/runtime code is touched.

NOTE: this changes what preprocessed `.pt` tensors contain. Existing preprocessed datasets must be rebuilt and adapters retrained; stale caches produce no error, only the old mismatched conditioning.

Validation: 1211 tests / 7 failures / 24 errors on upstream/main, 1218 / 7 / 24 here, the +7 being the new tests. Pre-existing failures are in the gradio UI, mlx and cfg_scale modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lyric prompts are now formatted consistently during training and generation.
  * Vocal language is included when encoding lyrics, with “unknown” used when language metadata is unavailable.
  * Lyric processing now supports up to 2,048 tokens with truncation, improving handling of longer lyrics.
  * Instrumental and language-specific lyric inputs follow the same formatting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->