### PR TITLE
fix: _get_project_root() resolves two directories too shallow

### DIFF
--- a/acestep/ui/gradio/api/api_routes.py
+++ b/acestep/ui/gradio/api/api_routes.py
@@ -127,8 +127,14 @@ atexit.register(_close_result_cache)
 # =============================================================================
 
 def _get_project_root() -> str:
-    """Get project root directory"""
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+    """Get project root directory.
+
+    Returns:
+        Absolute path to the repository root, five directories up from
+        this file (acestep/ui/gradio/api/api_routes.py).
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_dir))))
 
 
 def _load_all_examples(sample_mode: str = "simple_mode") -> List[Dict[str, Any]]:

--- a/acestep/ui/gradio/api/api_routes.py
+++ b/acestep/ui/gradio/api/api_routes.py
@@ -128,7 +128,7 @@ atexit.register(_close_result_cache)
 
 def _get_project_root() -> str:
     """Get project root directory"""
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 
 
 def _load_all_examples(sample_mode: str = "simple_mode") -> List[Dict[str, Any]]:


### PR DESCRIPTION
### Summary
The randomize button (and /create_random_sample directly) always
fails with "No example data available". Turned out _get_project_root()
in api_routes.py only walks up 3 directories from api_routes.py's own
path, which puts you at acestep/ui, not the repo root. So it looks for
examples/simple_mode two levels short of where it actually lives, finds
nothing, and the example caches load empty at startup.

### Scope
One line, api_routes.py only. Nothing else touched.

### Risk and Compatibility
Just a dirname() count, no platform-specific logic involved. Doesn't
touch anything outside this one function.

### Regression Checks
- Confirmed the corrected path lands on the real repo root and
  examples/simple_mode is found there.
- File still compiles.
- /create_random_sample returns actual example data instead of erroring.

### Reviewer Notes
Nothing else needed here, self-contained fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the application’s project path resolution for clearer, more maintainable behavior.
  * No user-facing functionality or path resolution behavior has changed.
* **Documentation**
  * Expanded technical documentation for project root resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->