### PR TITLE
feat(api-client): add a Python CLI client for the async music API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ docs/.vitepress/dist/
 docs/.vitepress/cache/
 docs/en/awesome.md
 package-lock.json
+
+# Default download dir for scripts/call_music_api.py
+api_outputs/

--- a/acestep/api_client.py
+++ b/acestep/api_client.py
@@ -1,0 +1,282 @@
+"""CLI-friendly client helpers for the legacy ACE-Step async music API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import requests
+
+
+SUPPORTED_TASK_TYPES = ("text2music", "cover", "cover-nofsq", "repaint")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for the legacy async API client."""
+
+    parser = argparse.ArgumentParser(description="Call the ACE-Step legacy async music API.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8001", help="API base URL.")
+    parser.add_argument("--api-key", default=None, help="Optional API key for Authorization header.")
+    parser.add_argument("--task-type", default="text2music", choices=SUPPORTED_TASK_TYPES)
+    parser.add_argument("--prompt", default="", help="Music prompt/caption.")
+    parser.add_argument("--lyrics", default="", help="Lyrics text.")
+    parser.add_argument("--src-audio", default=None, help="Source audio file for cover/repaint modes.")
+    parser.add_argument("--reference-audio", default=None, help="Optional reference audio file.")
+    parser.add_argument("--audio-duration", type=float, default=None, help="Target duration in seconds.")
+    parser.add_argument("--batch-size", type=int, default=1, help="Number of samples to generate.")
+    parser.add_argument("--inference-steps", type=int, default=8, help="Diffusion inference steps.")
+    parser.add_argument("--guidance-scale", type=float, default=7.0, help="CFG scale.")
+    parser.add_argument("--thinking", action="store_true", help="Enable 5Hz LM thinking mode.")
+    parser.add_argument("--model", default=None, help="Optional DiT model name.")
+    parser.add_argument("--audio-format", default="mp3", help="Output format: mp3/flac/wav/opus/aac/wav32.")
+    parser.add_argument("--seed", default=None, help="Optional seed or comma-separated seeds.")
+    parser.add_argument("--vocal-language", default="en", help="Lyrics language code.")
+    parser.add_argument("--repainting-start", type=float, default=0.0, help="Repaint region start in seconds.")
+    parser.add_argument("--repainting-end", type=float, default=None, help="Repaint region end in seconds.")
+    parser.add_argument(
+        "--repaint-mode",
+        default="balanced",
+        choices=("conservative", "balanced", "aggressive"),
+        help="Repaint mode. Matches the Gradio default.",
+    )
+    parser.add_argument(
+        "--repaint-strength",
+        type=float,
+        default=0.5,
+        help="Repaint strength. Matches the Gradio default.",
+    )
+    parser.add_argument("--poll-interval", type=float, default=2.0, help="Polling interval in seconds.")
+    parser.add_argument("--timeout", type=float, default=900.0, help="Polling timeout in seconds.")
+    parser.add_argument("--output-dir", default="api_outputs", help="Directory for downloaded audio.")
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Print returned audio URLs without downloading files.",
+    )
+    return parser
+
+
+def build_headers(api_key: Optional[str]) -> dict[str, str]:
+    """Build request headers with optional bearer authentication."""
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    """Validate task-specific CLI arguments before any network call."""
+
+    if args.batch_size < 1:
+        raise ValueError("--batch-size must be >= 1")
+    if args.task_type in {"cover", "cover-nofsq", "repaint"} and not args.src_audio:
+        raise ValueError(f"--src-audio is required for task type '{args.task_type}'")
+    if args.task_type == "repaint" and args.repainting_end is None:
+        raise ValueError("--repainting-end is required for repaint mode")
+
+
+def build_release_task_payload(args: argparse.Namespace) -> dict[str, Any]:
+    """Convert CLI arguments into a release-task payload."""
+
+    payload: dict[str, Any] = {
+        "task_type": args.task_type,
+        "prompt": args.prompt,
+        "lyrics": args.lyrics,
+        "thinking": args.thinking,
+        "vocal_language": args.vocal_language,
+        "batch_size": args.batch_size,
+        "inference_steps": args.inference_steps,
+        "guidance_scale": args.guidance_scale,
+        "audio_format": args.audio_format,
+        "repainting_start": args.repainting_start,
+    }
+    if args.task_type == "repaint":
+        payload["repaint_mode"] = args.repaint_mode
+        payload["repaint_strength"] = args.repaint_strength
+    if args.audio_duration is not None:
+        payload["audio_duration"] = args.audio_duration
+    if args.repainting_end is not None:
+        payload["repainting_end"] = args.repainting_end
+    if args.model:
+        payload["model"] = args.model
+    if args.seed is not None:
+        payload["seed"] = args.seed
+        payload["use_random_seed"] = False
+    return payload
+
+
+def submit_generation_task(
+    session: requests.Session,
+    base_url: str,
+    api_key: Optional[str],
+    payload: dict[str, Any],
+    src_audio: Optional[str] = None,
+    reference_audio: Optional[str] = None,
+) -> str:
+    """Submit a generation task and return the queued task ID."""
+
+    with ExitStack() as stack:
+        files = {}
+        data = {key: str(value) for key, value in payload.items()}
+        if src_audio:
+            files["src_audio"] = stack.enter_context(open(src_audio, "rb"))
+        if reference_audio:
+            files["reference_audio"] = stack.enter_context(open(reference_audio, "rb"))
+        response = session.post(
+            f"{base_url.rstrip('/')}/release_task",
+            headers=build_headers(api_key),
+            data=data,
+            files=files or None,
+            timeout=120,
+        )
+    response.raise_for_status()
+    body = response.json()
+    task_id = (((body or {}).get("data")) or {}).get("task_id")
+    if not task_id:
+        raise RuntimeError(f"release_task did not return a task_id: {body}")
+    return str(task_id)
+
+
+def parse_query_result_item(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse the legacy stringified ``result`` field into a list payload."""
+
+    raw_result = item.get("result", "[]")
+    if isinstance(raw_result, list):
+        return raw_result
+    if not isinstance(raw_result, str):
+        return []
+    try:
+        parsed = json.loads(raw_result)
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def poll_task_result(
+    session: requests.Session,
+    base_url: str,
+    api_key: Optional[str],
+    task_id: str,
+    poll_interval: float,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    """Poll ``/query_result`` until the task succeeds or fails."""
+
+    deadline = time.time() + timeout
+    last_progress = None
+    while time.time() < deadline:
+        response = session.post(
+            f"{base_url.rstrip('/')}/query_result",
+            headers={"Content-Type": "application/json", **build_headers(api_key)},
+            json={"task_id_list": [task_id]},
+            timeout=60,
+        )
+        response.raise_for_status()
+        body = response.json()
+        items = (body or {}).get("data") or []
+        if not items:
+            time.sleep(poll_interval)
+            continue
+        task = items[0]
+        status = int(task.get("status", 0))
+        progress_text = task.get("progress_text")
+        if progress_text and progress_text != last_progress and status == 0:
+            print(progress_text)
+            last_progress = progress_text
+        if status == 1:
+            return parse_query_result_item(task)
+        if status == 2:
+            raise RuntimeError(f"task failed: {task}")
+        time.sleep(poll_interval)
+    raise TimeoutError(f"task {task_id} did not finish within {timeout} seconds")
+
+
+def resolve_audio_url(base_url: str, file_url: str) -> str:
+    """Resolve relative audio URLs returned by the API against the base URL."""
+
+    return urljoin(f"{base_url.rstrip('/')}/", file_url)
+
+
+def infer_output_suffix(audio_url: str) -> str:
+    """Infer a file suffix from the ``/v1/audio?path=...`` URL query."""
+
+    parsed = urlparse(audio_url)
+    query_path = parse_qs(parsed.query).get("path", [""])[0]
+    suffix = Path(query_path).suffix
+    return suffix or ".bin"
+
+
+def download_audio_files(
+    session: requests.Session,
+    base_url: str,
+    audio_items: list[dict[str, Any]],
+    output_dir: str,
+    task_id: str,
+) -> list[Path]:
+    """Download generated audio files to the requested output directory."""
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    saved_paths: list[Path] = []
+    for index, item in enumerate(audio_items):
+        file_url = str(item.get("file", "")).strip()
+        if not file_url:
+            continue
+        response = session.get(resolve_audio_url(base_url, file_url), timeout=300)
+        response.raise_for_status()
+        output_path = out_dir / f"{task_id}_{index}{infer_output_suffix(file_url)}"
+        output_path.write_bytes(response.content)
+        saved_paths.append(output_path)
+    return saved_paths
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Run the legacy async music API client from the command line."""
+
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        validate_args(args)
+        payload = build_release_task_payload(args)
+        with requests.Session() as session:
+            task_id = submit_generation_task(
+                session=session,
+                base_url=args.base_url,
+                api_key=args.api_key,
+                payload=payload,
+                src_audio=args.src_audio,
+                reference_audio=args.reference_audio,
+            )
+            print(f"task_id: {task_id}")
+            results = poll_task_result(
+                session=session,
+                base_url=args.base_url,
+                api_key=args.api_key,
+                task_id=task_id,
+                poll_interval=args.poll_interval,
+                timeout=args.timeout,
+            )
+            print(f"returned_audio_count: {len(results)}")
+            if args.no_download:
+                for index, item in enumerate(results):
+                    print(f"audio[{index}]: {item.get('file', '')}")
+            else:
+                saved = download_audio_files(
+                    session=session,
+                    base_url=args.base_url,
+                    audio_items=results,
+                    output_dir=args.output_dir,
+                    task_id=task_id,
+                )
+                for path in saved:
+                    print(f"saved: {path}")
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}")
+        return 1

--- a/acestep/api_client_test.py
+++ b/acestep/api_client_test.py
@@ -1,0 +1,125 @@
+"""Tests for the legacy ACE-Step async API client helpers."""
+
+from __future__ import annotations
+
+import argparse
+import unittest
+
+from acestep.api_client import (
+    build_release_task_payload,
+    infer_output_suffix,
+    parse_query_result_item,
+    resolve_audio_url,
+    validate_args,
+)
+
+
+class ApiClientValidationTests(unittest.TestCase):
+    """Validate CLI argument rules for task-specific API modes."""
+
+    def test_cover_requires_src_audio(self) -> None:
+        """Cover-family tasks should require a source audio file."""
+
+        args = argparse.Namespace(
+            task_type="cover",
+            src_audio=None,
+            batch_size=1,
+            repainting_end=None,
+        )
+        with self.assertRaisesRegex(ValueError, "--src-audio is required"):
+            validate_args(args)
+
+    def test_repaint_requires_end_time(self) -> None:
+        """Repaint mode should require an explicit repaint end boundary."""
+
+        args = argparse.Namespace(
+            task_type="repaint",
+            src_audio="input.wav",
+            batch_size=1,
+            repainting_end=None,
+        )
+        with self.assertRaisesRegex(ValueError, "--repainting-end is required"):
+            validate_args(args)
+
+
+class ApiClientPayloadTests(unittest.TestCase):
+    """Exercise request payload building for the release-task API."""
+
+    def test_build_release_task_payload_disables_random_seed_when_seed_given(self) -> None:
+        """Explicit seeds should set ``use_random_seed`` false in the payload."""
+
+        args = argparse.Namespace(
+            task_type="text2music",
+            prompt="hello",
+            lyrics="",
+            thinking=False,
+            vocal_language="en",
+            batch_size=2,
+            inference_steps=8,
+            guidance_scale=7.0,
+            audio_format="mp3",
+            repainting_start=0.0,
+            repainting_end=None,
+            repaint_mode="balanced",
+            repaint_strength=0.5,
+            audio_duration=30.0,
+            model="acestep-v15-xl-turbo",
+            seed="42,43",
+        )
+        payload = build_release_task_payload(args)
+        self.assertEqual("42,43", payload["seed"])
+        self.assertFalse(payload["use_random_seed"])
+        self.assertEqual(2, payload["batch_size"])
+
+    def test_build_release_task_payload_includes_gradio_repaint_defaults(self) -> None:
+        """Repaint requests should send the same default mode/strength as Gradio."""
+
+        args = argparse.Namespace(
+            task_type="repaint",
+            prompt="repair the chorus",
+            lyrics="[Instrumental]",
+            thinking=False,
+            vocal_language="en",
+            batch_size=1,
+            inference_steps=8,
+            guidance_scale=7.0,
+            audio_format="mp3",
+            repainting_start=0.0,
+            repainting_end=12.0,
+            repaint_mode="balanced",
+            repaint_strength=0.5,
+            audio_duration=None,
+            model=None,
+            seed=None,
+        )
+        payload = build_release_task_payload(args)
+        self.assertEqual("balanced", payload["repaint_mode"])
+        self.assertEqual(0.5, payload["repaint_strength"])
+
+
+class ApiClientResultParsingTests(unittest.TestCase):
+    """Verify legacy query-result parsing and audio URL helpers."""
+
+    def test_parse_query_result_item_handles_batch_audio_list(self) -> None:
+        """Batch-sized generations should parse into one entry per returned audio."""
+
+        item = {
+            "result": (
+                '[{"file":"/v1/audio?path=%2Ftmp%2Fa.mp3","status":1},'
+                '{"file":"/v1/audio?path=%2Ftmp%2Fb.mp3","status":1}]'
+            )
+        }
+        result = parse_query_result_item(item)
+        self.assertEqual(2, len(result))
+        self.assertEqual("/v1/audio?path=%2Ftmp%2Fb.mp3", result[1]["file"])
+
+    def test_audio_url_helpers_preserve_relative_path_and_suffix(self) -> None:
+        """Relative ``/v1/audio`` URLs should resolve and keep output suffixes."""
+
+        file_url = "/v1/audio?path=%2Ftmp%2Fapi_audio%2Fdemo.flac"
+        self.assertEqual("http://127.0.0.1:8001/v1/audio?path=%2Ftmp%2Fapi_audio%2Fdemo.flac", resolve_audio_url("http://127.0.0.1:8001", file_url))
+        self.assertEqual(".flac", infer_output_suffix(file_url))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/call_music_api.py
+++ b/scripts/call_music_api.py
@@ -1,0 +1,9 @@
+"""Command-line wrapper for the legacy ACE-Step async music API client."""
+
+from __future__ import annotations
+
+from acestep.api_client import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds `acestep/api_client.py`, a small client for the async `/release_task` + `/query_result` flow, plus `scripts/call_music_api.py` as the CLI entry point.

Covers `text2music`, `cover`, `cover-nofsq` and `repaint`. Repaint sends the same default `repaint_mode` / `repaint_strength` as the Gradio UI so CLI and UI results stay comparable.

## Why

The API is currently only exercised from the Gradio UI or ad-hoc `curl`. A scriptable client makes batch runs and regression checks against a running server straightforward — for example generating N variations of one prompt without clicking through the UI.

The functions are split so each is testable without a live server: `validate_args`, `build_release_task_payload`, `parse_query_result_item`, `resolve_audio_url`, `infer_output_suffix`.

## Notes

- Only `requests` is used, already an indirect dependency; nothing added to `pyproject.toml`.
- `.gitignore` gains `api_outputs/`, the default download directory.
- Happy to drop this if the existing `.claude/skills/acestep/scripts/acestep.sh` is considered the canonical client — the overlap is intentional but the Python version is easier to unit test.

## Testing

`uv run python -m unittest acestep.api_client_test` — 6 tests, covering payload defaults for repaint, seed handling, batch result parsing, relative audio URL resolution, and validation errors for missing `--src-audio` / `--repainting-end`.

Not exercised against a live server in CI; the network path was verified manually against a local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line tool for submitting music-generation requests to the legacy ACE-Step API.
  - Supports text-to-music, cover, repaint, and related task types.
  - Supports optional source and reference audio files, configurable generation settings, progress polling, and automatic audio downloads.
  - Provides clear validation and error messages, including timeout and failed-task handling.

- **Tests**
  - Added coverage for argument validation, payload construction, result parsing, URL handling, and output file detection.

- **Chores**
  - Excluded downloaded API outputs from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->