### PR TITLE
fix(ui): Fix Remix no_fsq control layout and tooltip clipping

### DIFF
--- a/acestep/ui/gradio/interfaces/__init__.py
+++ b/acestep/ui/gradio/interfaces/__init__.py
@@ -154,7 +154,9 @@ def create_gradio_interface(dit_handler, llm_handler, dataset_handler, init_para
         .accordion:has(.has-info-container),
         .tabs:has(.has-info-container),
         .gr-block:has(.has-info-container),
-        .gr-box:has(.has-info-container) {
+        .gr-box:has(.has-info-container),
+        .gr-group:has(.has-info-container),
+        .styler:has(.has-info-container) {
             overflow: visible !important;
             contain: none !important;
         }

--- a/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
+++ b/acestep/ui/gradio/interfaces/generation_tab_secondary_controls.py
@@ -18,38 +18,39 @@ def build_cover_strength_controls() -> dict[str, Any]:
         A component map containing audio/code strength sliders and remix help group.
     """
 
-    audio_cover_strength = gr.Slider(
-        minimum=0.0,
-        maximum=1.0,
-        value=1.0,
-        step=0.01,
-        label=t("generation.codes_strength_label"),
-        info=t("generation.codes_strength_info"),
-        elem_classes=["has-info-container"],
-        visible=True,
-    )
-    with gr.Group(visible=False) as remix_help_group:
+    with gr.Group(visible=False, elem_classes=["has-info-container"]) as remix_help_group:
         create_help_button("generation_remix")
+        audio_cover_strength = gr.Slider(
+            minimum=0.0,
+            maximum=1.0,
+            value=1.0,
+            step=0.01,
+            label=t("generation.codes_strength_label"),
+            info=t("generation.codes_strength_info"),
+            elem_classes=["has-info-container"],
+            visible=True,
+        )
+        cover_noise_strength = gr.Slider(
+            minimum=0.0,
+            maximum=1.0,
+            value=0.0,
+            step=0.01,
+            label=t("generation.cover_noise_strength_label"),
+            info=t("generation.cover_noise_strength_info"),
+            elem_classes=["has-info-container"],
+            visible=False,
+        )
         no_fsq = gr.Checkbox(
             label="no_fsq",
             value=False,
             info="Use source-audio latents directly instead of FSQ-quantized audio codes.",
+            elem_classes=["has-info-container"],
         )
-    cover_noise_strength = gr.Slider(
-        minimum=0.0,
-        maximum=1.0,
-        value=0.0,
-        step=0.01,
-        label=t("generation.cover_noise_strength_label"),
-        info=t("generation.cover_noise_strength_info"),
-        elem_classes=["has-info-container"],
-        visible=False,
-    )
     return {
-        "audio_cover_strength": audio_cover_strength,
         "remix_help_group": remix_help_group,
-        "no_fsq": no_fsq,
+        "audio_cover_strength": audio_cover_strength,
         "cover_noise_strength": cover_noise_strength,
+        "no_fsq": no_fsq,
     }
 
 


### PR DESCRIPTION
## Problem
In the WebUI Remix mode, the `no_fsq` parameter renders incorrectly: it is wrapped in a very short scroll strip and its hover tooltip cannot display normally (it hides inside the scroll strip and requires scrolling to see). The root cause is that the Remix-only controls (help tutorial, mix strength, cover strength, no_fsq) are scattered across separate containers, and `gr.Group` / `.styler` are `overflow: hidden` by default, clipping the absolutely-positioned tooltip into a thin strip.

## Change
- Group the Remix-only controls (help tutorial, mix strength, cover strength, no_fsq) into a single `gr.Group`, laid out like the Custom tutorial: help `?` at the top, then 混音强度 / 翻唱强度 / no_fsq stacked below. These are Remix-only params now shown only in Remix mode.
- Add `.gr-group` and `.styler` to the `:has(.has-info-container)` overflow:visible rule so the no_fsq info tooltip is not clipped by the group's overflow-hidden boundary.

## Verification
- `acestep/ui/gradio/` contract tests pass. This is a pure UI layout/CSS change with no business logic, so no new assertion is strictly required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip visibility by preventing clipping across additional interface elements.
  * Improved the layout of remix controls so help information displays correctly alongside related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->