### PR TITLE
fix(llm): Fix LM engine memory leak on web UI service reinit

### DIFF
--- a/acestep/core/scoring/lm_score.py
+++ b/acestep/core/scoring/lm_score.py
@@ -168,22 +168,13 @@ def _temporary_unload_interactive_lm_for_scoring(llm_handler):
         return
 
     logger.info("[scoring] Temporarily unloading vLLM runtime for PMI scoring")
-    llm_runtime = llm_handler.llm
+    # unload() now performs a full engine teardown (exit()), releasing the model
+    # weights, KV cache, and CUDA graphs so the HF scorer has room (and so the
+    # subsequent initialize() restore does not leave a stale engine behind).
     try:
-        if hasattr(llm_runtime, "reset"):
-            llm_runtime.reset()
+        llm_handler.unload()
     except Exception as exc:
-        logger.warning("[scoring] vLLM reset during PMI offload failed: {}", exc)
-    try:
-        llm_handler._cleanup_torch_distributed_state()
-    except Exception as exc:
-        logger.warning("[scoring] vLLM distributed cleanup during PMI offload failed: {}", exc)
-    llm_handler.llm = None
-    llm_handler.llm_initialized = False
-    gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        logger.warning("[scoring] vLLM unload during PMI offload failed: {}", exc)
 
     try:
         yield

--- a/acestep/core/scoring/lm_score_test.py
+++ b/acestep/core/scoring/lm_score_test.py
@@ -54,6 +54,13 @@ class LmScoreMemoryCleanupTests(unittest.TestCase):
             _cleanup_torch_distributed_state=MagicMock(),
             initialize=MagicMock(return_value=("ok", True)),
         )
+        # Real unload() tears the engine down and resets the handler's state.
+        llm_handler.unload = MagicMock(
+            side_effect=lambda: (
+                setattr(llm_handler, "llm", None),
+                setattr(llm_handler, "llm_initialized", False),
+            )
+        )
 
         with (
             patch("torch.cuda.is_available", return_value=True),
@@ -64,7 +71,7 @@ class LmScoreMemoryCleanupTests(unittest.TestCase):
                 self.assertIsNone(llm_handler.llm)
                 self.assertFalse(llm_handler.llm_initialized)
 
-        runtime.reset.assert_called_once()
+        llm_handler.unload.assert_called_once()
         scorer.to.assert_called_once_with("cpu")
         self.assertIsNone(llm_handler._hf_model_for_scoring)
         llm_handler.initialize.assert_called_once_with(
@@ -84,6 +91,7 @@ class LmScoreMemoryCleanupTests(unittest.TestCase):
             _hf_model_for_scoring=None,
             _last_initialize_config={"checkpoint_dir": "/ckpt", "backend": "vllm"},
             _cleanup_torch_distributed_state=MagicMock(),
+            unload=MagicMock(),
             initialize=MagicMock(return_value=("restore failed", False)),
         )
 

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -129,8 +129,11 @@ class LLMHandler:
                 try:
                     if hasattr(self.llm, "exit"):
                         self.llm.exit()  # full teardown: weights/KV cache/CUDA graphs/subprocesses
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "[LLM unload] vllm engine exit() failed (continuing with cleanup): {}",
+                        exc,
+                    )
                 self._cleanup_torch_distributed_state()
                 # LLMEngine.__init__ registers self.exit in atexit. We already tore
                 # the engine down above, so deregister that callback to stop it from

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -126,28 +126,31 @@ class LLMHandler:
         """Release LM weights/tokenizer and clear caches to free memory."""
         try:
             if self.llm_backend == "vllm" and getattr(self, "llm", None) is not None:
+                exit_success = False
                 try:
                     if hasattr(self.llm, "exit"):
                         self.llm.exit()  # full teardown: weights/KV cache/CUDA graphs/subprocesses
+                        exit_success = True
                 except Exception as exc:
                     logger.warning(
                         "[LLM unload] vllm engine exit() failed (continuing with cleanup): {}",
                         exc,
                     )
                 self._cleanup_torch_distributed_state()
-                # LLMEngine.__init__ registers self.exit in atexit. We already tore
-                # the engine down above, so deregister that callback to stop it from
-                # re-running exit() on an already-released runner at process shutdown
-                # (which would otherwise log a harmless but noisy AttributeError).
+                # LLMEngine.__init__ registers self.exit in atexit. Only deregister that
+                # callback when teardown actually completed: if exit() raised, leave the
+                # callback registered so process shutdown can retry the unfinished cleanup
+                # (otherwise a released runner would log a noisy AttributeError on re-run).
                 try:
                     import atexit
-                    if hasattr(self.llm, "exit"):
+                    if exit_success and hasattr(self.llm, "exit"):
                         atexit.unregister(self.llm.exit)
                 except Exception:
                     pass
             self.llm = None
             self.llm_tokenizer = None
             self.constrained_processor = None
+            self._hf_model_for_scoring = None
             self.llm_initialized = False
             self.llm_backend = None
             self._mlx_model = None

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -122,8 +122,16 @@ class LLMHandler:
             if hasattr(torch.mps, "empty_cache"):
                 torch.mps.empty_cache()
 
-    def unload(self) -> None:
-        """Release LM weights/tokenizer and clear caches to free memory."""
+    def unload(self) -> bool:
+        """Release LM weights/tokenizer and clear caches to free memory.
+
+        Returns:
+            ``True`` when the process is safe to build a new engine (either no
+            vLLM engine was loaded, or its teardown completed), and ``False``
+            when an existing vLLM engine's ``exit()`` raised — the engine may not
+            have fully released weights/KV cache/CUDA graphs/workers, so callers
+            (``initialize``) must not build a replacement engine on top of it.
+        """
         try:
             if self.llm_backend == "vllm" and getattr(self, "llm", None) is not None:
                 exit_success = False
@@ -133,7 +141,7 @@ class LLMHandler:
                         exit_success = True
                 except Exception as exc:
                     logger.warning(
-                        "[LLM unload] vllm engine exit() failed (continuing with cleanup): {}",
+                        "[LLM unload] vllm engine exit() failed (teardown incomplete): {}",
                         exc,
                     )
                 self._cleanup_torch_distributed_state()
@@ -147,6 +155,18 @@ class LLMHandler:
                         atexit.unregister(self.llm.exit)
                 except Exception:
                     pass
+                if not exit_success:
+                    # A failed engine teardown leaves workers/CUDA graphs resident. Keep
+                    # self.llm/llm_backend cleared and report failure so initialize()
+                    # stops rather than stacking a new engine atop an un-released runtime.
+                    self.llm = None
+                    self.llm_tokenizer = None
+                    self.constrained_processor = None
+                    self._hf_model_for_scoring = None
+                    self.llm_initialized = False
+                    self.llm_backend = None
+                    gc.collect()
+                    return False
             self.llm = None
             self.llm_tokenizer = None
             self.constrained_processor = None
@@ -167,8 +187,9 @@ class LLMHandler:
             elif hasattr(torch, "xpu") and torch.xpu.is_available():
                 torch.xpu.empty_cache()
                 torch.xpu.synchronize()
+            return True
         except Exception:
-            pass
+            return False
 
     def _cleanup_torch_distributed_state(self) -> None:
         """Destroy default torch distributed process group when already initialized."""
@@ -539,7 +560,16 @@ class LLMHandler:
             # Release any previously-loaded engine before building a new one so a
             # reinit (or a restore after PMI scoring) does not leak the old engine's
             # model weights, KV cache, and CUDA graphs. No-op when nothing is loaded.
-            self.unload()
+            # If unload() reports the teardown was incomplete (engine exit() raised),
+            # stop here rather than stacking a new engine on an un-released runtime.
+            if not self.unload():
+                return (
+                    "❌ Failed to release the previously-loaded vLLM engine; "
+                    "its runtime may not be fully torn down (weights/KV cache/CUDA "
+                    "graphs/workers). Re-initialization aborted to avoid leaking "
+                    "memory on top of it.",
+                    False,
+                )
             if device == "auto":
                 if torch.cuda.is_available():
                     device = "cuda"

--- a/acestep/llm_inference.py
+++ b/acestep/llm_inference.py
@@ -125,13 +125,23 @@ class LLMHandler:
     def unload(self) -> None:
         """Release LM weights/tokenizer and clear caches to free memory."""
         try:
-            if self.llm_backend == "vllm":
+            if self.llm_backend == "vllm" and getattr(self, "llm", None) is not None:
                 try:
-                    if hasattr(self.llm, "reset"):
-                        self.llm.reset()
+                    if hasattr(self.llm, "exit"):
+                        self.llm.exit()  # full teardown: weights/KV cache/CUDA graphs/subprocesses
                 except Exception:
                     pass
                 self._cleanup_torch_distributed_state()
+                # LLMEngine.__init__ registers self.exit in atexit. We already tore
+                # the engine down above, so deregister that callback to stop it from
+                # re-running exit() on an already-released runner at process shutdown
+                # (which would otherwise log a harmless but noisy AttributeError).
+                try:
+                    import atexit
+                    if hasattr(self.llm, "exit"):
+                        atexit.unregister(self.llm.exit)
+                except Exception:
+                    pass
             self.llm = None
             self.llm_tokenizer = None
             self.constrained_processor = None
@@ -520,6 +530,10 @@ class LLMHandler:
             (status_message, success)
         """
         try:
+            # Release any previously-loaded engine before building a new one so a
+            # reinit (or a restore after PMI scoring) does not leak the old engine's
+            # model weights, KV cache, and CUDA graphs. No-op when nothing is loaded.
+            self.unload()
             if device == "auto":
                 if torch.cuda.is_available():
                     device = "cuda"

--- a/acestep/llm_inference_unload_test.py
+++ b/acestep/llm_inference_unload_test.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``LLMHandler.unload`` vLLM teardown.
+
+Regression test for the reinit memory-leak fix: on a vLLM-backed handler,
+``unload()`` must fully tear down the engine via ``llm.exit()`` (not a partial
+``reset()``) and deregister the ``exit`` callback that ``LLMEngine.__init__``
+registers with ``atexit``, so a reinit does not leak the old engine's weights,
+KV cache, and CUDA graphs and does not re-run ``exit()`` on an already-released
+runner at process shutdown.
+"""
+
+import unittest
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+try:
+    from acestep.llm_inference import LLMHandler
+    _IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - dependency guard
+    LLMHandler = None
+    _IMPORT_ERROR = exc
+
+
+def _make_vllm_handler() -> LLMHandler:
+    """Handler already holding a vLLM engine, with CUDA/distributed/gc mocked."""
+    handler = LLMHandler()
+    handler.llm_backend = "vllm"
+    handler.llm = MagicMock()
+    handler.llm.exit = MagicMock()  # emulate LLMEngine.exit
+    return handler
+
+
+@unittest.skipIf(LLMHandler is None, f"llm_inference import unavailable: {_IMPORT_ERROR}")
+class LlmUnloadVllmTests(unittest.TestCase):
+    """Verify ``unload`` tears down a vLLM engine and deregisters its callback."""
+
+    def _base_patches(self):
+        """Common stubs so unload() reaches the vLLM branch without real CUDA/DDP."""
+        return (
+            patch("torch.cuda.is_available", return_value=False),
+            patch("torch.distributed.is_available", return_value=False),
+            patch("torch.distributed.is_initialized", return_value=False),
+        )
+
+    def test_calls_exit_on_vllm_engine(self) -> None:
+        """The engine is fully ``exit()``-ed, not merely ``reset()``."""
+        handler = _make_vllm_handler()
+        engine = handler.llm
+        with ExitStack() as stack:
+            for p in self._base_patches():
+                stack.enter_context(p)
+            handler.unload()
+        engine.exit.assert_called_once()
+        self.assertFalse(handler.llm_initialized)
+        self.assertIsNone(handler.llm)
+        self.assertIsNone(handler.llm_backend)
+
+    def test_deregisters_exit_from_atexit(self) -> None:
+        """The engine's atexit entry is removed so it cannot re-run after teardown."""
+        handler = _make_vllm_handler()
+        engine = handler.llm
+        with ExitStack() as stack:
+            for p in self._base_patches():
+                stack.enter_context(p)
+            unregister_mock = stack.enter_context(patch("atexit.unregister"))
+            handler.unload()
+        unregister_mock.assert_called_once_with(engine.exit)
+
+    def test_exit_callback_not_deregistered_when_missing(self) -> None:
+        """An engine without ``exit`` is left for gc; unregister is skipped."""
+        handler = LLMHandler()
+        handler.llm_backend = "vllm"
+        handler.llm = MagicMock()
+        del handler.llm.exit  # this backend exposes no exit()
+        with ExitStack() as stack:
+            for p in self._base_patches():
+                stack.enter_context(p)
+            unregister_mock = stack.enter_context(patch("atexit.unregister"))
+            handler.unload()
+        unregister_mock.assert_not_called()
+
+    def test_noop_for_non_vllm_backend(self) -> None:
+        """``pt``/``mlx`` backends are not touched as vLLM; no exit() is called."""
+        handler = LLMHandler()
+        handler.llm_backend = "pt"
+        handler.llm = MagicMock()
+        handler.llm.exit = MagicMock()
+        engine = handler.llm
+        with ExitStack() as stack:
+            for p in self._base_patches():
+                stack.enter_context(p)
+            handler.unload()
+        engine.exit.assert_not_called()
+
+    def test_exit_exception_is_swallowed(self) -> None:
+        """A failing engine teardown must not break unload()/subsequent cleanup."""
+        handler = _make_vllm_handler()
+        engine = handler.llm
+        engine.exit.side_effect = RuntimeError("engine already released")
+        with ExitStack() as stack:
+            for p in self._base_patches():
+                stack.enter_context(p)
+            unregister_mock = stack.enter_context(patch("atexit.unregister"))
+            handler.unload()  # must not raise
+        unregister_mock.assert_called_once_with(engine.exit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/acestep/llm_inference_unload_test.py
+++ b/acestep/llm_inference_unload_test.py
@@ -110,5 +110,50 @@ class LlmUnloadVllmTests(unittest.TestCase):
         unregister_mock.assert_not_called()
 
 
+@unittest.skipIf(LLMHandler is None, f"llm_inference import unavailable: {_IMPORT_ERROR}")
+class LlmInitializeAfterFailedTeardownTests(unittest.TestCase):
+    """Verify initialize() aborts when unload() reports an incomplete teardown.
+
+    ChuxiJ review: if a previous vLLM engine's exit() raised, clearing the handler
+    state and silently building a replacement engine can stack a new runtime on an
+    un-released one (leaked weights/KV cache/CUDA graphs/workers). initialize()
+    must stop when unload() reports failure.
+    """
+
+    def test_initialize_aborts_when_unload_fails(self) -> None:
+        """A failed teardown must prevent building a replacement engine."""
+        handler = LLMHandler()
+        # unload() returning False is the guard this test locks down.
+        handler.unload = MagicMock(return_value=False)
+        status, success = handler.initialize(
+            checkpoint_dir="/tmp", lm_model_path="acestep-5Hz-lm-1.7B",
+            backend="vllm", device="cpu",
+        )
+        handler.unload.assert_called_once()
+        self.assertFalse(success)
+        self.assertIn("Failed to release", status)
+        # No new engine should be constructed after a failed teardown.
+        self.assertIsNone(handler.llm)
+        self.assertFalse(handler.llm_initialized)
+
+    def test_initialize_proceeds_when_unload_succeeds(self) -> None:
+        """A clean teardown lets initialize() continue past the guard."""
+        handler = LLMHandler()
+        handler.unload = MagicMock(return_value=True)
+        # Guard returns early only on failure; on success the code proceeds. Mock
+        # the model load path so numpy/tokenizer construction throws a controlled
+        # error, proving we got past the unload() guard (the guard itself is not
+        # what failed here).
+        with patch("acestep.llm_inference.LLMHandler.unload", return_value=True):
+            status, success = handler.initialize(
+                checkpoint_dir="/tmp", lm_model_path="acestep-5Hz-lm-1.7B",
+                backend="vllm", device="cpu",
+            )
+        # We cannot assert success(True) here (engine build would need real torch/
+        # model), but the guard passed: the failure, if any, is downstream of the
+        # teardown guard, not "Failed to release".
+        self.assertNotIn("Failed to release", status)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/acestep/llm_inference_unload_test.py
+++ b/acestep/llm_inference_unload_test.py
@@ -44,6 +44,7 @@ class LlmUnloadVllmTests(unittest.TestCase):
     def test_calls_exit_on_vllm_engine(self) -> None:
         """The engine is fully ``exit()``-ed, not merely ``reset()``."""
         handler = _make_vllm_handler()
+        handler._hf_model_for_scoring = "stale-scoring-model"
         engine = handler.llm
         with ExitStack() as stack:
             for p in self._base_patches():
@@ -53,6 +54,9 @@ class LlmUnloadVllmTests(unittest.TestCase):
         self.assertFalse(handler.llm_initialized)
         self.assertIsNone(handler.llm)
         self.assertIsNone(handler.llm_backend)
+        # New: unload must drop the cached scoring model so get_hf_model_for_scoring()
+        # reloads the current LM on the next call instead of returning stale weights.
+        self.assertIsNone(handler._hf_model_for_scoring)
 
     def test_deregisters_exit_from_atexit(self) -> None:
         """The engine's atexit entry is removed so it cannot re-run after teardown."""
@@ -92,7 +96,8 @@ class LlmUnloadVllmTests(unittest.TestCase):
         engine.exit.assert_not_called()
 
     def test_exit_exception_is_swallowed(self) -> None:
-        """A failing engine teardown must not break unload()/subsequent cleanup."""
+        """A failing teardown must not break unload(), and must keep the atexit
+        callback registered so process shutdown can retry the incomplete cleanup."""
         handler = _make_vllm_handler()
         engine = handler.llm
         engine.exit.side_effect = RuntimeError("engine already released")
@@ -101,7 +106,8 @@ class LlmUnloadVllmTests(unittest.TestCase):
                 stack.enter_context(p)
             unregister_mock = stack.enter_context(patch("atexit.unregister"))
             handler.unload()  # must not raise
-        unregister_mock.assert_called_once_with(engine.exit)
+        engine.exit.assert_called_once()
+        unregister_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/acestep/ui/gradio/events/generation/service_init.py
+++ b/acestep/ui/gradio/events/generation/service_init.py
@@ -148,6 +148,12 @@ def init_service_wrapper(
             status += f"\n{lm_status}"
         else:
             status += f"\n{lm_status}"
+    else:
+        # init_llm disabled: release any previously-loaded LM so it does not stay
+        # resident across re-initialization (avoids the reinit memory leak).
+        if getattr(llm_handler, "llm_initialized", False):
+            llm_handler.unload()
+            logger.info("[init_service] init_llm disabled: unloaded previously-loaded LM")
 
     is_model_initialized = dit_handler.model is not None
     accordion_state = gr.Accordion(open=not is_model_initialized)


### PR DESCRIPTION
## Problem
On re-init the nano-vLLM engine was never truly released: `LLMHandler.unload()` only `reset()` the block allocator (keeping the engine and its KV cache / CUDA graphs alive) instead of calling the real `LLMEngine.exit()` teardown, and `atexit` retained the old engine. Each reload therefore leaked the previous engine's weights, KV cache, and CUDA graphs; the KV cache re-allocation then shrank as free VRAM dropped, producing the reported convergent memory growth.

## Change
- `llm_inference.py`: for the vLLM backend, `unload()` now calls `self.llm.exit()` (full engine teardown) instead of `reset()`, then deregisters the engine's atexit callback so process shutdown does not re-run `exit()` on a released runner (which would log a noisy AttributeError). `initialize()` calls `unload()` first so a reinit releases the old engine before building a new one.
- `lm_score.py`: the PMI scoring temporary-unload helper now uses `llm_handler.unload()` instead of a manual reset + reference drop.
- `service_init.py`: when `init_llm` is disabled, unload a previously-loaded LM so it does not stay resident across re-initialization.
- `lm_score_test.py`: update the PMI offload test to assert `unload()` is called.
- Add `llm_inference_unload_test.py` (5 regression tests): assert the vLLM engine is `exit()`-ed (not `reset()`-ed), the atexit callback is deregistered, teardown errors are swallowed, and non-vLLM backends are unaffected.

## Verification
- `lm_score_test.py` + `llm_inference_unload_test.py` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language model resource cleanup by fully releasing model memory, caches, and GPU execution resources.
  * Prevented previously loaded models from remaining active when language model initialization is disabled or restarted.
  * Added safer handling for cleanup failures, preventing a new model from starting when old resources cannot be released successfully.
  * Improved recovery and state consistency after model shutdown errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->