### PR TITLE
fix(generation): neutralize cover-only params for non-cover tasks

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -296,8 +296,9 @@ class GenerateMusicMixin:
             instruction=instruction,
         )
 
-        # Drop stale cover-only params (e.g. leaked from a Remix session) for non-cover tasks;
-        # all entry points (single/batch/API) pass through here (issue #1271).
+        # Neutralize stale cover-only params for text2music; preserve them for
+        # source-audio tasks. All entry points (single/batch/API) pass through
+        # here (issue #1271).
         audio_cover_strength, cover_noise_strength = self._neutralize_cover_only_params(
             task_type=task_type,
             audio_cover_strength=audio_cover_strength,

--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -296,6 +296,14 @@ class GenerateMusicMixin:
             instruction=instruction,
         )
 
+        # Drop stale cover-only params (e.g. leaked from a Remix session) for non-cover tasks;
+        # all entry points (single/batch/API) pass through here (issue #1271).
+        audio_cover_strength, cover_noise_strength = self._neutralize_cover_only_params(
+            task_type=task_type,
+            audio_cover_strength=audio_cover_strength,
+            cover_noise_strength=cover_noise_strength,
+        )
+
         # Turbo models bake guidance into the distillation process and do not
         # use CFG.  Forcing guidance_scale to 1.0 avoids double-application of
         # guidance that produces noise or NaN/Inf on float16 (see issue #927).

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -55,6 +55,25 @@ class GenerateMusicRequestMixin:
             return "cover", TASK_INSTRUCTIONS["cover"]
         return task_type, instruction
 
+    def _neutralize_cover_only_params(
+        self,
+        task_type: str,
+        audio_cover_strength: float,
+        cover_noise_strength: float,
+    ) -> Tuple[float, float]:
+        """Reset cover-only params to their neutral defaults for non-cover tasks.
+
+        Stale UI state (e.g. after a Remix session) can leak a non-zero
+        ``cover_noise_strength`` into ``text2music`` and produce full-duration
+        noise (issue #1271). Run after ``_resolve_generate_music_task`` so the
+        audio-codes auto-switch to ``cover`` is preserved.
+        """
+        if task_type in ("cover", "cover-nofsq"):
+            return audio_cover_strength, cover_noise_strength
+        if audio_cover_strength != 1.0 or cover_noise_strength != 0.0:
+            logger.info("[generate_music] Neutralizing cover-only params for task_type={!r}", task_type)
+        return 1.0, 0.0
+
     def _prepare_generate_music_runtime(
         self,
         batch_size: Optional[int],

--- a/acestep/core/generation/handler/generate_music_request.py
+++ b/acestep/core/generation/handler/generate_music_request.py
@@ -61,14 +61,20 @@ class GenerateMusicRequestMixin:
         audio_cover_strength: float,
         cover_noise_strength: float,
     ) -> Tuple[float, float]:
-        """Reset cover-only params to their neutral defaults for non-cover tasks.
+        """Reset cover-only params to their neutral defaults for text2music.
 
         Stale UI state (e.g. after a Remix session) can leak a non-zero
         ``cover_noise_strength`` into ``text2music`` and produce full-duration
-        noise (issue #1271). Run after ``_resolve_generate_music_task`` so the
-        audio-codes auto-switch to ``cover`` is preserved.
+        noise, because ``text2music`` is the only task type whose source
+        latent is silence rather than real audio content (issue #1271).
+        Every other task type (cover, cover-nofsq, repaint, lego, extract,
+        complete) operates on real source audio/codes, where these params
+        are meaningful, documented controls -- not just cover leftovers --
+        so they must be left untouched. Run after
+        ``_resolve_generate_music_task`` so the audio-codes auto-switch to
+        ``cover`` is preserved.
         """
-        if task_type in ("cover", "cover-nofsq"):
+        if task_type != "text2music":
             return audio_cover_strength, cover_noise_strength
         if audio_cover_strength != 1.0 or cover_noise_strength != 0.0:
             logger.info("[generate_music] Neutralizing cover-only params for task_type={!r}", task_type)

--- a/acestep/core/generation/handler/generate_music_request_test.py
+++ b/acestep/core/generation/handler/generate_music_request_test.py
@@ -47,6 +47,28 @@ class GenerateMusicRequestMixinTests(unittest.TestCase):
         self.assertEqual(task, "cover")
         self.assertNotEqual(instruction, "old")
 
+    def test_neutralize_cover_params_reset_for_non_cover_tasks(self):
+        """Non-cover tasks must drop leaked cover params to neutral (issue #1271)."""
+        host = _Host()
+        for task in ("text2music", "repaint", "lego", "extract"):
+            strength, noise = host._neutralize_cover_only_params(
+                task_type=task,
+                audio_cover_strength=0.0,
+                cover_noise_strength=0.2,
+            )
+            self.assertEqual((strength, noise), (1.0, 0.0), task)
+
+    def test_neutralize_cover_params_preserved_for_cover_tasks(self):
+        """Cover tasks must keep their cover conditioning params."""
+        host = _Host()
+        for task in ("cover", "cover-nofsq"):
+            strength, noise = host._neutralize_cover_only_params(
+                task_type=task,
+                audio_cover_strength=0.3,
+                cover_noise_strength=0.15,
+            )
+            self.assertEqual((strength, noise), (0.3, 0.15), task)
+
     def test_prepare_runtime_normalizes_batch_and_duration(self):
         """Runtime helper should clamp batch floor and normalize invalid duration/end values."""
         host = _Host()

--- a/acestep/core/generation/handler/generate_music_request_test.py
+++ b/acestep/core/generation/handler/generate_music_request_test.py
@@ -47,21 +47,25 @@ class GenerateMusicRequestMixinTests(unittest.TestCase):
         self.assertEqual(task, "cover")
         self.assertNotEqual(instruction, "old")
 
-    def test_neutralize_cover_params_reset_for_non_cover_tasks(self):
-        """Non-cover tasks must drop leaked cover params to neutral (issue #1271)."""
+    def test_neutralize_cover_params_reset_for_text2music(self):
+        """text2music must drop leaked cover params to neutral (issue #1271)."""
         host = _Host()
-        for task in ("text2music", "repaint", "lego", "extract"):
-            strength, noise = host._neutralize_cover_only_params(
-                task_type=task,
-                audio_cover_strength=0.0,
-                cover_noise_strength=0.2,
-            )
-            self.assertEqual((strength, noise), (1.0, 0.0), task)
+        strength, noise = host._neutralize_cover_only_params(
+            task_type="text2music",
+            audio_cover_strength=0.0,
+            cover_noise_strength=0.2,
+        )
+        self.assertEqual((strength, noise), (1.0, 0.0))
 
-    def test_neutralize_cover_params_preserved_for_cover_tasks(self):
-        """Cover tasks must keep their cover conditioning params."""
+    def test_neutralize_cover_params_preserved_for_src_audio_tasks(self):
+        """Tasks operating on real source audio/codes must keep their params.
+
+        Only text2music lacks real source content (it runs on a silence
+        latent); every other task type -- including repaint/lego/extract/
+        complete, not just cover -- must be unaffected by this guard.
+        """
         host = _Host()
-        for task in ("cover", "cover-nofsq"):
+        for task in ("cover", "cover-nofsq", "repaint", "lego", "extract", "complete"):
             strength, noise = host._neutralize_cover_only_params(
                 task_type=task,
                 audio_cover_strength=0.3,

--- a/acestep/core/generation/handler/generate_music_test.py
+++ b/acestep/core/generation/handler/generate_music_test.py
@@ -109,6 +109,13 @@ class _Host(GenerateMusicMixin):
         self.calls["_resolve_generate_music_task"] = kwargs
         return kwargs["task_type"], kwargs["instruction"]
 
+    def _neutralize_cover_only_params(self, **kwargs):
+        """Mirror ``GenerateMusicRequestMixin``'s text2music-only reset (issue #1271)."""
+        self.calls["_neutralize_cover_only_params"] = kwargs
+        if kwargs["task_type"] == "text2music":
+            return 1.0, 0.0
+        return kwargs["audio_cover_strength"], kwargs["cover_noise_strength"]
+
     def _prepare_generate_music_runtime(self, **kwargs):
         """Capture runtime args and return deterministic runtime state."""
         self.calls["_prepare_generate_music_runtime"] = kwargs

--- a/acestep/ui/gradio/events/generation/mode_ui.py
+++ b/acestep/ui/gradio/events/generation/mode_ui.py
@@ -56,7 +56,9 @@ def compute_mode_ui_updates(mode: str, llm_handler=None, previous_mode: str = "C
     if is_cover:
         strength_kwargs["value"] = 0.0
     strength_update = gr.update(**strength_kwargs)
-    cover_noise_update = gr.update(visible=is_cover, value=0.2) if is_cover else gr.update(visible=False)
+    # Reset the value (not just hide) when leaving cover mode so a stale
+    # cover_noise_strength cannot leak into text2music (issue #1271).
+    cover_noise_update = gr.update(visible=is_cover, value=0.2) if is_cover else gr.update(visible=False, value=0.0)
 
     # Think checkbox
     lm_initialized = llm_handler.llm_initialized if llm_handler else False


### PR DESCRIPTION
 ### Summary

  - Cover-only conditioning params (audio_cover_strength / cover_noise_strength) could leak from a Remix/Cover session
  into text2music via saved or stale UI state, producing full-duration noise regardless of prompt, lyrics, or seed (#1271).
  - Root cause: text2music is the only task type whose source latent is silence rather than real audio content. Blending
  noise toward a silence latent via cover_noise_strength never converges on an 8-step turbo schedule, producing steady
  noise.
  - Fix: reset both params to their neutral defaults (1.0 / 0.0) specifically when task_type == "text2music", in the shared generate_music handler used by every entry point (single/batch/API). Also reset the cover_noise_strength slider's displayed value (not just hide it) when leaving cover mode in the Gradio UI.

  ### Scope

  - Files changed: generate_music.py (call site), generate_music_request.py (_neutralize_cover_only_params helper), generate_music_request_test.py (unit tests), mode_ui.py (slider reset on mode switch).
  - Out of scope: any other task type's conditioning logic. cover, cover-nofsq, repaint, lego, extract, and complete are all left untouched by this guard, since they operate on real source audio/codes where these params are legitimate, documented controls, not cover leftovers.

  ### Risk and Compatibility

  - The guard triggers only for task_type == "text2music"; every other task type is unaffected — confirmed by unit test
  test_neutralize_cover_params_preserved_for_src_audio_tasks, which asserts pass-through for all six non-text2music task
  types.
  - Self-review note: an earlier version of this fix used an allow-list of ("cover", "cover-nofsq") instead of a
  deny-list of "text2music". That would have silently reset audio_cover_strength/cover_noise_strength for
  repaint/lego/extract/complete callers passing those params intentionally (e.g. via direct API use) — a regression
  outside the issue's scope. Caught during self-review before opening this PR and fixed by inverting the condition to target
  only text2music.
  - Non-target platforms/paths unchanged;  this is a pure request-normalization change; no CUDA/CPU/MPS-specific code
  touched.

  ### Regression Checks

  - `python -m unittest acestep.core.generation.handler.generate_music_request_test -v`   —  12/12 pass, including 2 tests covering both the text2music reset and the preserved-params case across all 6 non-text2music task types.
  - Traced modeling_acestep_v15_turbo.py / modeling_acestep_v15_base.py to confirm text2music is the only task type using a silence src_latents, which is the actual root cause of the reported noise.

  ### Reviewer Notes
  - Known minor issue, not addressed here: in mode_ui.py, leaving cover mode resets the cover_noise_strength slider's
  displayed value but not audio_cover_strength's (it's only forced to 0.0 on entering cover mode). This is cosmetic
  only; the backend guard already neutralizes the value at generation time regardless of what the slider displays,  so
  left as a follow-up rather than expanding this PR's scope.

  Fixes #1271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cover-specific settings from carrying over into text-to-music generation.
  * Reset cover noise strength to its neutral value when leaving Cover mode.
  * Preserved user-provided cover settings for supported workflows, including Cover, Cover No-FSQ, Repaint, Lego, Extract, and Complete modes.
  * Improved consistency when switching between generation modes, preventing stale settings from affecting new music generation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->