### PR TITLE
chore(start-scripts): free the port and isolate temp dirs on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ docs/.vitepress/dist/
 docs/.vitepress/cache/
 docs/en/awesome.md
 package-lock.json
+
+# Launcher temp/cache dir (ACESTEP_TMP_DIR)
+.tmp/

--- a/start_gradio_ui.sh
+++ b/start_gradio_ui.sh
@@ -80,7 +80,7 @@ SHARE="${SHARE:-}"
 # SHARE="--share"
 
 # Reset LANGUAGE if it contains an invalid value (e.g. system locale like en_CA:en)
-case "$LANGUAGE" in
+case "${LANGUAGE:-}" in
     en|zh|he|ja) ;;
     *) unset LANGUAGE ;;
 esac
@@ -133,7 +133,42 @@ AUTH_USERNAME="${AUTH_USERNAME:-}"
 AUTH_PASSWORD="${AUTH_PASSWORD:-}"
 # AUTH_PASSWORD="--auth-password password"
 
+# Runtime temp/cache directories
+: "${ACESTEP_TMP_DIR:=${SCRIPT_DIR}/.tmp}"
+: "${GRADIO_TEMP_DIR:=${ACESTEP_TMP_DIR}/gradio}"
+
 # ==================== Launch ====================
+
+_kill_processes_on_port() {
+    local port="$1"
+    local pids=""
+
+    if command -v lsof &>/dev/null; then
+        pids="$(lsof -ti "tcp:${port}" 2>/dev/null || true)"
+    elif command -v fuser &>/dev/null; then
+        pids="$(fuser "${port}/tcp" 2>/dev/null || true)"
+    fi
+
+    [[ -z "${pids// }" ]] && return 0
+
+    echo "[Port] Releasing port ${port} from existing process(es): ${pids}"
+    kill $pids 2>/dev/null || true
+
+    for _ in {1..10}; do
+        sleep 1
+        if command -v lsof &>/dev/null; then
+            pids="$(lsof -ti "tcp:${port}" 2>/dev/null || true)"
+        elif command -v fuser &>/dev/null; then
+            pids="$(fuser "${port}/tcp" 2>/dev/null || true)"
+        else
+            pids=""
+        fi
+        [[ -z "${pids// }" ]] && return 0
+    done
+
+    echo "[Port] Force killing stubborn process(es) on port ${port}: ${pids}"
+    kill -9 $pids 2>/dev/null || true
+}
 
 # ==================== Startup Update Check ====================
 _startup_update_check() {
@@ -200,8 +235,18 @@ _startup_update_check() {
 }
 _startup_update_check
 
+_kill_processes_on_port "$PORT"
+
+mkdir -p "$ACESTEP_TMP_DIR" "$GRADIO_TEMP_DIR"
+export TMPDIR="$ACESTEP_TMP_DIR"
+export TEMP="$ACESTEP_TMP_DIR"
+export TMP="$ACESTEP_TMP_DIR"
+export GRADIO_TEMP_DIR="$GRADIO_TEMP_DIR"
+
 echo "Starting ACE-Step Gradio Web UI..."
 echo "Server will be available at: http://${SERVER_NAME}:${PORT}"
+echo "Temporary files will be stored in: ${ACESTEP_TMP_DIR}"
+echo "Gradio cache will be stored in: ${GRADIO_TEMP_DIR}"
 echo
 
 # ==================== Standard uv Workflow ====================


### PR DESCRIPTION
## What

Two small changes to `start_gradio_ui.sh`:

1. **Release the port before starting.** `_kill_processes_on_port` finds the holder via `lsof` (falling back to `fuser`), sends TERM, waits up to 10s, then KILLs.
2. **Keep temp files on the project volume.** `TMPDIR` / `TEMP` / `TMP` and `GRADIO_TEMP_DIR` now point at `./.tmp` instead of `/tmp`. Both are overridable via `ACESTEP_TMP_DIR` / `GRADIO_TEMP_DIR`.

Also guards `case "$LANGUAGE"` as `"${LANGUAGE:-}"` — the script runs under `set -u`, so an unset `LANGUAGE` aborts the launcher before it reaches the `: "${LANGUAGE:=en}"` default on the next line.

## Why

Restarting the UI after a crash or a Ctrl-C that left a child alive fails with "port already in use", and the fix is a manual `lsof`/`kill` every time.

Separately, Gradio caches every generated track under `/tmp`. On machines where `/tmp` is tmpfs or on a small root partition, a long session fills it up. Moving the cache next to the checkpoints puts it on the volume that is already sized for audio, and makes cleanup a single `rm -rf .tmp`.

## Notes

- `_kill_processes_on_port` no-ops when neither `lsof` nor `fuser` is present, so it cannot break a launch on a minimal image.
- The kill targets whatever holds the port, which on a shared box could be an unrelated process. That matches what the user is asking for by launching on that port, but say the word if you would rather it prompt first.
- Only `start_gradio_ui.sh` is touched; `start_api_server.sh` is left alone.

## Testing

`bash -n start_gradio_ui.sh` passes. Launch verified locally: the port-release path was exercised against a stale process, and startup reaches GPU detection with the temp dirs created under `./.tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher reliability when no language setting is configured.
  * Automatically frees the configured port before starting the application.

* **New Features**
  * Added configurable temporary and cache directories.
  * Displays the locations of temporary files and caches during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->