### PR TITLE
feat: add optional Atlas thumbnail provider

### DIFF
--- a/.claude/skills/acestep-thumbnail/SKILL.md
+++ b/.claude/skills/acestep-thumbnail/SKILL.md
@@ -1,35 +1,50 @@
 ---
 name: acestep-thumbnail
-description: Generate song cover/thumbnail images using Gemini API. Creates artistic images suitable for music video backgrounds. Use when users want to generate album art, song covers, thumbnails, or background images for MVs.
+description: Generate song cover/thumbnail images using Gemini API or the optional Atlas Cloud backend. Creates artistic images suitable for music video backgrounds. Use when users want to generate album art, song covers, thumbnails, or background images for MVs.
 allowed-tools: Read, Write, Bash
 ---
 
 # Thumbnail Generation Skill
 
-Generate song cover/thumbnail images using Google Gemini's image generation API. Output images can be used directly as MV backgrounds with the acestep-simplemv skill.
+Generate song cover/thumbnail images using Google Gemini's image generation API or Atlas Cloud. Gemini remains the default; Atlas is opt-in. Output images can be used directly as MV backgrounds with the acestep-simplemv skill.
 
 ## API Key Setup Guide
 
-**Before generating, you MUST check whether the user's API key is configured.** Run the following command to check:
+**Before generating, choose the provider and check only that provider's key.** Gemini is the
+default. For Gemini, run:
 
 ```bash
 cd "{project_root}/{.claude or .codex}/skills/acestep-thumbnail/" && bash ./scripts/acestep-thumbnail.sh config --check-key
 ```
 
-This command only reports whether the API key is set or empty — it does NOT print the actual key value. **NEVER read or display the user's API key content.** Do not use `config --get` on key fields or read `config.json` directly. The `config --list` command is safe — it automatically masks API keys as `***` in output.
+For Atlas, check the environment without printing the key:
 
-**If the command reports the key is empty**, you MUST stop and guide the user to configure it before proceeding. Do NOT attempt generation without a valid key — it will fail.
+```bash
+if [[ -n "${ATLASCLOUD_API_KEY:-${ATLAS_CLOUD_API_KEY:-}}" ]]; then
+  echo "Atlas Cloud API key: configured"
+else
+  echo "Atlas Cloud API key: empty"
+fi
+```
+
+These checks report only whether a key is set. **NEVER read or display the user's API key
+content.** Do not use `config --get` on key fields or read `config.json` directly. The Gemini
+`config --list` command is safe because it masks API keys as `***` in output.
+
+**If the selected provider's check reports the key is empty**, stop and guide the user to
+configure it before proceeding. Do not attempt generation without a valid key.
 
 Use `AskUserQuestion` to ask the user to provide their API key, with the following guidance:
 
-1. Tell the user the Gemini API key is not configured and image generation cannot proceed without it.
-2. Provide instructions on where to get a key:
+1. Tell the user which provider key is not configured.
+2. Provide the matching setup instructions:
    - **Google AI Studio**: Get a API key at https://aistudio.google.com/apikey — requires a Google account.
+   - **Atlas Cloud**: Create a key at https://www.atlascloud.ai/console/api-keys and export it as `ATLASCLOUD_API_KEY`.
 3. Once the user provides the key, configure it using:
    ```bash
    cd "{project_root}/{.claude or .codex}/skills/acestep-thumbnail/" && bash ./scripts/acestep-thumbnail.sh config --set api_key <KEY>
    ```
-4. After configuring, re-run `config --check-key` to verify the key is set before proceeding.
+4. After configuring Gemini, re-run `config --check-key`. For Atlas, repeat the safe environment check above.
 
 **If the API key is already configured**, proceed directly to generation without asking.
 
@@ -48,10 +63,28 @@ cd {project_root}/{.claude or .codex}/skills/acestep-thumbnail/
 # 4. Output saved to: {project_root}/acestep_output/<timestamp>_thumbnail.png
 ```
 
+### Atlas Cloud provider
+
+Set an Atlas Cloud key in the environment and select the provider per call:
+
+```bash
+export ATLASCLOUD_API_KEY="your-key"
+./scripts/acestep-thumbnail.sh generate \
+  --provider atlas \
+  --prompt "Cherry blossoms at night with moonlight" \
+  --aspect-ratio 16:9 \
+  --resolution 1k
+```
+
+Atlas uses `google/nano-banana-pro/text-to-image-developer` by default. Override it with
+`--atlas-model` only after confirming the replacement is an enabled image model in the live
+Atlas catalog. Atlas submission is made once; only prediction-status GET requests use bounded
+transient retries.
+
 ## Prerequisites
 
 - curl, jq, base64 (or python3)
-- A Gemini API key (at https://aistudio.google.com/apikey)
+- A Gemini API key (at https://aistudio.google.com/apikey), or `ATLASCLOUD_API_KEY` when using Atlas
 
 ## Script Usage
 
@@ -62,6 +95,9 @@ Options:
   --prompt       Image description (required)
   --aspect-ratio 16:9, 1:1, or 9:16 (default: 16:9)
   --output       Output image path (default: acestep_output/<timestamp>_thumbnail.png)
+  --provider     gemini or atlas (default: gemini)
+  --resolution   Atlas output resolution: 1k, 2k, or 4k (default: 1k)
+  --atlas-model  Optional Atlas image model override
 ```
 
 ## Prompt Guidelines

--- a/.claude/skills/acestep-thumbnail/scripts/acestep-thumbnail.sh
+++ b/.claude/skills/acestep-thumbnail/scripts/acestep-thumbnail.sh
@@ -12,6 +12,8 @@
 #   --prompt       Image description prompt (required)
 #   --aspect-ratio Aspect ratio: 16:9, 1:1, 9:16 (default: from config, typically 16:9)
 #   --output       Output image path (default: acestep_output/<timestamp>_thumbnail.png)
+#   --provider     gemini or atlas (default: gemini)
+#   --resolution   Atlas output resolution: 1k, 2k, or 4k (default: 1k)
 #
 # Examples:
 #   ./acestep-thumbnail.sh generate --prompt "Cyberpunk city skyline at night with neon lights"
@@ -108,7 +110,7 @@ handle_config() {
 handle_generate() {
   ensure_config
 
-  local prompt="" aspect_ratio="" output=""
+  local prompt="" aspect_ratio="" output="" provider="gemini" resolution="1k" atlas_model=""
 
   # Parse args
   while [[ $# -gt 0 ]]; do
@@ -116,6 +118,9 @@ handle_generate() {
       --prompt)       prompt="$2"; shift 2 ;;
       --aspect-ratio) aspect_ratio="$2"; shift 2 ;;
       --output)       output="$2"; shift 2 ;;
+      --provider)     provider="$2"; shift 2 ;;
+      --resolution)   resolution="$2"; shift 2 ;;
+      --atlas-model)  atlas_model="$2"; shift 2 ;;
       *)
         echo "Error: unknown argument: $1" >&2
         exit 1
@@ -129,7 +134,7 @@ handle_generate() {
   api_url=$(get_config "api_url")
   model=$(get_config "model")
 
-  if [[ -z "$api_key" ]]; then
+  if [[ "$provider" == "gemini" && -z "$api_key" ]]; then
     echo "Error: Gemini API key not configured." >&2
     echo "Get a free key at: https://aistudio.google.com/apikey" >&2
     echo "Then run: ./scripts/acestep-thumbnail.sh config --set api_key <YOUR_KEY>" >&2
@@ -148,6 +153,16 @@ handle_generate() {
 
   if [[ -z "$prompt" ]]; then
     echo "Error: --prompt is required" >&2
+    exit 1
+  fi
+
+  if [[ "$provider" != "gemini" && "$provider" != "atlas" ]]; then
+    echo "Error: --provider must be gemini or atlas" >&2
+    exit 1
+  fi
+
+  if [[ "$resolution" != "1k" && "$resolution" != "2k" && "$resolution" != "4k" ]]; then
+    echo "Error: --resolution must be 1k, 2k, or 4k" >&2
     exit 1
   fi
 
@@ -173,6 +188,22 @@ handle_generate() {
 
   # Ensure output directory exists
   mkdir -p "$(dirname "$output")"
+
+  if [[ "$provider" == "atlas" ]]; then
+    if [[ -z "${ATLASCLOUD_API_KEY:-${ATLAS_CLOUD_API_KEY:-}}" ]]; then
+      echo "Error: ATLASCLOUD_API_KEY is required for --provider atlas" >&2
+      exit 1
+    fi
+    local atlas_args=(
+      --prompt "$prompt"
+      --aspect-ratio "$aspect_ratio"
+      --resolution "$resolution"
+      --output "$output"
+    )
+    [[ -n "$atlas_model" ]] && atlas_args+=(--model "$atlas_model")
+    python3 "$SCRIPT_DIR/atlas_thumbnail.py" "${atlas_args[@]}"
+    return
+  fi
 
   echo "Generating thumbnail..."
   echo "  Prompt: ${prompt:0:100}$([ ${#prompt} -gt 100 ] && echo '...')"

--- a/.claude/skills/acestep-thumbnail/scripts/atlas_thumbnail.py
+++ b/.claude/skills/acestep-thumbnail/scripts/atlas_thumbnail.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Generate an ACE-Step thumbnail with the Atlas Cloud image API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_ROOT = "https://api.atlascloud.ai"
+CATALOG_URL = f"{API_ROOT}/api/v1/models"
+DEFAULT_MODEL = "google/nano-banana-pro/text-to-image-developer"
+USER_AGENT = "acestep-thumbnail/1.0"
+
+
+def _json_request(
+    request: urllib.request.Request, *, transient_retries: int = 0
+) -> dict[str, Any]:
+    """Send JSON, retrying only transient GET failures when requested."""
+    for attempt in range(transient_retries + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            if attempt >= transient_retries or exc.code not in {429, 500, 502, 503, 504}:
+                raise
+        except urllib.error.URLError:
+            if attempt >= transient_retries:
+                raise
+        time.sleep(2**attempt)
+    raise RuntimeError("request retry loop exhausted")
+
+
+def validate_model(model: str) -> None:
+    """Confirm the configured model is currently enabled in the Atlas catalog."""
+    data = _json_request(urllib.request.Request(CATALOG_URL, headers={"User-Agent": USER_AGENT}))
+    models = data.get("data", data)
+    if isinstance(models, dict):
+        models = models.get("models") or models.get("items") or []
+    match = next((item for item in models if item.get("model") == model), None)
+    if not match or match.get("type") != "Image" or match.get("display_console") is False:
+        raise RuntimeError(f"Atlas image model is not currently available: {model}")
+
+
+def submit(key: str, payload: dict[str, Any]) -> str:
+    """Submit exactly one billable image generation request and return its id."""
+    request = urllib.request.Request(
+        f"{API_ROOT}/api/v1/model/generateImage",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+        method="POST",
+    )
+    data = _json_request(request)
+    body = data.get("data", data)
+    prediction_id = body.get("id") if isinstance(body, dict) else None
+    if not prediction_id:
+        raise RuntimeError("Atlas generation response did not include a prediction id")
+    return str(prediction_id)
+
+
+def poll(key: str, prediction_id: str, timeout: int, interval: float) -> str:
+    """Poll a prediction until completion and return the first output URL."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        request = urllib.request.Request(
+            f"{API_ROOT}/api/v1/model/prediction/{prediction_id}",
+            headers={"Authorization": f"Bearer {key}", "User-Agent": USER_AGENT},
+        )
+        data = _json_request(request, transient_retries=3)
+        body = data.get("data", data)
+        status = str(body.get("status", "")).lower()
+        outputs = body.get("outputs") or []
+        if status in {"completed", "succeeded"} and outputs:
+            return str(outputs[0])
+        if status in {"failed", "canceled", "cancelled"}:
+            raise RuntimeError(f"Atlas prediction ended with status: {status}")
+        time.sleep(interval)
+    raise TimeoutError(f"Atlas prediction timed out after {timeout} seconds")
+
+
+def download(url: str, output: Path) -> Path:
+    """Download one generated image and atomically place it with the correct suffix."""
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        content = response.read()
+    if content.startswith(b"\x89PNG\r\n\x1a\n"):
+        suffix = ".png"
+    elif content.startswith(b"\xff\xd8\xff"):
+        suffix = ".jpg"
+    elif content.startswith(b"RIFF") and content[8:12] == b"WEBP":
+        suffix = ".webp"
+    else:
+        raise RuntimeError("Atlas output is not a recognized PNG, JPEG, or WebP image")
+    if output.suffix.lower() not in {suffix, ".jpeg" if suffix == ".jpg" else suffix}:
+        output = output.with_suffix(suffix)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.write_bytes(content)
+    temporary.replace(output)
+    return output
+
+
+def main() -> None:
+    """Parse CLI arguments and run the Atlas thumbnail workflow."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--aspect-ratio", default="16:9")
+    parser.add_argument("--resolution", choices=("1k", "2k", "4k"), default="1k")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--poll-interval", type=float, default=2)
+    args = parser.parse_args()
+    key = os.environ.get("ATLASCLOUD_API_KEY") or os.environ.get("ATLAS_CLOUD_API_KEY")
+    if not key:
+        parser.error("set ATLASCLOUD_API_KEY before using --provider atlas")
+    validate_model(args.model)
+    prediction_id = submit(
+        key,
+        {
+            "model": args.model,
+            "prompt": args.prompt,
+            "aspect_ratio": args.aspect_ratio,
+            "resolution": args.resolution,
+        },
+    )
+    output = download(poll(key, prediction_id, args.timeout, args.poll_interval), args.output)
+    print(output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/acestep-thumbnail/scripts/atlas_thumbnail_test.py
+++ b/.claude/skills/acestep-thumbnail/scripts/atlas_thumbnail_test.py
@@ -1,0 +1,84 @@
+"""Tests for the optional Atlas Cloud thumbnail backend."""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+MODULE_PATH = Path(__file__).with_name("atlas_thumbnail.py")
+SPEC = importlib.util.spec_from_file_location("atlas_thumbnail", MODULE_PATH)
+atlas = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(atlas)
+
+
+class Response:
+    """Small context-managed response fixture."""
+
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        if isinstance(self.payload, bytes):
+            return self.payload
+        return json.dumps(self.payload).encode()
+
+
+class AtlasThumbnailTest(unittest.TestCase):
+    """Cover successful routing, failure behavior, and output validation."""
+
+    def test_submit_uses_one_non_retried_post(self) -> None:
+        request_json = MagicMock(return_value={"data": {"id": "prediction-1"}})
+        with patch.object(atlas, "_json_request", request_json):
+            prediction_id = atlas.submit("secret", {"model": "example", "prompt": "cover"})
+        self.assertEqual(prediction_id, "prediction-1")
+        self.assertEqual(request_json.call_args.args[0].get_method(), "POST")
+        self.assertEqual(request_json.call_args.kwargs, {})
+
+    def test_poll_uses_bounded_prediction_get_retries(self) -> None:
+        request_json = MagicMock(
+            side_effect=[
+                {"data": {"status": "processing", "outputs": []}},
+                {"data": {"status": "completed", "outputs": ["https://image.test/a.png"]}},
+            ]
+        )
+        with patch.object(atlas, "_json_request", request_json), patch.object(atlas.time, "sleep"):
+            output = atlas.poll("secret", "prediction-1", timeout=10, interval=0)
+        self.assertEqual(output, "https://image.test/a.png")
+        self.assertTrue(
+            all(call.kwargs == {"transient_retries": 3} for call in request_json.call_args_list)
+        )
+
+    def test_download_writes_recognized_image_atomically(self) -> None:
+        image = b"\x89PNG\r\n\x1a\n" + b"content"
+        with tempfile.TemporaryDirectory() as directory, patch.object(
+            atlas.urllib.request, "urlopen", return_value=Response(image)
+        ):
+            output = Path(directory) / "cover.png"
+            actual = atlas.download("https://image.test/a.png", output)
+            self.assertEqual(actual, output)
+            self.assertEqual(output.read_bytes(), image)
+            self.assertFalse(output.with_suffix(".png.tmp").exists())
+
+    def test_download_corrects_a_mismatched_jpeg_suffix(self) -> None:
+        image = b"\xff\xd8\xff" + b"content"
+        with tempfile.TemporaryDirectory() as directory, patch.object(
+            atlas.urllib.request, "urlopen", return_value=Response(image)
+        ):
+            requested = Path(directory) / "cover.png"
+            actual = atlas.download("https://image.test/a.jpg", requested)
+            self.assertEqual(actual, requested.with_suffix(".jpg"))
+            self.assertEqual(actual.read_bytes(), image)
+            self.assertFalse(requested.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/acestep/SKILL.md
+++ b/.claude/skills/acestep/SKILL.md
@@ -38,10 +38,10 @@ If the user needs a simple music video, use the **acestep-simplemv** skill to re
 - **acestep-songwriting** — for writing lyrics and planning song structure
 - **acestep-lyrics-transcription** — for transcribing audio to timestamped lyrics (LRC)
 - **acestep-simplemv** — for rendering the final music video
-- **acestep-thumbnail** (optional) — for generating cover art / MV background images via Gemini API
+- **acestep-thumbnail** (optional) — for generating cover art / MV background images via Gemini API or Atlas Cloud
 
 **MV Background Image**: When the user requests MV production, ask whether they want a background image for the video:
-1. **Generate via Gemini** — use the **acestep-thumbnail** skill (requires Gemini API key configuration)
+1. **Generate via Gemini or Atlas Cloud** — use the **acestep-thumbnail** skill (requires the selected provider's API key)
 2. **Provide an existing image** — user supplies a local image path
 3. **Skip** — use the default animated gradient background (no image needed)
 


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an opt-in backend for the existing `acestep-thumbnail` skill
- keep Gemini as the unchanged default provider
- validate the live Atlas image catalog, submit generation once, poll with bounded GET retries, and save the returned image with the correct suffix
- document provider-specific key checks and usage

## Scope and risk
- changes are isolated to the thumbnail skill and its parent workflow documentation
- ACE-Step music generation and all hardware/runtime paths are unchanged
- Atlas is never selected unless `--provider atlas` is passed

## Regression checks
- `python3 -m unittest discover -s .claude/skills/acestep-thumbnail/scripts -p "*_test.py" -v` (4 tests)
- `python3 -m py_compile .claude/skills/acestep-thumbnail/scripts/atlas_thumbnail.py .claude/skills/acestep-thumbnail/scripts/atlas_thumbnail_test.py`
- `bash -n .claude/skills/acestep-thumbnail/scripts/acestep-thumbnail.sh`
- real Atlas smoke: one non-retried `google/nano-banana-pro/text-to-image-developer` submission produced a valid 1024x1024 album-cover image

## Checklist
- [x] Changes work as described
- [x] No hardcoded secrets or API keys
- [x] Focused tests pass
- [x] Shell and Python syntax checks pass
- [x] Non-target platforms and default behavior are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Atlas Cloud support for thumbnail generation alongside Gemini.
  * Added controls for provider selection, image resolution, and Atlas model overrides.
  * Added automatic polling, retries, image validation, and safe output handling for Atlas-generated thumbnails.
* **Documentation**
  * Updated setup and usage guidance for Atlas credentials, options, models, and retry behavior.
* **Tests**
  * Added coverage for Atlas requests, retries, polling, downloads, and file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->