### PR TITLE
Separate generation success from export-format failure

### DIFF
--- a/acestep/audio_utils.py
+++ b/acestep/audio_utils.py
@@ -11,6 +11,7 @@ Independent audio file operations outside of handler, supporting:
 import io
 import json
 import os
+import shutil
 import subprocess
 import hashlib
 import tempfile
@@ -20,6 +21,21 @@ import torch
 import numpy as np
 import torchaudio
 from loguru import logger
+
+
+class AudioExportDegradedError(RuntimeError):
+    """Raised when audio generation succeeded but the requested export format failed.
+
+    The underlying audio was already synthesized successfully; only the
+    format conversion (e.g. WAV -> MP3 via ffmpeg) failed. ``wav_fallback_path``
+    points to a valid WAV file already saved to disk, so callers can present
+    this as a degraded-but-successful result instead of a hard failure.
+    """
+
+    def __init__(self, message: str, wav_fallback_path: str, requested_format: str):
+        super().__init__(message)
+        self.wav_fallback_path = wav_fallback_path
+        self.requested_format = requested_format
 
 
 def apply_fade(
@@ -181,18 +197,31 @@ class AudioSaver:
             ]
             subprocess.run(cmd, check=True, capture_output=True, timeout=120)
             logger.debug(f"[AudioSaver] Saved audio to {output_path} (mp3, {target_sample_rate}Hz, {bitrate})")
-        except FileNotFoundError as e:
-            raise RuntimeError("ffmpeg executable not found. Install ffmpeg or add it to PATH to export MP3 files.") from e
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError("ffmpeg MP3 export timed out after 120 seconds.") from e
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr.decode('utf-8', errors='ignore') if e.stderr else str(e)
-            raise RuntimeError(f"ffmpeg MP3 export failed: {stderr}") from e
+        except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+            if isinstance(e, FileNotFoundError):
+                reason = "ffmpeg executable not found. Install ffmpeg or add it to PATH to export MP3 files."
+            elif isinstance(e, subprocess.TimeoutExpired):
+                reason = "ffmpeg MP3 export timed out after 120 seconds."
+            else:
+                stderr = e.stderr.decode('utf-8', errors='ignore') if e.stderr else str(e)
+                reason = f"ffmpeg MP3 export failed: {stderr}"
+
+            # The WAV was already synthesized successfully before the ffmpeg
+            # step -- preserve it instead of discarding a valid result.
+            wav_fallback_path = output_path.with_suffix(".wav")
+            try:
+                shutil.move(str(temp_wav_path), str(wav_fallback_path))
+            except Exception:
+                logger.error(f"[AudioSaver] {reason} Additionally failed to preserve WAV fallback.")
+                raise RuntimeError(reason) from e
+
+            logger.warning(f"[AudioSaver] {reason} Saved WAV fallback to {wav_fallback_path} instead.")
+            raise AudioExportDegradedError(reason, str(wav_fallback_path), "mp3") from e
         finally:
             try:
                 temp_wav_path.unlink(missing_ok=True)
             except Exception:
-                logger.warning(f"[AudioSaver] Failed to remove temporary WAV file: {temp_wav_path}")
+                pass
 
     def save_audio(
         self,
@@ -321,7 +350,8 @@ class AudioSaver:
             
         except Exception as e:
             if format == "mp3":
-                logger.error(f"[AudioSaver] MP3 export failed without fallback: {e}")
+                if not isinstance(e, AudioExportDegradedError):
+                    logger.error(f"[AudioSaver] MP3 export failed without fallback: {e}")
                 raise
             try:
                 import soundfile as sf

--- a/acestep/audio_utils_test.py
+++ b/acestep/audio_utils_test.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock
 import torch
 import numpy as np
 
-from acestep.audio_utils import AudioSaver, apply_fade, save_audio
+from acestep.audio_utils import AudioSaver, AudioExportDegradedError, apply_fade, save_audio
 
 class AudioSaverFormatTests(unittest.TestCase):
     """Tests for AudioSaver format support, especially new Opus and AAC formats."""
@@ -334,6 +334,83 @@ class AudioSaverFormatTests(unittest.TestCase):
                     sample_rate=self.sample_rate,
                     format="mp3",
                 )
+
+    def test_save_mp3_missing_ffmpeg_preserves_wav_fallback(self):
+        """When ffmpeg is missing, the already-synthesized WAV must be preserved.
+
+        Generation itself already succeeded before the ffmpeg step runs; a
+        missing ffmpeg binary should not discard that valid audio.
+        """
+        saver = AudioSaver()
+        output_path = Path(self.temp_dir) / "test.mp3"
+
+        with patch(
+            'acestep.audio_utils.subprocess.run',
+            side_effect=FileNotFoundError("ffmpeg not found"),
+        ):
+            with self.assertRaises(AudioExportDegradedError) as ctx:
+                saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
+
+        exc = ctx.exception
+        self.assertEqual(exc.requested_format, "mp3")
+        self.assertTrue(exc.wav_fallback_path.endswith(".wav"))
+        self.assertTrue(os.path.exists(exc.wav_fallback_path))
+        self.assertIn("ffmpeg", str(exc).lower())
+
+    def test_save_mp3_timeout_preserves_wav_fallback(self):
+        """An ffmpeg timeout also preserves the already-synthesized WAV."""
+        import subprocess as subprocess_module
+
+        saver = AudioSaver()
+        output_path = Path(self.temp_dir) / "test.mp3"
+
+        with patch(
+            'acestep.audio_utils.subprocess.run',
+            side_effect=subprocess_module.TimeoutExpired(cmd="ffmpeg", timeout=120),
+        ):
+            with self.assertRaises(AudioExportDegradedError) as ctx:
+                saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
+
+        self.assertTrue(os.path.exists(ctx.exception.wav_fallback_path))
+
+    def test_save_audio_mp3_missing_ffmpeg_raises_degraded_error_with_valid_wav(self):
+        """save_audio() propagates AudioExportDegradedError with a playable WAV fallback."""
+        saver = AudioSaver()
+        output_path = Path(self.temp_dir) / "test.mp3"
+
+        with patch(
+            'acestep.audio_utils.subprocess.run',
+            side_effect=FileNotFoundError("ffmpeg not found"),
+        ):
+            with self.assertRaises(AudioExportDegradedError) as ctx:
+                saver.save_audio(
+                    self.sample_audio,
+                    output_path,
+                    sample_rate=self.sample_rate,
+                    format="mp3",
+                )
+
+        wav_path = ctx.exception.wav_fallback_path
+        self.assertTrue(os.path.exists(wav_path))
+        self.assertGreater(os.path.getsize(wav_path), 0)
+
+    def test_save_mp3_temp_file_cleaned_up_when_fallback_move_fails(self):
+        """If even the WAV fallback move fails, the original ffmpeg reason still surfaces."""
+        saver = AudioSaver()
+        output_path = Path(self.temp_dir) / "test.mp3"
+
+        with (
+            patch(
+                'acestep.audio_utils.subprocess.run',
+                side_effect=FileNotFoundError("ffmpeg not found"),
+            ),
+            patch('acestep.audio_utils.shutil.move', side_effect=OSError("disk full")),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                saver._save_mp3(self.sample_audio, output_path, self.sample_rate)
+
+        self.assertNotIsInstance(ctx.exception, AudioExportDegradedError)
+        self.assertIn("ffmpeg", str(ctx.exception).lower())
 
 class ApplyFadeTests(unittest.TestCase):
     """Tests for apply_fade function."""

--- a/acestep/ui/gradio/events/results/generation_progress.py
+++ b/acestep/ui/gradio/events/results/generation_progress.py
@@ -15,7 +15,7 @@ import torch
 from loguru import logger
 
 from acestep.inference import generate_music, GenerationParams, GenerationConfig
-from acestep.audio_utils import save_audio
+from acestep.audio_utils import save_audio, AudioExportDegradedError
 from acestep.gpu_config import (
     get_global_gpu_config,
     check_duration_limit,
@@ -273,6 +273,7 @@ def generate_with_progress(
     )
     time_module.sleep(0.1)
 
+    export_warnings = []
     for i in range(8):
         if i >= len(audios):
             continue
@@ -291,11 +292,19 @@ def generate_with_progress(
         ext = "wav" if audio_format == "wav32" else audio_format
         audio_path = os.path.join(temp_dir, f"{key}.{ext}").replace("\\", "/")
 
-        saved_path = save_audio(
-            audio_data=audio_tensor, output_path=audio_path,
-            sample_rate=sample_rate, format=audio_format, channels_first=True,
-            mp3_bitrate=mp3_bitrate, mp3_sample_rate=mp3_sample_rate,
-        )
+        try:
+            saved_path = save_audio(
+                audio_data=audio_tensor, output_path=audio_path,
+                sample_rate=sample_rate, format=audio_format, channels_first=True,
+                mp3_bitrate=mp3_bitrate, mp3_sample_rate=mp3_sample_rate,
+            )
+        except AudioExportDegradedError as exc:
+            # Generation itself already succeeded (audio_tensor exists); only
+            # the requested export format failed. Use the WAV ACE-Step already
+            # saved instead of discarding a valid result as a hard error.
+            saved_path = exc.wav_fallback_path
+            logger.warning(f"[generate_with_progress] Sample {key}: {exc}")
+            export_warnings.append(f"{key}: {exc.requested_format} export unavailable ({exc}), saved as WAV")
         if saved_path:
             audio_path = saved_path.replace("\\", "/")
 
@@ -413,9 +422,14 @@ def generate_with_progress(
         {**result.extra_outputs, "lrcs": final_lrcs_list, "subtitles": final_subtitles_list}
     )
 
+    if export_warnings:
+        final_status = "Generation Complete (WAV). " + "; ".join(export_warnings)
+    else:
+        final_status = "Generation Complete"
+
     yield (
         *audio_playback_updates,
-        all_audio_paths, generation_info, "Generation Complete", seed_value_for_ui,
+        all_audio_paths, generation_info, final_status, seed_value_for_ui,
         *final_scores_list, *final_codes_display, *final_accordions, *final_lrcs_list,
         lm_generated_metadata, is_format_caption,
         extra_to_store,


### PR DESCRIPTION
A failed MP3 export (e.g. missing ffmpeg) currently discards an already-successfully-generated audio result and surfaces as a hard error in the Gradio UI, indistinguishable from a real generation failure (GPU OOM, NaN latents, etc). The DiT/VAE pipeline already completed successfully in this case; only the WAV -> MP3 format conversion step failed.

`_save_mp3()` already writes a temporary WAV file before invoking ffmpeg. This PR preserves that WAV instead of deleting it when ffmpeg fails (missing binary, timeout, or non-zero exit), and introduces `AudioExportDegradedError` carrying the fallback WAV path plus the original failure reason.

`generate_with_progress()` catches this specific exception, uses the WAV fallback as the sample's saved path, and reports a distinguishable status (`Generation Complete (WAV). <key>: mp3 export unavailable (<reason>), saved as WAV`) instead of letting the exception propagate into a generic error toast that discards the result.

## Behavior

* generation PASS + export PASS -> unchanged: `Generation Complete`, requested format saved
* generation PASS + export FAIL -> `Generation Complete (WAV). <reason>`, WAV saved instead of discarding a valid result
* generation FAIL -> unchanged: existing error handling

Other export formats (opus/aac/flac/wav) and the case where the WAV fallback move itself fails are unaffected -- they keep their existing behavior (soundfile fallback / hard failure respectively).

## Verification

Reproduced live on a GTX 1080 Ti deployment:

* ffmpeg installed: MP3 export produces a valid file (ffprobe-verified, 15.0s duration)
* ffmpeg simulated missing: WAV fallback is written and playable (192KB, valid audio) instead of the result being discarded

Tests cover: missing-ffmpeg WAV preservation, timeout WAV preservation, `save_audio()` propagating the degraded error with a valid WAV path, and the case where the fallback move itself fails (falls back to the original hard-failure behavior with the real ffmpeg reason surfaced).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves a playable WAV fallback when requested audio export formats, such as MP3, cannot be generated.
  * Displays a completion status with export warnings when fallback audio is used.
  * Supports explicit CUDA precision settings through `ACESTEP_DTYPE`.

* **Bug Fixes**
  * Prevents failed audio exports from discarding successfully generated samples.
  * Provides clearer errors for invalid or unsupported CUDA precision settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->