### PR TITLE
fix(flow-edit): Fix device mismatch when DiT offload meets flow-edit morph

### DIFF
--- a/acestep/core/generation/handler/service_generate_flow_edit.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit.py
@@ -165,20 +165,25 @@ def dispatch_flow_edit_overlay(
             )
 
     # Return target-side encoder/context for downstream auto-LRC + scoring.
-    attn = torch.ones(bsz, seq, device=device, dtype=dtype)
-    enc_hs, enc_am, ctx = handler.model.prepare_condition(
-        text_hidden_states=payload["text_hidden_states"],
-        text_attention_mask=payload["text_attention_mask"],
-        lyric_hidden_states=payload["lyric_hidden_states"],
-        lyric_attention_mask=payload["lyric_attention_mask"],
-        refer_audio_acoustic_hidden_states_packed=payload["refer_audio_acoustic_hidden_states_packed"],
-        refer_audio_order_mask=payload["refer_audio_order_mask"],
-        hidden_states=ctx_input,
-        attention_mask=attn,
-        silence_latent=handler.silence_latent,
-        src_latents=ctx_input,
-        chunk_masks=payload["chunk_mask"],
-        is_covers=is_covers_arg,
-        precomputed_lm_hints_25Hz=precomputed_lm_hints_arg,
-    )
+    # Reacquire the model context: under DiT-offload the whole model (incl.
+    # the condition encoder) was just offloaded back to CPU when the block
+    # above closed, but the input tensors (text_hidden_states, silence_latent)
+    # live on GPU — load it again for this call, else F.linear mismatches.
+    with handler._load_model_context("model"):
+        attn = torch.ones(bsz, seq, device=device, dtype=dtype)
+        enc_hs, enc_am, ctx = handler.model.prepare_condition(
+            text_hidden_states=payload["text_hidden_states"],
+            text_attention_mask=payload["text_attention_mask"],
+            lyric_hidden_states=payload["lyric_hidden_states"],
+            lyric_attention_mask=payload["lyric_attention_mask"],
+            refer_audio_acoustic_hidden_states_packed=payload["refer_audio_acoustic_hidden_states_packed"],
+            refer_audio_order_mask=payload["refer_audio_order_mask"],
+            hidden_states=ctx_input,
+            attention_mask=attn,
+            silence_latent=handler.silence_latent,
+            src_latents=ctx_input,
+            chunk_masks=payload["chunk_mask"],
+            is_covers=is_covers_arg,
+            precomputed_lm_hints_25Hz=precomputed_lm_hints_arg,
+        )
     return outputs, enc_hs, enc_am, ctx

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -27,19 +27,32 @@ class ModelContextTrackingHandler(FakeHandler):
     when prepare_condition runs — catches offload device mismatches."""
 
     def __init__(self, *args, **kwargs):
+        """Set up tracking state and wrap prepare_condition to log context depth.
+
+        The wrapped ``tracked`` appends whether the model context is currently
+        active (depth > 0) for the downstream prepare_condition call, so the
+        offload-path regression test can assert that call runs with the model
+        loaded onto the device.
+        """
         super().__init__(*args, **kwargs)
         self._model_ctx_depth = 0
         self.prepare_condition_model_ctx = []
         enc_hs, enc_am, ctx = self.prepared_enc_hs, self.prepared_enc_am, self.prepared_ctx
 
         def tracked(*args, **kwargs):
+            """Record context depth, then defer to the prepared condition tensors."""
             self.prepare_condition_model_ctx.append(self._model_ctx_depth > 0)
             return (enc_hs, enc_am, ctx)
 
         self.model.prepare_condition = tracked
 
     @contextmanager
-    def _load_model_context(self, name):
+    def _load_model_context(self, name: str):
+        """Teach this handler the real offload context depth tracking.
+
+        Mirrors the production ``_load_model_context`` (a no-op under the test
+        fake otherwise) so depth is visible inside ``prepare_condition``.
+        """
         if name == "model":
             self._model_ctx_depth += 1
         try:
@@ -173,14 +186,33 @@ class CoverStillRunsLmTests(unittest.TestCase):
     skipped because cover already extracts codes from the ref audio)."""
 
     def test_no_edit_in_skip_lm_tasks(self):
+        """skip_lm_tasks must keep cover as direct-conditioning and stay edit-free.
+
+        The literal set-based assertion was stale: inference.py now derives
+        skip_lm_tasks from DIRECT_CONDITIONING_TASKS, which gained complete/lego
+        in the direct-conditioning fix. Assert that contract instead of a frozen
+        source string, so this test does not rot again.
+        """
+        import re
         from pathlib import Path
+
         src = (Path(__file__).resolve().parents[3] / "inference.py").read_text()
-        self.assertIn(
-            'skip_lm_tasks = {"cover", "cover-nofsq", "repaint", "extract"}',
-            src,
-            "edit task is removed; skip_lm_tasks should no longer mention it",
-        )
-        self.assertNotIn('"edit"', src.split("skip_lm_tasks")[1].split("\n")[0])
+
+        # skip_lm_tasks is fed from DIRECT_CONDITIONING_TASKS, not a literal.
+        self.assertIn("skip_lm_tasks = DIRECT_CONDITIONING_TASKS", src)
+
+        # Pull the frozenset body and assert the intended membership.
+        block = src.split("DIRECT_CONDITIONING_TASKS = frozenset(", 1)[1]
+        body = block.split("}", 1)[0]
+        tasks = set(re.findall(r'"([^"]+)"', body))
+
+        self.assertIn("cover", tasks)
+        self.assertIn("cover-nofsq", tasks)
+        self.assertIn("complete", tasks)
+        self.assertIn("lego", tasks)
+        # A flow-edit task that reaches the LM is an overlay, not a direct
+        # condition — it must never be listed as a skip-LM task.
+        self.assertNotIn("edit", tasks)
 
 
 if __name__ == "__main__":

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -163,8 +163,8 @@ class FlowEditOverlayDispatchTests(unittest.TestCase):
             handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
             seed_param=None, flow_edit_ctx=make_flow_edit_ctx(),
         )
-        # dispatch 只直接调用一次 prepare_condition（下游那一次）；修复后它
-        # 必须在模型加载状态下执行，否则 offload 下 F.linear 会设备不匹配。
+        # Dispatch directly calls prepare_condition once (the downstream call).
+        # It must run while the model is loaded, or F.linear has a device mismatch.
         self.assertEqual(handler.prepare_condition_model_ctx, [True])
 
 

--- a/acestep/core/generation/handler/service_generate_flow_edit_test.py
+++ b/acestep/core/generation/handler/service_generate_flow_edit_test.py
@@ -8,6 +8,7 @@ the user's ``caption`` / ``lyrics`` are the *target*; the overlay adds a
 """
 
 import unittest
+from contextlib import contextmanager
 
 import torch
 
@@ -19,6 +20,33 @@ from acestep.core.generation.handler._flow_edit_dispatch_test_support import (
     make_flow_edit_ctx,
     make_payload,
 )
+
+
+class ModelContextTrackingHandler(FakeHandler):
+    """FakeHandler that records whether _load_model_context("model") is active
+    when prepare_condition runs — catches offload device mismatches."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._model_ctx_depth = 0
+        self.prepare_condition_model_ctx = []
+        enc_hs, enc_am, ctx = self.prepared_enc_hs, self.prepared_enc_am, self.prepared_ctx
+
+        def tracked(*args, **kwargs):
+            self.prepare_condition_model_ctx.append(self._model_ctx_depth > 0)
+            return (enc_hs, enc_am, ctx)
+
+        self.model.prepare_condition = tracked
+
+    @contextmanager
+    def _load_model_context(self, name):
+        if name == "model":
+            self._model_ctx_depth += 1
+        try:
+            yield
+        finally:
+            if name == "model":
+                self._model_ctx_depth -= 1
 
 
 class FlowEditOverlayDispatchTests(unittest.TestCase):
@@ -128,6 +156,16 @@ class FlowEditOverlayDispatchTests(unittest.TestCase):
         kwargs = handler.model.flowedit_generate_audio.call_args.kwargs
         self.assertEqual(kwargs["seed"], 42)
         self.assertEqual(kwargs["retake_seed"], [99, 100])
+
+    def test_offload_path_loads_model_for_downstream_prepare_condition(self):
+        handler = ModelContextTrackingHandler()
+        dispatch_flow_edit_overlay(
+            handler, payload=make_payload(), generate_kwargs={"infer_steps": 4},
+            seed_param=None, flow_edit_ctx=make_flow_edit_ctx(),
+        )
+        # dispatch 只直接调用一次 prepare_condition（下游那一次）；修复后它
+        # 必须在模型加载状态下执行，否则 offload 下 F.linear 会设备不匹配。
+        self.assertEqual(handler.prepare_condition_model_ctx, [True])
 
 
 class CoverStillRunsLmTests(unittest.TestCase):


### PR DESCRIPTION
## Problem
With "Offload DiT to CPU" enabled, the `flow_edit_morph=True` path calls the downstream `prepare_condition` (used for auto-LRC + scoring) outside the `_load_model_context("model")` block. At that point the whole model — including the condition encoder's `text_projector` — has already been offloaded back to CPU, while `text_hidden_states` / `silence_latent` remain on cuda:0, so `F.linear` raises a device mismatch. This only triggers on the `flow_edit_morph` path.

## Change
- Wrap the downstream `prepare_condition` (and `attn` construction) in a `_load_model_context("model")` block so the condition encoder and `silence_latent` are back on the device for that call.
- Add a regression test: `ModelContextTrackingHandler` tracks the `_load_model_context("model")` activation depth and asserts the downstream `prepare_condition` runs while the model is loaded.

## Verification
- `service_generate_flow_edit_test.py` passes, including the new offload regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow-edit audio generation when model offloading is enabled.
  * Ensured generated conditions are prepared correctly for text-to-music and cover workflows.

* **Tests**
  * Added coverage verifying that model resources are available during condition preparation.
  * Expanded task-selection coverage for supported cover, complete, and LEGO workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->