### PR TITLE
fix[lowvram]: Optimizing CPU offloading when using a LoRA in a low vram environment

### DIFF
--- a/acestep/core/generation/handler/generate_music.py
+++ b/acestep/core/generation/handler/generate_music.py
@@ -323,8 +323,13 @@ class GenerateMusicMixin:
         # adapter weights on the wrong device, causing NaN in the diffusion
         # forward pass.  The check is cheap and prevents a hard-to-debug
         # generation failure.
-        if getattr(self, "lora_loaded", False) and getattr(self, "use_lora", False):
+        if (
+            getattr(self, "lora_loaded", False)
+            and getattr(self, "use_lora", False)
+            and not getattr(self, "offload_dit_to_cpu", False)
+        ):
             self._verify_decoder_device_dtype()
+
 
         logger.info("[generate_music] Starting generation...")
         if progress:


### PR DESCRIPTION
Don't verify_decoder_device_dtype if offloading DiT to the CPU.  This may still cause issues with NaN but I haven't reproduced that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music generation with DiT CPU offloading by preventing unnecessary decoder device and data-type verification.
  * Requests using CPU offloading now proceed without the previously triggered decoder verification step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->